### PR TITLE
Fix AddFile to accept JSON which have no stats

### DIFF
--- a/python/delta_sharing/protocol.py
+++ b/python/delta_sharing/protocol.py
@@ -160,7 +160,7 @@ class AddFile:
     id: str
     partition_values: Dict[str, str]
     size: int
-    stats: str = None
+    stats: Optional[str] = None
 
     @staticmethod
     def from_json(json) -> "AddFile":

--- a/python/delta_sharing/protocol.py
+++ b/python/delta_sharing/protocol.py
@@ -160,7 +160,7 @@ class AddFile:
     id: str
     partition_values: Dict[str, str]
     size: int
-    stats: str
+    stats: str = None
 
     @staticmethod
     def from_json(json) -> "AddFile":
@@ -171,5 +171,5 @@ class AddFile:
             id=json["id"],
             partition_values=json["partitionValues"],
             size=int(json["size"]),
-            stats=json["stats"],
+            stats=json.get("stats", None),
         )

--- a/python/delta_sharing/tests/test_protocol.py
+++ b/python/delta_sharing/tests/test_protocol.py
@@ -190,6 +190,24 @@ def test_metadata():
             ),
             id="partitioned",
         ),
+        pytest.param(
+            """
+            {
+                "url" : "https://localhost/path/to/file.parquet",
+                "id" : "id",
+                "partitionValues" : {"b": "x"},
+                "size" : 120
+            }
+            """,
+            AddFile(
+                url="https://localhost/path/to/file.parquet",
+                id="id",
+                partition_values={"b": "x"},
+                size=120,
+                stats=None
+            ),
+            id="no stats",
+        ),
     ],
 )
 def test_add_file(json: str, expected: AddFile):

--- a/python/delta_sharing/tests/test_protocol.py
+++ b/python/delta_sharing/tests/test_protocol.py
@@ -204,7 +204,7 @@ def test_metadata():
                 id="id",
                 partition_values={"b": "x"},
                 size=120,
-                stats=None
+                stats=None,
             ),
             id="no stats",
         ),


### PR DESCRIPTION
According to [PROTOCOL](https://github.com/delta-io/delta-sharing/blob/main/PROTOCOL.md)  definition, "stats" field of "File" is an optional field.
Therefore, "AddFile" and "from_json" method should accept JSON which have no "stats".

Signed-off-by: Masaru Dobashi <dobachi1983oss@gmail.com>