### PR TITLE
Improve error handling in Delta Sharing Server

### DIFF
--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -62,14 +62,17 @@ class DeltaSharingServiceExceptionHandler extends ExceptionHandlerFunction {
       // happens before `DeltaSharingService` receives the requests so these exceptions should never
       // contain sensitive information and should be okay to return their messages to the user.
       case _: scalapb.json4s.JsonFormatException =>
+        // valid json but may be incorrect field type
         HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8, cause.getMessage)
       case _: com.fasterxml.jackson.databind.JsonMappingException =>
+        // invalid json
         HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8, cause.getMessage)
       case _: NumberFormatException =>
+        // `maxResults` is not an int.
         HttpResponse.of(
           HttpStatus.BAD_REQUEST,
           MediaType.PLAIN_TEXT_UTF_8,
-          "expected a number but the string does not have the appropriate format")
+          "expected a number but the string didn't have the appropriate format")
       // Handle unhandle exceptions
       case _: DeltaInternalException =>
         logger.error(cause.getMessage, cause)

--- a/server/src/main/scala/io/delta/sharing/server/exceptions.scala
+++ b/server/src/main/scala/io/delta/sharing/server/exceptions.scala
@@ -35,3 +35,11 @@ class DeltaSharingIllegalArgumentException(message: String)
  */
 class DeltaSharingNoSuchElementException(message: String)
   extends NoSuchElementException(message)
+
+
+/**
+ * A special exception that wraps an unhandled exception when processing a request.
+ * `DeltaInternalException` should never be exposed to users as an unhandled exception may contain
+ * sensitive information.
+ */
+class DeltaInternalException(e: Throwable) extends RuntimeException(e)

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -428,7 +428,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(IOUtils.toString(connection.getErrorStream()).contains(expectedErrorMessage))
   }
 
-  integrationTest("invalid request json") {
+  integrationTest("valid request json but incorrect field type") {
     assertHttpError(
       url = requestPath("/shares/share1/schemas/default/tables/table1/query"),
       method = "POST",
@@ -444,7 +444,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
   }
 
-  integrationTest("empty request body") {
+  integrationTest("invalid request json") {
     assertHttpError(
       url = requestPath("/shares/share1/schemas/default/tables/table1/query"),
       method = "POST",
@@ -460,7 +460,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       method = "GET",
       data = None,
       expectedErrorCode = 400,
-      expectedErrorMessage = "expected a number but the string does not have the appropriate format"
+      expectedErrorMessage = "expected a number but the string didn't have the appropriate format"
     )
   }
 }


### PR DESCRIPTION
Currently Armeria is doing the request parsing work. When a request is invalid, such as invalid json (#27), or incorrect type (`maxResults` is not an int), it will throw an exception and report 500 Internal Error.

In this PR, we catch any unhandled exception when process a request, and convert it to `DeltaInternalException` when processing a request. Then we scope all exceptions that may contain sensitive information to a single type `DeltaInternalException`. Hence, `DeltaSharingServiceExceptionHandler` can safely expose the messages in the following exceptions to the user for better user experience and report 400 Bad Request:
- `scalapb.json4s.JsonFormatException`: Valid json string but invalid field type (#27).
- `com.fasterxml.jackson.databind.JsonMappingException`: Invalid json string.
- `java.lang.NumberFormatException`: `maxResults` is not an int.

Fixes #27