### PR TITLE
Add more test tables and update integration tests

### DIFF
--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -119,7 +119,7 @@ def test_list_all_tables(sharing_client: SharingClient):
                     "type": [None, None],
                 }
             ),
-            id="none of parquet files has all table columns",
+            id="table column order is not the same as parquet files",
         ),
     ],
 )

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -26,7 +26,7 @@ from delta_sharing.tests.conftest import ENABLE_INTEGRATION, SKIP_MESSAGE
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_list_shares(sharing_client: SharingClient):
     shares = sharing_client.list_shares()
-    assert shares == [Share(name="share1"), Share(name="share2")]
+    assert shares == [Share(name="share1"), Share(name="share2"), Share(name="share3")]
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
@@ -57,6 +57,8 @@ def test_list_all_tables(sharing_client: SharingClient):
         Table(name="table1", share="share1", schema="default"),
         Table(name="table3", share="share1", schema="default"),
         Table(name="table2", share="share2", schema="default"),
+        Table(name="table4", share="share3", schema="default"),
+        Table(name="table5", share="share3", schema="default"),
     ]
 
 
@@ -104,6 +106,20 @@ def test_list_all_tables(sharing_client: SharingClient):
                 }
             ),
             id="partitioned and different schemas",
+        ),
+        pytest.param(
+            "share3.default.table4",
+            pd.DataFrame(
+                {
+                    "eventTime": [
+                        pd.Timestamp("2021-04-28 23:33:48.719"),
+                        pd.Timestamp("2021-04-28 23:33:57.955"),
+                    ],
+                    "date": [date(2021, 4, 28), date(2021, 4, 28)],
+                    "type": [None, None],
+                }
+            ),
+            id="none of parquet files has all table columns",
         ),
     ],
 )

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -113,8 +113,8 @@ def test_list_all_tables(sharing_client: SharingClient):
                 {
                     "type": [None, None],
                     "eventTime": [
-                        pd.Timestamp("2021-04-28 23:33:48.719"),
                         pd.Timestamp("2021-04-28 23:33:57.955"),
+                        pd.Timestamp("2021-04-28 23:33:48.719"),
                     ],
                     "date": [date(2021, 4, 28), date(2021, 4, 28)],
                 }

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -111,12 +111,12 @@ def test_list_all_tables(sharing_client: SharingClient):
             "share3.default.table4",
             pd.DataFrame(
                 {
+                    "type": [None, None],
                     "eventTime": [
                         pd.Timestamp("2021-04-28 23:33:48.719"),
                         pd.Timestamp("2021-04-28 23:33:57.955"),
                     ],
                     "date": [date(2021, 4, 28), date(2021, 4, 28)],
-                    "type": [None, None],
                 }
             ),
             id="table column order is not the same as parquet files",

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -31,7 +31,7 @@ from delta_sharing.tests.conftest import ENABLE_INTEGRATION, SKIP_MESSAGE
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_list_shares(rest_client: DataSharingRestClient):
     response = rest_client.list_shares()
-    assert response.shares == [Share(name="share1"), Share(name="share2")]
+    assert response.shares == [Share(name="share1"), Share(name="share2"), Share(name="share3")]
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -152,7 +152,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   integrationTest("/shares") {
     val response = readJson(requestPath("/shares"))
     val expected = ListSharesResponse(
-      Vector(Share().withName("share1"), Share().withName("share2")))
+      Vector(Share().withName("share1"), Share().withName("share2"), Share().withName("share3")))
     assert(expected == JsonFormat.fromJsonString[ListSharesResponse](response))
   }
 
@@ -165,7 +165,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       response = JsonFormat.fromJsonString[ListSharesResponse](readJson(requestPath(s"/shares?pageToken=${response.nextPageToken.get}&maxResults=1")))
       shares ++= response.items
     }
-    val expected = Seq(Share().withName("share1"), Share().withName("share2"))
+    val expected = Seq(Share().withName("share1"), Share().withName("share2"), Share().withName("share3"))
     assert(expected == shares)
   }
 

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -55,7 +55,18 @@ object TestResource {
             TableConfig("table2", s"s3a://${TestResource.AWS.bucket}/delta-exchange-test/table2")
           )
           )
-        ))
+        )),
+      ShareConfig("share3",
+        java.util.Arrays.asList(
+          SchemaConfig(
+            "default",
+            java.util.Arrays.asList(
+              TableConfig("table4", s"s3a://${TestResource.AWS.bucket}/delta-exchange-test/table4"),
+              TableConfig("table5", s"s3a://${TestResource.AWS.bucket}/delta-exchange-test/table5")
+            )
+          )
+        )
+      )
     )
 
     val serverConfig = new ServerConfig()

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -27,7 +27,9 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       val expected = Set(
         Table(name = "table1", schema = "default", share = "share1"),
         Table(name = "table2", schema = "default", share = "share2"),
-        Table(name = "table3", schema = "default", share = "share1")
+        Table(name = "table3", schema = "default", share = "share1"),
+        Table(name = "table4", schema = "default", share = "share3"),
+        Table(name = "table5", schema = "default", share = "share3")
       )
       assert(expected == client.listAllTables().toSet)
     } finally {

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -85,11 +85,11 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
     }
   }
 
-  integrationTest("table4: none of parquet files has all table columns") {
+  integrationTest("table4: table column order is not the same as parquet files") {
     val tablePath = testProfileFile.getCanonicalPath + "#share3.default.table4"
     val expected = Seq(
-      Row(sqlTimestamp("2021-04-28 16:33:57.955"), sqlDate("2021-04-28"), null),
-      Row(sqlTimestamp("2021-04-28 16:33:48.719"), sqlDate("2021-04-28"), null)
+      Row(null, sqlTimestamp("2021-04-28 16:33:57.955"), sqlDate("2021-04-28")),
+      Row(null, sqlTimestamp("2021-04-28 16:33:48.719"), sqlDate("2021-04-28"))
     )
     checkAnswer(spark.read.format("deltaSharing").load(tablePath), expected)
     withTable("delta_sharing_test") {


### PR DESCRIPTION
Add two more tables and update existing integration tests accordingly:

- `share3.default.table4`: The table column order is not the same as parquet files.
- `share3.default.table5`: An empty table.