### PR TITLE
Add columns to empty table in load_as_pandas and fix issues for complex types

### DIFF
--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ -21,6 +21,12 @@ import pandas as pd
 
 
 def _get_dummy_column(schema_type):
+    """
+    Return a dummy column with the data type specified in schema_type.
+    The dummy column is used to populate the dtype fields in empty tables.
+    :param schema_type: str or json representing a data type
+    :return: dummy pandas Series to be inserted into an empty table
+    """
     if schema_type == "boolean":
         return pd.Series([False])
     elif schema_type == "byte":
@@ -52,6 +58,13 @@ def _get_dummy_column(schema_type):
 
 
 def get_empty_table(schema_json: dict) -> pd.DataFrame:
+    """
+    For empty tables, we use dummy columns from `_get_dummy_column` and then
+    drop all rows to generate a table with the correct column names and
+    data types.
+    :param schema_json: json object representing the table schema
+    :return: empty table with columns specified in schema_json
+    """
     assert schema_json["type"] == "struct"
 
     dummy_table = pd.DataFrame(
@@ -67,6 +80,13 @@ def to_converters(schema_json: dict) -> Dict[str, Callable[[str], Any]]:
 
 
 def to_converter(schema_type) -> Callable[[str], Any]:
+    """
+    For types that support partitioning, a lambda to parse data into the
+    corresponding type is returned. For data types that cannot be partitioned
+    on, we return None. The caller is expected to check if the value is None before using.
+    :param schema_type: str or json representing a data type
+    :return: converter function or None
+    """
     if schema_type == "boolean":
         return lambda x: None if (x is None or x == "") else (x is True or x == "true")
     elif schema_type == "byte":

--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ -50,9 +50,9 @@ def get_empty_table(schema_string: str) -> pd.DataFrame:
     schema_json = loads(schema_string)
     assert schema_json["type"] == "struct"
 
-    dummy_table = pd.DataFrame({field["name"]:
-                                _get_dummy_column(field["type"])
-                                for field in schema_json["fields"]})
+    dummy_table = pd.DataFrame(
+        {field["name"]: _get_dummy_column(field["type"]) for field in schema_json["fields"]}
+    )
     return dummy_table.iloc[0:0]
 
 

--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ -36,7 +36,7 @@ def _get_dummy_column(type_string: str):
         return pd.Series([0], dtype="float32")
     elif type_string == "double":
         return pd.Series([0], dtype="float64")
-    elif isinstance(type_string, str) and type_string.startswith("decimal"):
+    elif type_string.startswith("decimal"):
         return pd.Series([Decimal("1.2")])
     elif type_string == "string":
         return pd.Series(["dummy"], dtype="string")
@@ -44,6 +44,8 @@ def _get_dummy_column(type_string: str):
         return pd.Series([pd.Timestamp(0).date()], dtype="datetime64[ns]")
     elif type_string == "timestamp":
         return pd.Series([pd.Timestamp(0)], dtype="datetime64[ns]")
+
+    raise ValueError(f"Could not parse datatype: {type_string}")
 
 
 def get_empty_table(schema_string: str) -> pd.DataFrame:
@@ -78,7 +80,7 @@ def to_converter(json) -> Callable[[str], Any]:
         return lambda x: np.nan if (x is None or x == "") else np.float32(x)
     elif json == "double":
         return lambda x: np.nan if (x is None or x == "") else np.float64(x)
-    elif isinstance(json, str) and json.startswith("decimal"):
+    elif json.startswith("decimal"):
         return lambda x: None if (x is None or x == "") else Decimal(x)
     elif json == "string":
         return lambda x: None if (x is None or x == "") else str(x)

--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ -114,6 +114,4 @@ def to_converter(schema_type) -> Callable[[str], Any]:
     elif isinstance(schema_type, dict) and schema_type["type"] in ("array", "struct", "map"):
         return None  # partition on complex column not supported
 
-    # TODO: binary
-
     raise ValueError(f"Could not parse datatype: {schema_type}")

--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ -51,7 +51,8 @@ def get_empty_table(schema_string: str) -> pd.DataFrame:
     assert schema_json["type"] == "struct"
 
     dummy_table = pd.DataFrame({field["name"]:
-                                _get_dummy_column(field["type"]) for field in schema_json["fields"]})
+                                _get_dummy_column(field["type"])
+                                for field in schema_json["fields"]})
     return dummy_table.iloc[0:0]
 
 

--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ -21,6 +21,40 @@ import numpy as np
 import pandas as pd
 
 
+def _get_dummy_column(type_string: str):
+    if type_string == "boolean":
+        return pd.Series([False])
+    elif type_string == "byte":
+        return pd.Series([0], dtype="int8")
+    elif type_string == "short":
+        return pd.Series([0], dtype="int16")
+    elif type_string == "integer":
+        return pd.Series([0], dtype="int32")
+    elif type_string == "long":
+        return pd.Series([0], dtype="int64")
+    elif type_string == "float":
+        return pd.Series([0], dtype="float32")
+    elif type_string == "double":
+        return pd.Series([0], dtype="float64")
+    elif isinstance(type_string, str) and type_string.startswith("decimal"):
+        return pd.Series([Decimal("1.2")])
+    elif type_string == "string":
+        return pd.Series(["dummy"], dtype="string")
+    elif type_string == "date":
+        return pd.Series([pd.Timestamp(0).date()], dtype="datetime64[ns]")
+    elif type_string == "timestamp":
+        return pd.Series([pd.Timestamp(0)], dtype="datetime64[ns]")
+
+
+def get_empty_table(schema_string: str) -> pd.DataFrame:
+    schema_json = loads(schema_string)
+    assert schema_json["type"] == "struct"
+
+    dummy_table = pd.DataFrame({field["name"]:
+                                _get_dummy_column(field["type"]) for field in schema_json["fields"]})
+    return dummy_table.iloc[0:0]
+
+
 def to_converters(schema_string: str) -> Dict[str, Callable[[str], Any]]:
     schema_json = loads(schema_string)
     assert schema_json["type"] == "struct"

--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ -48,7 +48,7 @@ def _get_dummy_column(schema_type):
     elif schema_type == "date":
         return pd.Series([pd.Timestamp(0).date()])
     elif schema_type == "timestamp":
-        return pd.Series([pd.Timestamp(0).date()], dtype=np.dtype("datetime64[ns]"))
+        return pd.Series([pd.Timestamp(0)], dtype=np.dtype("datetime64[ns]"))
     elif schema_type == "binary":
         return pd.Series([0], dtype=np.dtype("O"))
     elif isinstance(schema_type, dict) and schema_type["type"] in ("array", "struct", "map"):

--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from decimal import Decimal
-from json import loads
 from typing import Any, Callable, Dict
 
 import numpy as np
@@ -52,8 +51,7 @@ def _get_dummy_column(schema_type):
     raise ValueError(f"Could not parse datatype: {schema_type}")
 
 
-def get_empty_table(schema_string: str) -> pd.DataFrame:
-    schema_json = loads(schema_string)
+def get_empty_table(schema_json: dict) -> pd.DataFrame:
     assert schema_json["type"] == "struct"
 
     dummy_table = pd.DataFrame(
@@ -62,8 +60,7 @@ def get_empty_table(schema_string: str) -> pd.DataFrame:
     return dummy_table.iloc[0:0]
 
 
-def to_converters(schema_string: str) -> Dict[str, Callable[[str], Any]]:
-    schema_json = loads(schema_string)
+def to_converters(schema_json: dict) -> Dict[str, Callable[[str], Any]]:
     assert schema_json["type"] == "struct"
 
     return {field["name"]: to_converter(field["type"]) for field in schema_json["fields"]}
@@ -93,9 +90,9 @@ def to_converter(schema_type) -> Callable[[str], Any]:
     elif schema_type == "timestamp":
         return lambda x: pd.NaT if (x is None or x == "") else pd.Timestamp(x)
     elif schema_type == "binary":
-        return None  # partition on binary column not supported yet
+        return None  # partition on binary column not supported
     elif isinstance(schema_type, dict) and schema_type["type"] in ("array", "struct", "map"):
-        return None  # partition on complex column not supported yet
+        return None  # partition on complex column not supported
 
     # TODO: binary
 

--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ -39,11 +39,11 @@ def _get_dummy_column(type_string: str):
     elif type_string.startswith("decimal"):
         return pd.Series([Decimal("1.2")])
     elif type_string == "string":
-        return pd.Series(["dummy"], dtype="string")
+        return pd.Series(["dummy"])
     elif type_string == "date":
-        return pd.Series([pd.Timestamp(0).date()], dtype="datetime64[ns]")
+        return pd.Series([pd.Timestamp(0).date()])
     elif type_string == "timestamp":
-        return pd.Series([pd.Timestamp(0)], dtype="datetime64[ns]")
+        return pd.Series([pd.Timestamp(0)])
 
     raise ValueError(f"Could not parse datatype: {type_string}")
 

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -20,7 +20,7 @@ import fsspec
 import pandas as pd
 from pyarrow.dataset import dataset
 
-from delta_sharing.converter import to_converters
+from delta_sharing.converter import to_converters, get_empty_table
 from delta_sharing.protocol import AddFile, Table
 from delta_sharing.rest_client import DataSharingRestClient
 
@@ -62,7 +62,7 @@ class DeltaSharingReader:
         )
 
         if len(response.add_files) == 0:
-            return pd.DataFrame()
+            return get_empty_table(response.metadata.schema_string)
 
         converters = to_converters(response.metadata.schema_string)
 

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -44,6 +44,7 @@ def test_list_tables(sharing_client: SharingClient):
     assert tables == [
         Table(name="table1", share="share1", schema="default"),
         Table(name="table3", share="share1", schema="default"),
+        Table(name="table7", share="share1", schema="default"),
     ]
 
     tables = sharing_client.list_tables(Schema(name="default", share="share2"))
@@ -56,6 +57,7 @@ def test_list_all_tables(sharing_client: SharingClient):
     assert tables == [
         Table(name="table1", share="share1", schema="default"),
         Table(name="table3", share="share1", schema="default"),
+        Table(name="table7", share="share1", schema="default"),
         Table(name="table2", share="share2", schema="default"),
         Table(name="table4", share="share3", schema="default"),
         Table(name="table5", share="share3", schema="default"),

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -187,25 +187,29 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
 
 
 def test_to_pandas_empty(tmp_path):
-    pdf1 = pd.DataFrame({"a": pd.Series([], dtype=np.dtype("bool")),
-                         "b": pd.Series([], dtype=np.dtype("int8")),
-                         "c": pd.Series([], dtype=np.dtype("int16")),
-                         "d": pd.Series([], dtype=np.dtype("int32")),
-                         "e": pd.Series([], dtype=np.dtype("int64")),
-                         "f": pd.Series([], dtype=np.dtype("float32")),
-                         "g": pd.Series([], dtype=np.dtype("float64")),
-                         "h": pd.Series([], dtype=np.dtype("O")),
-                         "i": pd.Series([], dtype="string"),
-                         "j": pd.Series([], dtype="datetime64[ns]"),
-                         "k": pd.Series([], dtype="datetime64[ns]"),})
+    pdf1 = pd.DataFrame(
+        {
+            "a": pd.Series([], dtype=np.dtype("bool")),
+            "b": pd.Series([], dtype=np.dtype("int8")),
+            "c": pd.Series([], dtype=np.dtype("int16")),
+            "d": pd.Series([], dtype=np.dtype("int32")),
+            "e": pd.Series([], dtype=np.dtype("int64")),
+            "f": pd.Series([], dtype=np.dtype("float32")),
+            "g": pd.Series([], dtype=np.dtype("float64")),
+            "h": pd.Series([], dtype=np.dtype("O")),
+            "i": pd.Series([], dtype="string"),
+            "j": pd.Series([], dtype="datetime64[ns]"),
+            "k": pd.Series([], dtype="datetime64[ns]"),
+        }
+    )
 
     class RestClientMock:
         def list_files_in_table(
-                self,
-                table: Table,
-                *,
-                predicateHints: Optional[Sequence[str]] = None,
-                limitHint: Optional[int] = None,
+            self,
+            table: Table,
+            *,
+            predicateHints: Optional[Sequence[str]] = None,
+            limitHint: Optional[int] = None,
         ) -> ListFilesInTableResponse:
             assert table == Table("table_name", "share_name", "schema_name")
 

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -228,7 +228,9 @@ def test_to_pandas_empty(rest_client: DataSharingRestClient):
             add_files: Sequence[AddFile] = []
             return ListFilesInTableResponse(protocol=None, metadata=metadata, add_files=add_files)
 
-    reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
+    reader = DeltaSharingReader(
+        Table("table_name", "share_name", "schema_name"), RestClientMock()  # type: ignore
+    )
     pdf = reader.to_pandas()
 
     reader = DeltaSharingReader(Table(name="table7", share="share1", schema="default"), rest_client)

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -230,7 +230,7 @@ def test_to_pandas_empty(tmp_path):
                     '],"type":"struct"}'
                 )
             )
-            add_files = []
+            add_files: Sequence[AddFile] = []
             return ListFilesInTableResponse(protocol=None, metadata=metadata, add_files=add_files)
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -197,8 +197,8 @@ def test_to_pandas_empty(tmp_path):
             "f": pd.Series([], dtype=np.dtype("float32")),
             "g": pd.Series([], dtype=np.dtype("float64")),
             "h": pd.Series([], dtype=np.dtype("O")),
-            "i": pd.Series([], dtype="string"),
-            "j": pd.Series([], dtype="datetime64[ns]"),
+            "i": pd.Series([], dtype=np.dtype("O")),
+            "j": pd.Series([], dtype=np.dtype("O")),
             "k": pd.Series([], dtype="datetime64[ns]"),
         }
     )

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -49,6 +49,7 @@ def test_list_tables(rest_client: DataSharingRestClient):
     assert response.tables == [
         Table(name="table1", share="share1", schema="default"),
         Table(name="table3", share="share1", schema="default"),
+        Table(name="table7", share="share1", schema="default"),
     ]
 
     response = rest_client.list_tables(Schema(name="default", share="share2"))

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -180,7 +180,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     val response = readJson(requestPath("/shares/share1/schemas/default/tables"))
     val expected = ListTablesResponse(
       Table().withName("table1").withSchema("default").withShare("share1") ::
-        Table().withName("table3").withSchema("default").withShare("share1") :: Nil)
+        Table().withName("table3").withSchema("default").withShare("share1") ::
+        Table().withName("table7").withSchema("default").withShare("share1") :: Nil)
     assert(expected == JsonFormat.fromJsonString[ListTablesResponse](response))
   }
 
@@ -194,7 +195,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     }
     val expected =
       Table().withName("table1").withSchema("default").withShare("share1") ::
-        Table().withName("table3").withSchema("default").withShare("share1") :: Nil
+        Table().withName("table3").withSchema("default").withShare("share1") ::
+        Table().withName("table7").withSchema("default").withShare("share1") :: Nil
     assert(expected == tables)
   }
 

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -44,7 +44,8 @@ object TestResource {
             "default",
             java.util.Arrays.asList(
               TableConfig("table1", s"s3a://${TestResource.AWS.bucket}/delta-exchange-test/table1"),
-              TableConfig("table3", s"s3a://${TestResource.AWS.bucket}/delta-exchange-test/table3")
+              TableConfig("table3", s"s3a://${TestResource.AWS.bucket}/delta-exchange-test/table3"),
+              TableConfig("table7", s"s3a://${TestResource.AWS.bucket}/delta-exchange-test/table7")
             )
           )
         )

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -29,7 +29,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Table(name = "table2", schema = "default", share = "share2"),
         Table(name = "table3", schema = "default", share = "share1"),
         Table(name = "table4", schema = "default", share = "share3"),
-        Table(name = "table5", schema = "default", share = "share3")
+        Table(name = "table5", schema = "default", share = "share3"),
+        Table(name = "table7", schema = "default", share = "share1")
       )
       assert(expected == client.listAllTables().toSet)
     } finally {


### PR DESCRIPTION
This PR fixes two issues:
- When a table is empty, `load_as_pandas` should return an empty Pandas DataFrame with the table schema. Fixes #35 
- When the type of a data column is a complex type, `load_as_pandas` should not fail. In a Delta table, only partition columns are not allowed to use complex types.