### PR TITLE
Call DeltaSharingDataSource.setupFileSystem lazily

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -6,7 +6,7 @@ requests
 aiohttp
 
 # Linter
-mypy
+mypy==0.812
 flake8
 
 # Code formatter. Only support Python 3.6+


### PR DESCRIPTION
`DeltaSharingDataSource.setupFileSystem` needs to use `SparkContext`. Call it in `createRelation` so that `DeltaSharingDataSource` can be created without `SparkContext`.