### PR TITLE
Remove extra slash in endpoint for Python connector

### DIFF
--- a/python/delta_sharing/protocol.py
+++ b/python/delta_sharing/protocol.py
@@ -55,9 +55,12 @@ class DeltaSharingProfile:
     def from_json(json) -> "DeltaSharingProfile":
         if isinstance(json, (str, bytes, bytearray)):
             json = loads(json)
+        endpoint = json["endpoint"]
+        if endpoint.endswith("/"):
+            endpoint = endpoint[:-1]
         return DeltaSharingProfile(
             share_credentials_version=int(json["shareCredentialsVersion"]),
-            endpoint=json["endpoint"],
+            endpoint=endpoint,
             bearer_token=json["bearerToken"],
         )
 

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -67,8 +67,6 @@ class ListFilesInTableResponse:
 class DataSharingRestClient:
     def __init__(self, profile: DeltaSharingProfile):
         self._profile = profile
-        if self._profile.endpoint.endswith("/"):
-            self._profile.endpoint = self._profile.endpoint[:-1]
 
         self._session = requests.Session()
         self._session.headers.update({"Authorization": f"Bearer {profile.bearer_token}"})
@@ -171,6 +169,7 @@ class DataSharingRestClient:
 
     @contextmanager
     def _request_internal(self, request, target: str, data: Optional[Dict[str, Any]]):
+        assert target.startswith("/"), "Targets should start with '/'"
         response = request(f"{self._profile.endpoint}{target}", json=data)
         try:
             response.raise_for_status()

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -67,6 +67,8 @@ class ListFilesInTableResponse:
 class DataSharingRestClient:
     def __init__(self, profile: DeltaSharingProfile):
         self._profile = profile
+        if self._profile.endpoint.endswith("/"):
+            self._profile.endpoint = self._profile.endpoint[:-1]
 
         self._session = requests.Session()
         self._session.headers.update({"Authorization": f"Bearer {profile.bearer_token}"})

--- a/python/delta_sharing/tests/test_protocol.py
+++ b/python/delta_sharing/tests/test_protocol.py
@@ -38,26 +38,26 @@ def test_share_profile(tmp_path):
         }
         """
     profile = DeltaSharingProfile.from_json(json)
-    assert profile == DeltaSharingProfile(1, "https://localhost/delta-sharing/", "token")
+    assert profile == DeltaSharingProfile(1, "https://localhost/delta-sharing", "token")
 
     profile = DeltaSharingProfile.read_from_file(io.StringIO(json))
-    assert profile == DeltaSharingProfile(1, "https://localhost/delta-sharing/", "token")
+    assert profile == DeltaSharingProfile(1, "https://localhost/delta-sharing", "token")
 
     profile_path = tmp_path / "test_profile.json"
     with open(profile_path, "w") as f:
         f.write(json)
 
     profile = DeltaSharingProfile.read_from_file(str(profile_path))
-    assert profile == DeltaSharingProfile(1, "https://localhost/delta-sharing/", "token")
+    assert profile == DeltaSharingProfile(1, "https://localhost/delta-sharing", "token")
 
     profile = DeltaSharingProfile.read_from_file(profile_path.as_uri())
-    assert profile == DeltaSharingProfile(1, "https://localhost/delta-sharing/", "token")
+    assert profile == DeltaSharingProfile(1, "https://localhost/delta-sharing", "token")
 
     profile = DeltaSharingProfile.read_from_file(profile_path)
-    assert profile == DeltaSharingProfile(1, "https://localhost/delta-sharing/", "token")
+    assert profile == DeltaSharingProfile(1, "https://localhost/delta-sharing", "token")
 
     profile = DeltaSharingProfile.read_from_file(io.FileIO(profile_path))
-    assert profile == DeltaSharingProfile(1, "https://localhost/delta-sharing/", "token")
+    assert profile == DeltaSharingProfile(1, "https://localhost/delta-sharing", "token")
 
     json = """
         {

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -29,6 +29,11 @@ from delta_sharing.tests.conftest import ENABLE_INTEGRATION, SKIP_MESSAGE
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
+def test_read_endpoint(rest_client: DataSharingRestClient):
+    assert not rest_client._profile.endpoint.endswith("/")
+
+
+@pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_list_shares(rest_client: DataSharingRestClient):
     response = rest_client.list_shares()
     assert response.shares == [Share(name="share1"), Share(name="share2"), Share(name="share3")]

--- a/python/dev/lint-python
+++ b/python/dev/lint-python
@@ -196,7 +196,7 @@ function sphinx_test {
     local SPHINX_REPORT=
     local SPHINX_STATUS=
 
-    python -c "import sys; assert sys.version_info >= (3, 6), 'Sphinx buiild requires Python 3.6+, skipping for now.'"
+    python -c "import sys; assert sys.version_info >= (3, 6), 'Sphinx build requires Python 3.6+, skipping for now.'"
     exit_code=$?
     if [ $exit_code -ne 0 ]; then
         return


### PR DESCRIPTION
Removes slash in profile.endpoint when reading in the profile. If the slash is kept, we may have urls like `/delta-sharing//shares`