### PR TITLE
Add conf/ to server classpath

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,7 @@ lazy val server = (project in file("server")) enablePlugins(JavaAppPackaging) se
   commonSettings,
   scalaStyleSettings,
   releaseSettings,
+  scriptClasspath ++= Seq("../conf"),
   libraryDependencies ++= Seq(
     // Pin versions for jackson libraries as the new version of `jackson-module-scala` introduces a
     // breaking change making us not able to use `delta-standalone`.


### PR DESCRIPTION
Add conf/ to server classpath so that users can put their hadoop configuration files in conf/ directly.

Manually checked the generated script and verified `conf/` is on the classpath.