### PR TITLE
Test for non-default compression codec

### DIFF
--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -16,7 +16,6 @@
 from datetime import date
 
 import pandas as pd
-import numpy as np
 import pytest
 
 from delta_sharing.delta_sharing import SharingClient, load_as_pandas, load_as_spark, _parse_url

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -16,6 +16,7 @@
 from datetime import date
 
 import pandas as pd
+import numpy as np
 import pytest
 
 from delta_sharing.delta_sharing import SharingClient, load_as_pandas, load_as_spark, _parse_url
@@ -127,6 +128,11 @@ def test_list_all_tables(sharing_client: SharingClient):
                     "date": [date(2021, 4, 28), date(2021, 4, 28)],
                 }
             ),
+            id="table column order is not the same as parquet files",
+        ),
+        pytest.param(
+            "share4.default.test_gzip",
+            pd.DataFrame({"a": [True], "b": pd.Series([1], dtype="int32"), "c": ["Hi"]}),
             id="table column order is not the same as parquet files",
         ),
     ],

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -26,7 +26,12 @@ from delta_sharing.tests.conftest import ENABLE_INTEGRATION, SKIP_MESSAGE
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_list_shares(sharing_client: SharingClient):
     shares = sharing_client.list_shares()
-    assert shares == [Share(name="share1"), Share(name="share2"), Share(name="share3"), Share(name="share4")]
+    assert shares == [
+        Share(name="share1"),
+        Share(name="share2"),
+        Share(name="share3"),
+        Share(name="share4"),
+    ]
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
@@ -61,7 +66,7 @@ def test_list_all_tables(sharing_client: SharingClient):
         Table(name="table2", share="share2", schema="default"),
         Table(name="table4", share="share3", schema="default"),
         Table(name="table5", share="share3", schema="default"),
-        Table(name="test_gzip", share="share4", schema="default")
+        Table(name="test_gzip", share="share4", schema="default"),
     ]
 
 

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -26,7 +26,7 @@ from delta_sharing.tests.conftest import ENABLE_INTEGRATION, SKIP_MESSAGE
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_list_shares(sharing_client: SharingClient):
     shares = sharing_client.list_shares()
-    assert shares == [Share(name="share1"), Share(name="share2"), Share(name="share3")]
+    assert shares == [Share(name="share1"), Share(name="share2"), Share(name="share3"), Share(name="share4")]
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
@@ -61,6 +61,7 @@ def test_list_all_tables(sharing_client: SharingClient):
         Table(name="table2", share="share2", schema="default"),
         Table(name="table4", share="share3", schema="default"),
         Table(name="table5", share="share3", schema="default"),
+        Table(name="test_gzip", share="share4", schema="default")
     ]
 
 

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -238,8 +238,11 @@ def test_to_pandas_empty(rest_client: DataSharingRestClient):
 
     pd.testing.assert_frame_equal(pdf, expected)
 
+
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_load_gzip_table(rest_client: DataSharingRestClient):
-    reader = DeltaSharingReader(Table(name="test_gzip", share="share4", schema="default"), rest_client)
+    reader = DeltaSharingReader(
+        Table(name="test_gzip", share="share4", schema="default"), rest_client
+    )
     expected = reader.to_pandas()
-    assert(len(expected) == 1)
+    assert len(expected) == 1

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -237,12 +237,3 @@ def test_to_pandas_empty(rest_client: DataSharingRestClient):
     expected = reader.to_pandas().iloc[0:0]
 
     pd.testing.assert_frame_equal(pdf, expected)
-
-
-@pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
-def test_load_gzip_table(rest_client: DataSharingRestClient):
-    reader = DeltaSharingReader(
-        Table(name="test_gzip", share="share4", schema="default"), rest_client
-    )
-    expected = reader.to_pandas()
-    assert len(expected) == 1

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -237,3 +237,9 @@ def test_to_pandas_empty(rest_client: DataSharingRestClient):
     expected = reader.to_pandas().iloc[0:0]
 
     pd.testing.assert_frame_equal(pdf, expected)
+
+@pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
+def test_load_gzip_table(rest_client: DataSharingRestClient):
+    reader = DeltaSharingReader(Table(name="test_gzip", share="share4", schema="default"), rest_client)
+    expected = reader.to_pandas()
+    assert(len(expected) == 1)

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -36,7 +36,7 @@ def test_read_endpoint(rest_client: DataSharingRestClient):
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_list_shares(rest_client: DataSharingRestClient):
     response = rest_client.list_shares()
-    assert response.shares == [Share(name="share1"), Share(name="share2"), Share(name="share3")]
+    assert response.shares == [Share(name="share1"), Share(name="share2"), Share(name="share3"), Share(name="share4")]
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -36,7 +36,12 @@ def test_read_endpoint(rest_client: DataSharingRestClient):
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_list_shares(rest_client: DataSharingRestClient):
     response = rest_client.list_shares()
-    assert response.shares == [Share(name="share1"), Share(name="share2"), Share(name="share3"), Share(name="share4")]
+    assert response.shares == [
+        Share(name="share1"),
+        Share(name="share2"),
+        Share(name="share3"),
+        Share(name="share4"),
+    ]
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -152,7 +152,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   integrationTest("/shares") {
     val response = readJson(requestPath("/shares"))
     val expected = ListSharesResponse(
-      Vector(Share().withName("share1"), Share().withName("share2"), Share().withName("share3")))
+      Vector(Share().withName("share1"), Share().withName("share2"), Share().withName("share3"), Share().withName("share4")))
     assert(expected == JsonFormat.fromJsonString[ListSharesResponse](response))
   }
 
@@ -165,7 +165,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       response = JsonFormat.fromJsonString[ListSharesResponse](readJson(requestPath(s"/shares?pageToken=${response.nextPageToken.get}&maxResults=1")))
       shares ++= response.items
     }
-    val expected = Seq(Share().withName("share1"), Share().withName("share2"), Share().withName("share3"))
+    val expected = Seq(Share().withName("share1"), Share().withName("share2"), Share().withName("share3"), Share().withName("share4"))
     assert(expected == shares)
   }
 

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -67,6 +67,17 @@ object TestResource {
             )
           )
         )
+      ),
+      ShareConfig("share4",
+        java.util.Arrays.asList(
+          SchemaConfig(
+            "default",
+            java.util.Arrays.asList(
+              // table made with spark.sql.parquet.compression.codec=gzip
+              TableConfig("test_gzip", s"s3a://${TestResource.AWS.bucket}/compress-test/table1")
+            )
+          )
+        )
       )
     )
 

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -30,7 +30,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Table(name = "table3", schema = "default", share = "share1"),
         Table(name = "table4", schema = "default", share = "share3"),
         Table(name = "table5", schema = "default", share = "share3"),
-        Table(name = "table7", schema = "default", share = "share1")
+        Table(name = "table7", schema = "default", share = "share1"),
+        Table(name = "test_gzip", schema = "default", share = "share4")
       )
       assert(expected == client.listAllTables().toSet)
     } finally {

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -113,6 +113,16 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
     }
   }
 
+  integrationTest("test_gzip: non-default compression codec") {
+    val tablePath = testProfileFile.getCanonicalPath + "#share4.default.test_gzip"
+    val expected = Seq(Row(true, 1, "Hi"))
+    checkAnswer(spark.read.format("deltaSharing").load(tablePath), expected)
+    withTable("delta_sharing_test") {
+      sql(s"CREATE TABLE delta_sharing_test USING deltaSharing LOCATION '$tablePath'")
+      checkAnswer(sql(s"SELECT * FROM delta_sharing_test"), expected)
+    }
+  }
+
   integrationTest("partition pruning") {
     val tablePath = testProfileFile.getCanonicalPath + "#share1.default.table3"
     val expected = Seq(


### PR DESCRIPTION
- Added a new table compressed with gzip to the test bucket.
- Added tests to make sure the client is able to read the table.