### PR TITLE
Fix KeyError in client when response contains empty items

### DIFF
--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -85,7 +85,7 @@ class DataSharingRestClient:
         with self._get_internal("/shares", data) as lines:
             shares_json = json.loads(next(lines))
             return ListSharesResponse(
-                shares=[Share.from_json(share_json) for share_json in shares_json["items"]],
+                shares=[Share.from_json(share_json) for share_json in shares_json.get("items", [])],
                 next_page_token=shares_json.get("nextPageToken", None),
             )
 
@@ -101,7 +101,7 @@ class DataSharingRestClient:
         with self._get_internal(f"/shares/{share.name}/schemas", data) as lines:
             schemas_json = json.loads(next(lines))
             return ListSchemasResponse(
-                schemas=[Schema.from_json(schema_json) for schema_json in schemas_json["items"]],
+                schemas=[Schema.from_json(schema_json) for schema_json in schemas_json.get("items", [])],
                 next_page_token=schemas_json.get("nextPageToken", None),
             )
 
@@ -119,7 +119,7 @@ class DataSharingRestClient:
         ) as lines:
             tables_json = json.loads(next(lines))
             return ListTablesResponse(
-                tables=[Table.from_json(table_json) for table_json in tables_json["items"]],
+                tables=[Table.from_json(table_json) for table_json in tables_json.get("items", [])],
                 next_page_token=tables_json.get("nextPageToken", None),
             )
 

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -101,7 +101,9 @@ class DataSharingRestClient:
         with self._get_internal(f"/shares/{share.name}/schemas", data) as lines:
             schemas_json = json.loads(next(lines))
             return ListSchemasResponse(
-                schemas=[Schema.from_json(schema_json) for schema_json in schemas_json.get("items", [])],
+                schemas=[
+                    Schema.from_json(schema_json) for schema_json in schemas_json.get("items", [])
+                ],
                 next_page_token=schemas_json.get("nextPageToken", None),
             )
 

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -31,6 +31,8 @@ def test_list_shares(sharing_client: SharingClient):
         Share(name="share2"),
         Share(name="share3"),
         Share(name="share4"),
+        Share(name="share5"),
+        Share(name="share6")
     ]
 
 

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -32,7 +32,7 @@ def test_list_shares(sharing_client: SharingClient):
         Share(name="share3"),
         Share(name="share4"),
         Share(name="share5"),
-        Share(name="share6")
+        Share(name="share6"),
     ]
 
 

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -42,7 +42,7 @@ def test_list_shares(rest_client: DataSharingRestClient):
         Share(name="share3"),
         Share(name="share4"),
         Share(name="share5"),
-        Share(name="share6")
+        Share(name="share6"),
     ]
 
 

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -41,6 +41,8 @@ def test_list_shares(rest_client: DataSharingRestClient):
         Share(name="share2"),
         Share(name="share3"),
         Share(name="share4"),
+        Share(name="share5"),
+        Share(name="share6")
     ]
 
 

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -152,7 +152,15 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   integrationTest("/shares") {
     val response = readJson(requestPath("/shares"))
     val expected = ListSharesResponse(
-      Vector(Share().withName("share1"), Share().withName("share2"), Share().withName("share3"), Share().withName("share4")))
+      Vector(
+        Share().withName("share1"),
+        Share().withName("share2"),
+        Share().withName("share3"),
+        Share().withName("share4"),
+        Share().withName("share5"),
+        Share().withName("share6")
+      )
+    )
     assert(expected == JsonFormat.fromJsonString[ListSharesResponse](response))
   }
 
@@ -165,7 +173,14 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       response = JsonFormat.fromJsonString[ListSharesResponse](readJson(requestPath(s"/shares?pageToken=${response.nextPageToken.get}&maxResults=1")))
       shares ++= response.items
     }
-    val expected = Seq(Share().withName("share1"), Share().withName("share2"), Share().withName("share3"), Share().withName("share4"))
+    val expected = Seq(
+        Share().withName("share1"),
+        Share().withName("share2"),
+        Share().withName("share3"),
+        Share().withName("share4"),
+        Share().withName("share5"),
+        Share().withName("share6")
+    )
     assert(expected == shares)
   }
 

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -78,6 +78,17 @@ object TestResource {
             )
           )
         )
+      ),
+      ShareConfig("share5",
+        java.util.Arrays.asList(
+          SchemaConfig(
+            "default", // empty schema
+            java.util.Arrays.asList()
+          )
+        )
+      ),
+      ShareConfig("share6",
+        java.util.Arrays.asList()
       )
     )
 

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -109,12 +109,12 @@ private[sharing] class DeltaSharingRestClient(
     val target = getTargetUrl("shares")
     val shares = ArrayBuffer[Share]()
     var response = getJson[ListSharesResponse](target)
-    shares ++= response.items
+    if (response != null && response.items != null) shares ++= response.items
     while (response.nextPageToken.nonEmpty) {
       val encodedPageToken = URLEncoder.encode(response.nextPageToken.get, "UTF-8")
       val target = getTargetUrl(s"/shares?pageToken=$encodedPageToken")
       response = getJson[ListSharesResponse](target)
-      shares ++= response.items
+      if (response != null && response.items != null) shares ++= response.items
     }
     shares
   }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -109,12 +109,16 @@ private[sharing] class DeltaSharingRestClient(
     val target = getTargetUrl("shares")
     val shares = ArrayBuffer[Share]()
     var response = getJson[ListSharesResponse](target)
-    if (response != null && response.items != null) shares ++= response.items
+    if (response != null && response.items != null) {
+      shares ++= response.items
+    }
     while (response.nextPageToken.nonEmpty) {
       val encodedPageToken = URLEncoder.encode(response.nextPageToken.get, "UTF-8")
       val target = getTargetUrl(s"/shares?pageToken=$encodedPageToken")
       response = getJson[ListSharesResponse](target)
-      if (response != null && response.items != null) shares ++= response.items
+      if (response != null && response.items != null) {
+        shares ++= response.items
+      }
     }
     shares
   }
@@ -124,13 +128,17 @@ private[sharing] class DeltaSharingRestClient(
     val target = getTargetUrl(s"/shares/$encodedShareName/schemas")
     val schemas = ArrayBuffer[Schema]()
     var response = getJson[ListSchemasResponse](target)
-    if (response != null && response.items != null) schemas ++= response.items
+    if (response != null && response.items != null) {
+      schemas ++= response.items
+    }
     while (response.nextPageToken.nonEmpty) {
       val encodedPageToken = URLEncoder.encode(response.nextPageToken.get, "UTF-8")
       val target =
         getTargetUrl(s"/shares/$encodedShareName/schemas?pageToken=$encodedPageToken")
       response = getJson[ListSchemasResponse](target)
-      if (response != null && response.items != null) schemas ++= response.items
+      if (response != null && response.items != null) {
+        schemas ++= response.items
+      }
     }
     schemas
   }
@@ -141,13 +149,17 @@ private[sharing] class DeltaSharingRestClient(
     val target = getTargetUrl(s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables")
     val tables = ArrayBuffer[Table]()
     var response = getJson[ListTablesResponse](target)
-    if (response != null && response.items != null) tables ++= response.items
+    if (response != null && response.items != null) {
+      tables ++= response.items
+    }
     while (response.nextPageToken.nonEmpty) {
       val encodedPageToken = URLEncoder.encode(response.nextPageToken.get, "UTF-8")
       val target = getTargetUrl(s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables" +
         s"?pageToken=$encodedPageToken")
       response = getJson[ListTablesResponse](target)
-      if (response != null && response.items != null) tables ++= response.items
+      if (response != null && response.items != null) {
+        tables ++= response.items
+      }
     }
     tables
   }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -124,13 +124,13 @@ private[sharing] class DeltaSharingRestClient(
     val target = getTargetUrl(s"/shares/$encodedShareName/schemas")
     val schemas = ArrayBuffer[Schema]()
     var response = getJson[ListSchemasResponse](target)
-    schemas ++= response.items
+    if (response != null && response.items != null) schemas ++= response.items
     while (response.nextPageToken.nonEmpty) {
       val encodedPageToken = URLEncoder.encode(response.nextPageToken.get, "UTF-8")
       val target =
         getTargetUrl(s"/shares/$encodedShareName/schemas?pageToken=$encodedPageToken")
       response = getJson[ListSchemasResponse](target)
-      schemas ++= response.items
+      if (response != null && response.items != null) schemas ++= response.items
     }
     schemas
   }
@@ -141,13 +141,13 @@ private[sharing] class DeltaSharingRestClient(
     val target = getTargetUrl(s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables")
     val tables = ArrayBuffer[Table]()
     var response = getJson[ListTablesResponse](target)
-    tables ++= response.items
+    if (response != null && response.items != null) tables ++= response.items
     while (response.nextPageToken.nonEmpty) {
       val encodedPageToken = URLEncoder.encode(response.nextPageToken.get, "UTF-8")
       val target = getTargetUrl(s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables" +
         s"?pageToken=$encodedPageToken")
       response = getJson[ListTablesResponse](target)
-      tables ++= response.items
+      if (response != null && response.items != null) tables ++= response.items
     }
     tables
   }


### PR DESCRIPTION
When the items field of the protobuf is empty, the resulting json won't contain the items field. This PR adds checks so that we won't have KeyErrors or NullPointerExceptions if we have empty responses for listSchema and listTables.

Added tests with empty shares and schemas.