### PR TITLE
Initial PR to add Support for Azure Data Lake Storage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,6 +86,10 @@ lazy val server = (project in file("server")) enablePlugins(JavaAppPackaging) se
       ExclusionRule("com.fasterxml.jackson.core"),
       ExclusionRule("com.fasterxml.jackson.module")
     ),
+    "org.apache.hadoop" % "hadoop-azure" % "2.10.1" excludeAll(
+      ExclusionRule("com.fasterxml.jackson.core"),
+      ExclusionRule("com.fasterxml.jackson.module")
+    ),
     "org.apache.hadoop" % "hadoop-common" % "2.10.1" excludeAll(
       ExclusionRule("com.fasterxml.jackson.core"),
       ExclusionRule("com.fasterxml.jackson.module")


### PR DESCRIPTION
Fixes #21 

This commit  adds support for sharing Delta tables on Azure Blob Storage and Data Lake Storage Gen2. In particular, this commit adds a new class `AzureFileSigner` which generates a pre-signed URL to Azure blob using a Shared Access Account Policy. Also, this commit automatically sets the Hadoop configuration with the `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_KEY` environment variables, which is used to generate the pre-signed blob URLs.

Signed-off-by: Will Girten <will.girten@databricks.com>