### PR TITLE
Fix server package steps in release script

### DIFF
--- a/dev/release.sh
+++ b/dev/release.sh
@@ -32,11 +32,14 @@ cd ..
 
 # Generate the pre-built server package and sign files
 build/sbt server/universal:packageBin
-sha256sum server/target/universal/delta-sharing-server-$VERSION.zip > server/target/universal/delta-sharing-server-$VERSION.zip.sha256
-gpg --detach-sign --armor --sign server/target/universal/delta-sharing-server-$VERSION.zip
-gpg --detach-sign --armor --sign server/target/universal/delta-sharing-server-$VERSION.zip.sha256
-gpg --verify server/target/universal/delta-sharing-server-$VERSION.zip.asc
-gpg --verify server/target/universal/delta-sharing-server-$VERSION.zip.sha256.asc
+cd server/target/universal
+gpg --detach-sign --armor --sign delta-sharing-server-$VERSION.zip
+gpg --verify delta-sharing-server-$VERSION.zip.asc
+sha256sum delta-sharing-server-$VERSION.zip > delta-sharing-server-$VERSION.zip.sha256
+sha256sum -c delta-sharing-server-$VERSION.zip.sha256
+sha256sum delta-sharing-server-$VERSION.zip.asc > delta-sharing-server-$VERSION.zip.asc.sha256
+sha256sum -c delta-sharing-server-$VERSION.zip.asc.sha256
+cd -
 
 # Build the docker image
 build/sbt server/docker:publish


### PR DESCRIPTION
Fix the incorrect commands in the release script. Found them when I was making 0.2.0 release. See https://github.com/delta-io/delta-sharing/releases/tag/v0.2.0 for the list of files the script is supposed to generate.