### PR TITLE
Fix Azure support for Delta Sharing Server

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,7 @@ jobs:
       SPARK_LOCAL_IP: localhost
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -40,6 +41,7 @@ jobs:
       SPARK_LOCAL_IP: localhost
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
       # Github Actions' default miniconda
       CONDA_PREFIX: /usr/share/miniconda
     steps:

--- a/README.md
+++ b/README.md
@@ -206,15 +206,19 @@ Download the pre-built package `delta-sharing-server-x.y.z.zip` from [GitHub Rel
 - Unpack the pre-built package and copy the server config template file `conf/delta-sharing-server.yaml.template` to create your own server yaml file, such as `conf/delta-sharing-server.yaml`.
 - Make changes to your yaml file, such as add the Delta Lake tables you would like to share in this server. You may also need to update some server configs for special requirements.
 
-## Config the server to access tables on S3
+## Config the server to access tables on cloud storage
 
-We only support sharing Delta Lake tables on S3 right now. There are multiple ways to config the server to access S3.
+We support sharing Delta Lake tables on S3, Azure Blob Storage and Azure Data Lake Storage Gen2.
 
-### EC2 IAM Metadata Authentication (Recommended)
+### S3
+
+There are multiple ways to config the server to access S3.
+
+#### EC2 IAM Metadata Authentication (Recommended)
 
 Applications running in EC2 may associate an IAM role with the VM and query the [EC2 Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for credentials to access S3.
 
-### Authenticating via the AWS Environment Variables
+#### Authenticating via the AWS Environment Variables
 
 We support configuration via [the standard AWS environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html#cli-environment). The core environment variables are for the access key and associated secret:
 ```
@@ -222,9 +226,42 @@ export AWS_ACCESS_KEY_ID=my.aws.key
 export AWS_SECRET_ACCESS_KEY=my.secret.key
 ```
 
-### Other S3 authentication methods
+#### Other S3 authentication methods
 
 The server is using `hadooop-aws` to read S3. You can find other approaches in [hadoop-aws doc](https://hadoop.apache.org/docs/r2.10.1/hadoop-aws/tools/hadoop-aws/index.html#S3A_Authentication_methods).
+
+### Azure Blob Storage
+
+The server is using `hadoop-azure` to read Azure Blob Storage. Using Azure Blob Storage requires [configuration of credentials](https://hadoop.apache.org/docs/current/hadoop-azure/index.html#Configuring_Credentials). You can create a Hadoop configuration file named `core-site.xml` and add it to the server's `conf` directory. Then add the following content to the xml file:
+
+```xml
+<property>
+  <name>fs.azure.account.key.YOUR-ACCOUNT-NAME.blob.core.windows.net</name>
+  <value>YOUR-ACCOUNT-KEY</value>
+</property>
+```
+`YOUR-ACCOUNT-NAME` is your Azure storage account and `YOUR-ACCOUNT-KEY` is your account key.
+
+### Azure Data Lake Storage Gen2
+
+The server is using `hadoop-azure` to read Azure Data Lake Storage Gen2. We support [the Shared Key authentication](https://hadoop.apache.org/docs/stable/hadoop-azure/abfs.html#Default:_Shared_Key). You can create a Hadoop configuration file named `core-site.xml` and add it to the server's `conf` directory. Then add the following content to the xml file:
+
+```xml
+<property>
+  <name>fs.azure.account.auth.type.YOUR-ACCOUNT-NAME.dfs.core.windows.net</name>
+  <value>SharedKey</value>
+  <description>
+  </description>
+</property>
+<property>
+  <name>fs.azure.account.key.YOUR-ACCOUNT-NAME.dfs.core.windows.net</name>
+  <value>YOUR-ACCOUNT-KEY</value>
+  <description>
+  The secret password. Never share these.
+  </description>
+</property>
+```
+`YOUR-ACCOUNT-NAME` is your Azure storage account and `YOUR-ACCOUNT-KEY` is your account key.
 
 More cloud storage supports will be added in the future.
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val commonSettings = Seq(
     "-Dspark.sql.shuffle.partitions=5",
     "-Dspark.sql.sources.parallelPartitionDiscovery.parallelism=5",
     "-Dspark.delta.sharing.network.sslTrustAll=true",
+    s"-Dazure.account.key=${sys.env.getOrElse("AZURE_TEST_ACCOUNT_KEY", "")}",
     "-Xmx1024m"
   )
 )

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -141,22 +141,12 @@ def test_list_all_tables(sharing_client: SharingClient):
         ),
         pytest.param(
             "share_azure.default.table_wasb",
-            pd.DataFrame(
-                {
-                    "c1": ["foo bar"],
-                    "c2": ["foo bar"],
-                }
-            ),
+            pd.DataFrame({"c1": ["foo bar"], "c2": ["foo bar"],}),
             id="Azure Blob Storage",
         ),
         pytest.param(
             "share_azure.default.table_abfs",
-            pd.DataFrame(
-                {
-                    "c1": ["foo bar"],
-                    "c2": ["foo bar"],
-                }
-            ),
+            pd.DataFrame({"c1": ["foo bar"], "c2": ["foo bar"],}),
             id="Azure Data Lake Storage Gen2",
         ),
     ],

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -33,6 +33,7 @@ def test_list_shares(sharing_client: SharingClient):
         Share(name="share4"),
         Share(name="share5"),
         Share(name="share6"),
+        Share(name="share_azure"),
     ]
 
 
@@ -69,6 +70,8 @@ def test_list_all_tables(sharing_client: SharingClient):
         Table(name="table4", share="share3", schema="default"),
         Table(name="table5", share="share3", schema="default"),
         Table(name="test_gzip", share="share4", schema="default"),
+        Table(name="table_wasb", share="share_azure", schema="default"),
+        Table(name="table_abfs", share="share_azure", schema="default"),
     ]
 
 
@@ -135,6 +138,26 @@ def test_list_all_tables(sharing_client: SharingClient):
             "share4.default.test_gzip",
             pd.DataFrame({"a": [True], "b": pd.Series([1], dtype="int32"), "c": ["Hi"]}),
             id="table column order is not the same as parquet files",
+        ),
+        pytest.param(
+            "share_azure.default.table_wasb",
+            pd.DataFrame(
+                {
+                    "c1": ["foo bar"],
+                    "c2": ["foo bar"],
+                }
+            ),
+            id="Azure Blob Storage",
+        ),
+        pytest.param(
+            "share_azure.default.table_abfs",
+            pd.DataFrame(
+                {
+                    "c1": ["foo bar"],
+                    "c2": ["foo bar"],
+                }
+            ),
+            id="Azure Data Lake Storage Gen2",
         ),
     ],
 )

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -104,6 +104,7 @@ def test_list_shares(rest_client: DataSharingRestClient):
         Share(name="share4"),
         Share(name="share5"),
         Share(name="share6"),
+        Share(name='share_azure'),
     ]
 
 

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -104,7 +104,7 @@ def test_list_shares(rest_client: DataSharingRestClient):
         Share(name="share4"),
         Share(name="share5"),
         Share(name="share6"),
-        Share(name='share_azure'),
+        Share(name="share_azure"),
     ]
 
 

--- a/python/dev/lint-python
+++ b/python/dev/lint-python
@@ -246,7 +246,7 @@ function black_test {
     fi
 
     echo "starting black test..."
-    BLACK_REPORT=$( ($BLACK_BUILD delta_sharing --line-length 100 --check ) 2>&1)
+    BLACK_REPORT=$( ($BLACK_BUILD delta_sharing --line-length 100 --check --diff) 2>&1)
     BLACK_STATUS=$?
 
     if [ "$BLACK_STATUS" -ne 0 ]; then

--- a/server/src/main/scala/io/delta/sharing/server/CloudFileSigner.scala
+++ b/server/src/main/scala/io/delta/sharing/server/CloudFileSigner.scala
@@ -171,8 +171,6 @@ object AbfsFileSigner {
       fs: AzureBlobFileSystem,
       uri: URI,
       preSignedUrlTimeoutSeconds: Long): CloudFileSigner = {
-    val getAbfsStoreMethod = classOf[AzureBlobFileSystem].getDeclaredMethod("getAbfsStore")
-    getAbfsStoreMethod.setAccessible(true)
     val abfsStore = getAbfsStore(fs)
     val abfsConfiguration = abfsStore.getAbfsConfiguration
     val accountName = abfsConfiguration.accountConf("dummy").stripPrefix("dummy.")

--- a/server/src/main/scala/io/delta/sharing/server/CloudFileSigner.scala
+++ b/server/src/main/scala/io/delta/sharing/server/CloudFileSigner.scala
@@ -100,7 +100,7 @@ class AzureFileSigner(
     val containerRef = blobClient.getContainerReference(container)
     val objectKey = objectKeyExtractor(path)
     assert(objectKey.nonEmpty, s"cannot get object key from $path")
-    val blobRef = containerRef.getBlockBlobReference(objectKeyExtractor(path))
+    val blobRef = containerRef.getBlockBlobReference(objectKey)
     val accessPolicy = getAccessPolicy
     val sasToken = blobRef.generateSharedAccessSignature(
       accessPolicy,

--- a/server/src/main/scala/io/delta/sharing/server/CloudFileSigner.scala
+++ b/server/src/main/scala/io/delta/sharing/server/CloudFileSigner.scala
@@ -72,7 +72,6 @@ class AzureFileSigner(
     (splits(0), splits(2))
   }
 
-  // endpointSuffix ?
   private def getCloudStorageAccount: CloudStorageAccount = {
     val connectionString = Seq(
       "DefaultEndpointsProtocol=https",

--- a/server/src/main/scala/io/delta/sharing/server/CloudFileSigner.scala
+++ b/server/src/main/scala/io/delta/sharing/server/CloudFileSigner.scala
@@ -50,6 +50,7 @@ class S3FileSigner(
     val objectKey = absPath.getPath.stripPrefix("/")
     val expiration =
       new Date(System.currentTimeMillis() + SECONDS.toMillis(preSignedUrlTimeoutSeconds))
+    assert(objectKey.nonEmpty, s"cannot get object key from $path")
     val request = new GeneratePresignedUrlRequest(bucketName, objectKey)
       .withMethod(HttpMethod.GET)
       .withExpiration(expiration)
@@ -97,6 +98,8 @@ class AzureFileSigner(
 
   override def sign(path: Path): String = {
     val containerRef = blobClient.getContainerReference(container)
+    val objectKey = objectKeyExtractor(path)
+    assert(objectKey.nonEmpty, s"cannot get object key from $path")
     val blobRef = containerRef.getBlockBlobReference(objectKeyExtractor(path))
     val accessPolicy = getAccessPolicy
     val sasToken = blobRef.generateSharedAccessSignature(

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -89,7 +89,7 @@ class DeltaSharedTable(
       case abfs: AzureBlobFileSystem =>
         AbfsFileSigner(abfs, deltaLog.dataPath.toUri, preSignedUrlTimeoutSeconds)
       case _ =>
-        throw new IllegalStateException("Cannot share tables on non S3 or non Azure file systems")
+        throw new IllegalStateException(s"File system ${fs.getClass} is not supported")
     }
   }
 

--- a/server/src/test/resources/core-site.xml
+++ b/server/src/test/resources/core-site.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+    <!-- wasb -->
+    <property>
+        <name>fs.azure.account.key.deltasharingtest.blob.core.windows.net</name>
+        <value>${azure.account.key}</value>
+    </property>
+    <!-- abfs -->
+    <property>
+        <name>fs.azure.account.auth.type.deltasharingtest.dfs.core.windows.net</name>
+        <value>SharedKey</value>
+        <description>
+        </description>
+    </property>
+    <property>
+        <name>fs.azure.account.key.deltasharingtest.dfs.core.windows.net</name>
+        <value>${azure.account.key}</value>
+    </property>
+</configuration>

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -520,11 +520,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
 
     // Modifying the file to access a different path should fail. This ensures the url is scoped
     // down to the specific file.
-    // scalastyle:off
-    println("url: " + url)
     val urlForDifferentObject = url.replaceAll("\\.parquet", ".orc")
     assert(url != urlForDifferentObject)
-    println("urlForDifferentObject: " + urlForDifferentObject)
     val e = intercept[IOException] {
       IOUtils.toByteArray(new URL(urlForDifferentObject))
     }

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -101,9 +101,7 @@ object TestResource {
           SchemaConfig(
             "default",
             java.util.Arrays.asList(
-              // table made with spark.sql.parquet.compression.codec=gzip
               TableConfig("table_wasb", s"wasbs://${Azure.container}@${Azure.accountName}.blob.core.windows.net/delta-sharing-test/table1"),
-              // table made with spark.sql.parquet.compression.codec=gzip
               TableConfig("table_abfs", s"abfss://${Azure.container}@${Azure.accountName}.dfs.core.windows.net/delta-sharing-test/table1")
             )
           )

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -30,6 +30,11 @@ object TestResource {
     val bucket = "delta-exchange-test"
   }
 
+  object Azure {
+    val accountName = "deltasharingtest"
+    val container = "delta-sharing-test-container"
+  }
+
   val TEST_PORT = 12345
 
   val testAuthorizationToken = "dapi5e3574ec767ca1548ae5bbed1a2dc04d"
@@ -89,7 +94,22 @@ object TestResource {
       ),
       ShareConfig("share6",
         java.util.Arrays.asList()
+      ),
+      // scalastyle:off maxLineLength
+      ShareConfig("share_azure",
+        java.util.Arrays.asList(
+          SchemaConfig(
+            "default",
+            java.util.Arrays.asList(
+              // table made with spark.sql.parquet.compression.codec=gzip
+              TableConfig("table_wasb", s"wasbs://${Azure.container}@${Azure.accountName}.blob.core.windows.net/delta-sharing-test/table1"),
+              // table made with spark.sql.parquet.compression.codec=gzip
+              TableConfig("table_abfs", s"abfss://${Azure.container}@${Azure.accountName}.dfs.core.windows.net/delta-sharing-test/table1")
+            )
+          )
+        )
       )
+      // scalastyle:on
     )
 
     val serverConfig = new ServerConfig()

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -31,7 +31,9 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Table(name = "table4", schema = "default", share = "share3"),
         Table(name = "table5", schema = "default", share = "share3"),
         Table(name = "table7", schema = "default", share = "share1"),
-        Table(name = "test_gzip", schema = "default", share = "share4")
+        Table(name = "test_gzip", schema = "default", share = "share4"),
+        Table(name = "table_wasb", schema = "default", share = "share_azure"),
+        Table(name = "table_abfs", schema = "default", share = "share_azure")
       )
       assert(expected == client.listAllTables().toSet)
     } finally {

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -138,6 +138,15 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
     }
   }
 
+  integrationTest("azure support") {
+    for (azureTableName <- "table_wasb" :: "table_abfs" :: Nil) {
+      val tablePath = testProfileFile.getCanonicalPath + s"#share_azure.default.${azureTableName}"
+      checkAnswer(
+        spark.read.format("deltaSharing").load(tablePath),
+        Row("foo bar", "foo bar") :: Nil)
+    }
+  }
+
   integrationTest("random access stream") {
     // Set maxConnections to 1 so that if we leak any connection, we will hang forever because any
     // further request won't be able to get a free connection from the pool.


### PR DESCRIPTION
This is a followup PR for #56. There are multiple changes:

- Add integration tests for Azure.
- Change the pre-signed url generation for Azure to make sure it's scoped down to the path only. We also have tests verifying this.
- Refactor the code to leverage hadoop-azure to get credentials rather than from the system env. The user can just follow the hadoop-azure doc to set up the credentials. See the updated README for more information.

Closes #21