### PR TITLE
Add pre-signed URL request logging to server

### DIFF
--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -92,7 +92,7 @@ class DeltaSharingService(serverConfig: ServerConfig) {
 
   private val deltaSharedTableLoader = new DeltaSharedTableLoader(serverConfig)
 
-  val logger = LoggerFactory.getLogger(classOf[DeltaSharingService])
+  private val logger = LoggerFactory.getLogger(classOf[DeltaSharingService])
   /**
    * Call `func` and catch any unhandled exception and convert it to `DeltaInternalException`. Any
    * code that processes requests should use this method to ensure that unhandled exceptions are


### PR DESCRIPTION
This is a PR which implements #39.
I modify only 1 method for logging time for generation the pre-signed URLs, the count of the URLs, and the table name.

I have some concerns about my implementation.
- I didn't add any test because what I had implemented is only logging. I think this is no problem. Is it OK?
- My implementation outputs logs on "INFO" level because the default log level of slf4j is INFO, not including "DEBUG". #39 says  "It would be nice if the server logged at the DEBUG level every time it generated a new pre-signed S3 URL." Is it no problem?