### PR TITLE
Avoid modifying the global Hadoop configuration when fs.delta-sharing.impl is set

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
@@ -66,7 +66,7 @@ private[sharing] object DeltaSharingDataSource {
     // we add the library after starting Spark. Therefore we change the global `hadoopConfiguration`
     // to make sure we set up `DeltaSharingFileSystem` correctly.
     sqlContext.sparkContext.hadoopConfiguration
-      .set("fs.delta-sharing.impl", "io.delta.sharing.spark.DeltaSharingFileSystem")
+      .setIfUnset("fs.delta-sharing.impl", "io.delta.sharing.spark.DeltaSharingFileSystem")
     PreSignedUrlCache.registerIfNeeded(SparkEnv.get)
   }
 }


### PR DESCRIPTION
Currently we will still modify the global Hadoop configuration when fs.delta-sharing.impl is set. This is a tiny optimization.