### PR TITLE
Add the User-Agent request header to Delta Sharing client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,18 @@ lazy val spark = (project in file("spark")) settings(
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",
     "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests",
     "org.scalatest" %% "scalatest" % "3.2.3" % "test"
-  )
+  ),
+  sourceGenerators in Compile += Def.task {
+    val file = (sourceManaged in Compile).value / "io" / "delta" / "sharing" / "package.scala"
+    IO.write(file,
+      s"""package io.delta.sharing
+         |
+         |package object spark {
+         |  val VERSION = "${version.value}"
+         |}
+         |""".stripMargin)
+    Seq(file)
+  }
 )
 
 lazy val server = (project in file("server")) enablePlugins(JavaAppPackaging) settings(


### PR DESCRIPTION
This PR adds the User-Agent request header to Delta Sharing client so that the server can use this information to track client metrics and it's also easier to debug issues. Here are examples of the header:

- Spark connector

> Delta-Sharing-Spark/0.3.0-SNAPSHOT Spark/3.1.1 Hadoop/3.2.0 Mac_OS_X/10.14.6 Java_HotSpot(TM)_64-Bit_Server_VM/25.171-b11 java/1.8.0_171 scala/2.12.10 java_vendor/Oracle_Corporation

- Pandas connector

> Delta-Sharing-Python/0.3.0.dev0 pandas/1.2.4 PyArrow/4.0.0 Python/3.9.5 System/macOS-10.14.6-x86_64-i386-64bit

Closes #57