### PR TITLE
Add a limit parameter to 'load_as_pandas'

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,7 +33,7 @@ jobs:
         include:
           - python-version: 3.8
             pandas-version: 1.2.4
-            pyarrow-version: 2.0.0
+            pyarrow-version: 4.0.0
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       PANDAS_VERSION: ${{ matrix.pandas-version }}

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ client.list_all_tables()
 # A table path is the profile file path following with `#` and the fully qualified name of a table (`<share-name>.<schema-name>.<table-name>`).
 table_url = profile_file + "#<share-name>.<schema-name>.<table-name>"
 
+# Fetch 10 rows from a table and convert it to a Pandas DataFrame. This can be used to read sample data from a table that cannot fit in the memory.
+delta_sharing.load_as_pandas(table_url, limit=10)
+
 # Load a table as a Pandas DataFrame. This can be used to process tables that can fit in the memory.
 delta_sharing.load_as_pandas(table_url)
 

--- a/examples/python/quickstart_pandas.py
+++ b/examples/python/quickstart_pandas.py
@@ -31,6 +31,14 @@ print(client.list_all_tables())
 # A table path is the profile file path following with `#` and the fully qualified name of a table (`<share-name>.<schema-name>.<table-name>`).
 table_url = profile_file + "#delta_sharing.default.owid-covid-data"
 
+# Fetch 10 rows from a table and convert it to a Pandas DataFrame. This can be used to read sample data from a table that cannot fit in the memory.
+print("########### Loading 10 rows from delta_sharing.default.owid-covid-data as a Pandas DataFrame #############")
+data = delta_sharing.load_as_pandas(table_url, limit=10)
+
+# Print the sample.
+print("########### Show the fetched 10 rows #############")
+print(data)
+
 # Load a table as a Pandas DataFrame. This can be used to process tables that can fit in the memory.
 print("########### Loading delta_sharing.default.owid-covid-data as a Pandas DataFrame #############")
 data = delta_sharing.load_as_pandas(table_url)

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -47,11 +47,14 @@ def _parse_url(url: str) -> Tuple[str, str, str, str]:
     return (profile, share, schema, table)
 
 
-def load_as_pandas(url: str) -> pd.DataFrame:
+def load_as_pandas(url: str, limit: Optional[int] = None) -> pd.DataFrame:
     """
     Load the shared table using the give url as a pandas DataFrame.
 
     :param url: a url under the format "<profile>#<share>.<schema>.<table>"
+    :param limit: a non-negative int. Load only the ``limit`` rows if the parameter is specified.
+      Use this optional parameter to explore the shared table without loading the entire table to
+      the memory.
     :return: A pandas DataFrame representing the shared table.
     """
     profile_json, share, schema, table = _parse_url(url)
@@ -59,6 +62,7 @@ def load_as_pandas(url: str) -> pd.DataFrame:
     return DeltaSharingReader(
         table=Table(name=table, share=share, schema=schema),
         rest_client=DataSharingRestClient(profile),
+        limit=limit,
     ).to_pandas()
 
 

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -33,7 +33,7 @@ class DeltaSharingReader:
         rest_client: DataSharingRestClient,
         *,
         predicateHints: Optional[Sequence[str]] = None,
-        limitHint: Optional[int] = None
+        limit: Optional[int] = None,
     ):
         self._table = table
         self._rest_client = rest_client
@@ -43,60 +43,77 @@ class DeltaSharingReader:
             assert all(isinstance(predicateHint, str) for predicateHint in predicateHints)
         self._predicateHints = predicateHints
 
-        if limitHint is not None:
-            assert isinstance(limitHint, int)
-        self._limitHint = limitHint
+        if limit is not None:
+            assert isinstance(limit, int) and limit >= 0, "'limit' must be a non-negative int"
+        self._limit = limit
 
     @property
     def table(self) -> Table:
         return self._table
 
     def predicateHints(self, predicateHints: Optional[Sequence[str]]) -> "DeltaSharingReader":
-        return self._copy(predicateHints=predicateHints, limitHint=self._limitHint)
+        return self._copy(predicateHints=predicateHints, limit=self._limit)
 
-    def limitHint(self, limitHint: Optional[int]) -> "DeltaSharingReader":
-        return self._copy(predicateHints=self._predicateHints, limitHint=limitHint)
+    def limit(self, limit: Optional[int]) -> "DeltaSharingReader":
+        return self._copy(predicateHints=self._predicateHints, limit=limit)
 
     def to_pandas(self) -> pd.DataFrame:
         response = self._rest_client.list_files_in_table(
-            self._table, predicateHints=self._predicateHints, limitHint=self._limitHint
+            self._table, predicateHints=self._predicateHints, limitHint=self._limit
         )
 
         schema_json = loads(response.metadata.schema_string)
 
-        if len(response.add_files) == 0:
+        if len(response.add_files) == 0 or self._limit == 0:
             return get_empty_table(schema_json)
 
         converters = to_converters(schema_json)
 
+        if self._limit is None:
+            pdfs = [
+                DeltaSharingReader._to_pandas(file, converters, None) for file in response.add_files
+            ]
+        else:
+            left = self._limit
+            pdfs = []
+            for file in response.add_files:
+                pdf = DeltaSharingReader._to_pandas(file, converters, left)
+                pdfs.append(pdf)
+                left -= len(pdf)
+                assert (
+                    left >= 0
+                ), f"'_to_pandas' returns too many rows. Required: {left}, returned: {len(pdf)}"
+                if left == 0:
+                    break
+
         return pd.concat(
-            [DeltaSharingReader._to_pandas(file, converters) for file in response.add_files],
+            pdfs,
             axis=0,
             ignore_index=True,
             copy=False,
         )[[field["name"] for field in schema_json["fields"]]]
 
     def _copy(
-        self, *, predicateHints: Optional[Sequence[str]], limitHint: Optional[int]
+        self, *, predicateHints: Optional[Sequence[str]], limit: Optional[int]
     ) -> "DeltaSharingReader":
         return DeltaSharingReader(
             table=self._table,
             rest_client=self._rest_client,
             predicateHints=predicateHints,
-            limitHint=limitHint,
+            limit=limit,
         )
 
     @staticmethod
-    def _to_pandas(add_file: AddFile, converters: Dict[str, Callable[[str], Any]]) -> pd.DataFrame:
+    def _to_pandas(
+        add_file: AddFile, converters: Dict[str, Callable[[str], Any]], limit: Optional[int]
+    ) -> pd.DataFrame:
         protocol = urlparse(add_file.url).scheme
         filesystem = fsspec.filesystem(protocol)
 
-        pdf = (
-            dataset(source=add_file.url, format="parquet", filesystem=filesystem)
-            .to_table()
-            .to_pandas(
-                date_as_object=True, use_threads=False, split_blocks=True, self_destruct=True
-            )
+        pa_dataset = dataset(source=add_file.url, format="parquet", filesystem=filesystem)
+        pa_table = pa_dataset.head(limit) if limit is not None else pa_dataset.to_table()
+        pdf = pa_table.to_pandas(
+            date_as_object=True, use_threads=False, split_blocks=True, self_destruct=True
         )
 
         for col, converter in converters.items():

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -33,7 +33,7 @@ class DeltaSharingReader:
         rest_client: DataSharingRestClient,
         *,
         predicateHints: Optional[Sequence[str]] = None,
-        limit: Optional[int] = None,
+        limit: Optional[int] = None
     ):
         self._table = table
         self._rest_client = rest_client
@@ -82,16 +82,13 @@ class DeltaSharingReader:
                 left -= len(pdf)
                 assert (
                     left >= 0
-                ), f"'_to_pandas' returns too many rows. Required: {left}, returned: {len(pdf)}"
+                ), f"'_to_pandas' returned too many rows. Required: {left}, returned: {len(pdf)}"
                 if left == 0:
                     break
 
-        return pd.concat(
-            pdfs,
-            axis=0,
-            ignore_index=True,
-            copy=False,
-        )[[field["name"] for field in schema_json["fields"]]]
+        return pd.concat(pdfs, axis=0, ignore_index=True, copy=False,)[
+            [field["name"] for field in schema_json["fields"]]
+        ]
 
     def _copy(
         self, *, predicateHints: Optional[Sequence[str]], limit: Optional[int]

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -33,7 +33,7 @@ class DeltaSharingReader:
         rest_client: DataSharingRestClient,
         *,
         predicateHints: Optional[Sequence[str]] = None,
-        limit: Optional[int] = None
+        limit: Optional[int] = None,
     ):
         self._table = table
         self._rest_client = rest_client

--- a/python/setup.py
+++ b/python/setup.py
@@ -43,7 +43,7 @@ setup(
     python_requires='>=3.6,<3.10',
     install_requires=[
         'pandas',
-        'pyarrow',
+        'pyarrow>=4.0.0',
         'fsspec>=0.7.4',
         'requests',
         'aiohttp',


### PR DESCRIPTION
This PR adds a new parameter `limit` to `load_as_pandas`. Users can use this parameter to limit the number of rows to be loaded into a pandas DataFrame. It can be used to explore a shared table without loading the entire table into the memory.

This PR also upgrades pyarrow to 4.0.0 so that we can use [dataset.head](https://issues.apache.org/jira/browse/ARROW-9731) to load only the first N rows.

Closes #62