### PR TITLE
Support GCS for delta sharing Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .pydevproject
 .scala_dependencies
 .settings
+/lib/
 R-unit-tests.log
 R/unit-tests.out
 R/cran-check.out

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@
 .pydevproject
 .scala_dependencies
 .settings
-/lib/
 R-unit-tests.log
 R/unit-tests.out
 R/cran-check.out

--- a/build.sbt
+++ b/build.sbt
@@ -96,38 +96,49 @@ lazy val server = (project in file("server")) enablePlugins(JavaAppPackaging) se
     ),
     "org.apache.hadoop" % "hadoop-aws" % "2.10.1" excludeAll(
       ExclusionRule("com.fasterxml.jackson.core"),
-      ExclusionRule("com.fasterxml.jackson.module")
+      ExclusionRule("com.fasterxml.jackson.module"),
+      ExclusionRule("com.google.guava", "guava")
     ),
     "org.apache.hadoop" % "hadoop-azure" % "2.10.1" excludeAll(
       ExclusionRule("com.fasterxml.jackson.core"),
-      ExclusionRule("com.fasterxml.jackson.module")
+      ExclusionRule("com.fasterxml.jackson.module"),
+      ExclusionRule("com.google.guava", "guava")
     ),
     "com.google.cloud" % "google-cloud-storage" % "2.2.1" excludeAll(
       ExclusionRule("com.fasterxml.jackson.core"),
       ExclusionRule("com.fasterxml.jackson.module")
     ),
-    "org.apache.hadoop" % "hadoop-common" % "2.10.1" excludeAll(
+    "com.google.cloud.bigdataoss" % "gcs-connector" % "hadoop2-2.2.3" excludeAll(
       ExclusionRule("com.fasterxml.jackson.core"),
       ExclusionRule("com.fasterxml.jackson.module")
+    ),
+    "org.apache.hadoop" % "hadoop-common" % "2.10.1" excludeAll(
+      ExclusionRule("com.fasterxml.jackson.core"),
+      ExclusionRule("com.fasterxml.jackson.module"),
+      ExclusionRule("com.google.guava", "guava")
     ),
     "org.apache.hadoop" % "hadoop-client" % "2.10.1" excludeAll(
       ExclusionRule("com.fasterxml.jackson.core"),
-      ExclusionRule("com.fasterxml.jackson.module")
+      ExclusionRule("com.fasterxml.jackson.module"),
+      ExclusionRule("com.google.guava", "guava")
     ),
     "org.apache.parquet" % "parquet-hadoop" % "1.10.1" excludeAll(
       ExclusionRule("com.fasterxml.jackson.core"),
-      ExclusionRule("com.fasterxml.jackson.module")
+      ExclusionRule("com.fasterxml.jackson.module"),
+      ExclusionRule("com.google.guava", "guava")
     ),
     "io.delta" %% "delta-standalone" % "0.2.0" excludeAll(
       ExclusionRule("com.fasterxml.jackson.core"),
-      ExclusionRule("com.fasterxml.jackson.module")
+      ExclusionRule("com.fasterxml.jackson.module"),
+      ExclusionRule("com.google.guava", "guava")
     ),
     "org.apache.spark" %% "spark-sql" % "2.4.7" excludeAll(
       ExclusionRule("org.slf4j"),
       ExclusionRule("io.netty"),
       ExclusionRule("com.fasterxml.jackson.core"),
       ExclusionRule("com.fasterxml.jackson.module"),
-      ExclusionRule("org.json4s")
+      ExclusionRule("org.json4s"),
+      ExclusionRule("com.google.guava", "guava")
     ),
     "org.slf4j" % "slf4j-api" % "1.6.1",
     "org.slf4j" % "slf4j-simple" % "1.6.1",

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import sbt.{ExclusionRule, file}
+import sbt.ExclusionRule
 
 ThisBuild / parallelExecution := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import sbt.ExclusionRule
+import sbt.{ExclusionRule, file}
 
 ThisBuild / parallelExecution := false
 
@@ -99,6 +99,10 @@ lazy val server = (project in file("server")) enablePlugins(JavaAppPackaging) se
       ExclusionRule("com.fasterxml.jackson.module")
     ),
     "org.apache.hadoop" % "hadoop-azure" % "2.10.1" excludeAll(
+      ExclusionRule("com.fasterxml.jackson.core"),
+      ExclusionRule("com.fasterxml.jackson.module")
+    ),
+    "com.google.cloud" % "google-cloud-storage" % "2.2.1" excludeAll(
       ExclusionRule("com.fasterxml.jackson.core"),
       ExclusionRule("com.fasterxml.jackson.module")
     ),

--- a/server/src/main/scala/io/delta/sharing/server/CloudFileSigner.scala
+++ b/server/src/main/scala/io/delta/sharing/server/CloudFileSigner.scala
@@ -197,13 +197,15 @@ object AbfsFileSigner {
 class GCSFileSigner(
     name: URI,
     conf: Configuration,
-    preSignedUrlTimeoutSeconds: Long) extends CloudFileSigner{
+    preSignedUrlTimeoutSeconds: Long) extends CloudFileSigner {
+
+  private val storage = StorageOptions.newBuilder.build.getService
 
   override def sign(path: Path): String = {
     val absPath = path.toUri
     val bucketName = absPath.getHost
     val objectName = absPath.getPath.stripPrefix("/")
-    val storage = StorageOptions.newBuilder.build.getService
+    assert(objectName.nonEmpty, s"cannot get object key from $path")
     val blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, objectName)).build
     storage.signUrl(
       blobInfo, preSignedUrlTimeoutSeconds, SECONDS, Storage.SignUrlOption.withV4Signature())

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -21,6 +21,7 @@ import java.net.URI
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.TimeUnit
 
+import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem
 import com.google.common.cache.CacheBuilder
 import com.google.common.hash.Hashing
 import io.delta.standalone.DeltaLog
@@ -31,7 +32,7 @@ import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem
 import org.apache.hadoop.fs.s3a.S3AFileSystem
 import org.apache.spark.sql.types.{DataType, MetadataBuilder, StructType}
 
-import io.delta.sharing.server.{model, AbfsFileSigner, S3FileSigner, WasbFileSigner}
+import io.delta.sharing.server.{model, AbfsFileSigner, GCSFileSigner, S3FileSigner, WasbFileSigner}
 import io.delta.sharing.server.config.{ServerConfig, TableConfig}
 
 /**
@@ -88,6 +89,8 @@ class DeltaSharedTable(
         WasbFileSigner(wasb, deltaLog.dataPath.toUri, conf, preSignedUrlTimeoutSeconds)
       case abfs: AzureBlobFileSystem =>
         AbfsFileSigner(abfs, deltaLog.dataPath.toUri, preSignedUrlTimeoutSeconds)
+      case gc: GoogleHadoopFileSystem =>
+        new GCSFileSigner(deltaLog.dataPath.toUri, conf, preSignedUrlTimeoutSeconds)
       case _ =>
         throw new IllegalStateException(s"File system ${fs.getClass} is not supported")
     }

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -552,7 +552,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(e.getMessage.contains("Server returned HTTP response code: 403")) // 403 Forbidden
   }
 
-  integrationTest("gcs support") {
+  ignore("gcs support") {
+    assume(shouldRunIntegrationTest)
     val gcsTableName = "table_gcs"
     val response = readNDJson(requestPath(s"/shares/share_gcs/schemas/default/tables/${gcsTableName}/query"), Some("POST"), Some("{}"), Some(0))
     val lines = response.split("\n")

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -551,4 +551,34 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     }
     assert(e.getMessage.contains("Server returned HTTP response code: 403")) // 403 Forbidden
   }
+
+  integrationTest("gcs support") {
+    val gcsTableName = "table_gcs"
+    val response = readNDJson(requestPath(s"/shares/share_gcs/schemas/default/tables/${gcsTableName}/query"), Some("POST"), Some("{}"), Some(0))
+    val lines = response.split("\n")
+    val protocol = lines(0)
+    val metadata = lines(1)
+    val expectedProtocol = Protocol(minReaderVersion = 1).wrap
+    assert(expectedProtocol == JsonUtils.fromJson[SingleAction](protocol))
+    val expectedMetadata = Metadata(
+      id = "de102585-bd69-4bba-bb10-fa92c50a7f85",
+      format = Format(),
+      schemaString = """{"type":"struct","fields":[{"name":"c1","type":"string","nullable":true,"metadata":{}},{"name":"c2","type":"string","nullable":true,"metadata":{}}]}""",
+      partitionColumns = Seq("c2")).wrap
+    assert(expectedMetadata == JsonUtils.fromJson[SingleAction](metadata))
+    val files = lines.drop(2)
+    val actualFiles = files.map(f => JsonUtils.fromJson[SingleAction](f).file)
+    assert(actualFiles.size == 1)
+    val expectedFiles = Seq(
+      AddFile(
+        url = actualFiles(0).url,
+        id = "84f5f9e4de01e99837f77bfc2b7215b0",
+        partitionValues = Map("c2" -> "foo bar"),
+        size = 568,
+        stats = """{"numRecords":1,"minValues":{"c1":"foo bar"},"maxValues":{"c1":"foo bar"},"nullCount":{"c1":0}}"""
+      )
+    )
+    assert(expectedFiles == actualFiles.toList)
+    verifyPreSignedUrl(actualFiles(0).url, 568)
+  }
 }


### PR DESCRIPTION
This is a PR for #20.

I implemented GCS support by using Google Cloud Client Library (https://cloud.google.com/storage/docs/reference/libraries) and Google Cloud Storage connector (https://cloud.google.com/dataproc/docs/concepts/connectors/cloud-storage).
Google Cloud Storage connector (GCS connector) has a dependency problem with Apache Spark releated with Google Guava, so I added this library's shaded jar in server/lib (SBT Unmanaged dependencies, not Managed dependencies in build.sbt).
I implemented this very forcefully, is this no problem?

To use GCP for delta sharing server, you have to do 2 steps.

1. In your terminal, Do `export GOOGLE_APPLICATION_CREDENTIALS=</path/to/your_gcp_service_acount_key.json>`
2. In the server config (e,g, delta-sharing-server.yaml), add a setting for GCP
```
shares:
- name: "share_gcp"
  schemas:
  - name: "schema_gcp"
    tables:
    - name: "table_gcp"
      location: "gs://delta-start/delta/"
```

If you want to coneect this server from Apache Spark,  execute spark-shell or spark-submit like below.

```
spark-shell \
--packages io.delta:delta-core_2.12:1.0.0,io.delta:delta-contribs_2.12:1.0.0,io.delta:delta-sharing-spark_2.12:0.2.0 \
--jars </path/to/gcs-connector-latest-hadoop2.jar> \
--conf spark.delta.logStore.oci.impl=io.delta.storage.GCSLogStore \
--conf spark.hadoop.fs.gs.impl=com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS \
--conf spark.hadoop.google.cloud.auth.service.account.enable=true 
--conf spark.hadoop.google.cloud.auth.service.account.json.keyfile=</path/to/your_gcp_service_acount_key.json>
```

I haven't implement integration test on GCP support yet.
If I understand correctly, what I should do is to add the almost same test with Azure support (https://github.com/delta-io/delta-sharing/blob/main/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala#L510).
Is this correct?
If my understanding is correct, I'll add this integreation test later.