### PR TITLE
Add list_all_tables backward compatibility

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -64,7 +64,7 @@ private[sharing] case class ListAllTablesResponse(
     nextPageToken: Option[String]) extends PaginationResponse
 
 /** A REST client to fetch Delta metadata from remote server. */
-class DeltaSharingRestClient(
+private[spark] class DeltaSharingRestClient(
     profileProvider: DeltaSharingProfileProvider,
     timeoutInSeconds: Int = 120,
     numRetries: Int = 10,
@@ -295,7 +295,7 @@ class DeltaSharingRestClient(
   }
 }
 
-object DeltaSharingRestClient extends Logging {
+private[spark] object DeltaSharingRestClient extends Logging {
   val CURRENT = 1
 
   lazy val USER_AGENT = {


### PR DESCRIPTION
Currently Python list_all_tables API doesn't work with servers using 0.2.0 and below. As per some user feedback, this PR makes it work with old versions by adding a fallback logic.

We don't need to update spark connector. Its DeltaSharingRestClient is private and built mainly for testing the server logic, so no users will be affected.

This PR adds a PR to test the fallback logic. I also manually verified `list_all_tables` using a local server running 0.2.0.