### PR TITLE
Block managed table creation for Delta Sharing

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
@@ -28,29 +28,15 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /** A DataSource V1 for integrating Delta into Spark SQL batch APIs. */
-private[sharing] class DeltaSharingDataSource extends TableProvider with RelationProvider
-  with DataSourceRegister {
-
-  override def inferSchema(options: CaseInsensitiveStringMap): StructType = new StructType()
-
-  override def getTable(
-      schema: StructType,
-      partitioning: Array[Transform],
-      properties: java.util.Map[String, String]): Table = {
-    // Return a Table with no capabilities so we fall back to the v1 path.
-    new Table {
-      override def name(): String = s"V1FallbackTable"
-      override def schema(): StructType = new StructType()
-      override def capabilities(): java.util.Set[TableCapability] = Collections.emptySet()
-    }
-  }
+private[sharing] class DeltaSharingDataSource extends RelationProvider with DataSourceRegister {
 
   override def createRelation(
       sqlContext: SQLContext,
       parameters: Map[String, String]): BaseRelation = {
     DeltaSharingDataSource.setupFileSystem(sqlContext)
-    val path = parameters.getOrElse(
-      "path", throw new IllegalArgumentException("'path' is not specified"))
+    val path = parameters.getOrElse("path", throw new IllegalArgumentException(
+      "'path' is not specified. If you use SQL to create a Delta Sharing table, " +
+        "LOCATION must be specified"))
     val deltaLog = RemoteDeltaLog(path)
     deltaLog.createRelation()
   }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -202,4 +202,11 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
       }
     }
   }
+
+  test("creating a managed table should fail") {
+    val e = intercept[IllegalArgumentException] {
+      sql("CREATE table foo USING deltaSharing")
+    }
+    assert(e.getMessage.contains("LOCATION must be specified"))
+  }
 }


### PR DESCRIPTION
Currently users can run `create table foo using deltaSharing` without location to create a Delta Sharing in Hive Metastore. However, such managed tables are useless because users won't be able to read the table. The default location of managed tables will be pointed to a file system path such as `/user/hive/warehouse/foo`, so the user will see an invalid path error. The path format of Delta Sharing must be `profile_file + "#<share-name>.<schema-name>.<table-name>"`.

This PR updates the code to block managed table creation, and adds a test for this. Also manually tested the following two cases to make sure we don't break external tables:
- Use an old version to create an **external** table and use the jar built by this PR to read it.
- Use the jar built by this PR to create an **external** table and use an old version to read it.