### PR TITLE
Allow passing of profile in Spark options instead of a profile-file (#102)

### DIFF
--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingIntegrationTest.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingIntegrationTest.scala
@@ -40,6 +40,9 @@ trait DeltaSharingIntegrationTest extends SparkFunSuite with BeforeAndAfterAll {
   var testProfileFile: File = _
 
   val TEST_PORT = 12345
+  val ENDPOINT = s"https://localhost:$TEST_PORT/delta-sharing"
+  val BEARER_TOKEN = "dapi5e3574ec767ca1548ae5bbed1a2dc04d"
+  val SHARE_CREDENTIALS_VERSION = 1
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -48,9 +51,9 @@ trait DeltaSharingIntegrationTest extends SparkFunSuite with BeforeAndAfterAll {
       testProfileFile = Files.createTempFile("delta-test", ".share").toFile
       FileUtils.writeStringToFile(testProfileFile,
         s"""{
-          |  "shareCredentialsVersion": 1,
-          |  "endpoint": "https://localhost:$TEST_PORT/delta-sharing",
-          |  "bearerToken": "dapi5e3574ec767ca1548ae5bbed1a2dc04d"
+          |  "shareCredentialsVersion": $SHARE_CREDENTIALS_VERSION,
+          |  "endpoint": "$ENDPOINT",
+          |  "bearerToken": "$BEARER_TOKEN"
           |}""".stripMargin, UTF_8)
 
       val startLatch = new CountDownLatch(1)

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -58,6 +58,24 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
     }
   }
 
+  integrationTest("table1 passing profile with read options") {
+    val tablePath = "share1.default.table1"
+    val expected = Seq(
+      Row(sqlTimestamp("2021-04-27 23:32:02.07"), sqlDate("2021-04-28")),
+      Row(sqlTimestamp("2021-04-27 23:32:22.421"), sqlDate("2021-04-28"))
+    )
+    val readOptions = Map(
+      "endpoint" -> ENDPOINT,
+      "bearerToken" -> BEARER_TOKEN,
+      "shareCredentialsVersion" -> SHARE_CREDENTIALS_VERSION.toString
+    )
+    checkAnswer(spark.read.format("deltaSharing").options(readOptions).load(tablePath), expected)
+    withTable("delta_sharing_test") {
+      sql(s"CREATE TABLE delta_sharing_test USING deltaSharing LOCATION '$tablePath'")
+      checkAnswer(sql(s"SELECT * FROM delta_sharing_test"), expected)
+    }
+  }
+
   integrationTest("table2") {
     val tablePath = testProfileFile.getCanonicalPath + "#share2.default.table2"
     val expected = Seq(

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -30,6 +30,27 @@ import io.delta.sharing.spark.model.Table
 
 class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
 
+  test("parsePathWithoutProfileFile") {
+    assert(RemoteDeltaLog.parsePathWithoutProfileFile("a.b.c") == (
+      "a", "b", "c"
+    ))
+    intercept[IllegalArgumentException] {
+      RemoteDeltaLog.parsePathWithoutProfileFile("abc")
+    }
+    intercept[IllegalArgumentException] {
+      RemoteDeltaLog.parsePathWithoutProfileFile("a.b")
+    }
+    intercept[IllegalArgumentException] {
+      RemoteDeltaLog.parsePathWithoutProfileFile("a.b.c.d")
+    }
+    intercept[IllegalArgumentException] {
+      RemoteDeltaLog.parsePathWithoutProfileFile("a.b.")
+    }
+    intercept[IllegalArgumentException] {
+      RemoteDeltaLog.parsePathWithoutProfileFile("a.b.c.")
+    }
+  }
+
   test("parsePath") {
     assert(RemoteDeltaLog.parsePath("file:///foo/bar#a.b.c") == ("file:///foo/bar", "a", "b", "c"))
     assert(RemoteDeltaLog.parsePath("file:///foo/bar#bar#a.b.c") ==


### PR DESCRIPTION
This PR provides the ability to pass in the secrets stored in the profile-file directly into Spark.

While I've added an integration test, I was unable to run it directly since I do not have access to the test environment. However, using a debugger, I was able to confirm that the parameters from the DeltaSharingDataSource's createRelation method contain the options, and that the method constructs the RemoteDeltaLog object correctly.

Closes #102

Signed-off-by: Jacob Heldenbrand <jacob.heldenbrand@closedloop.ai>