### PR TITLE
Trigger the hack for yarl only if the urls are GCS pre-signed urls

### DIFF
--- a/python/delta_sharing/_yarl_patch.py
+++ b/python/delta_sharing/_yarl_patch.py
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2021 The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+try:
+    from yarl import URL
+    from yarl._quoting import _Quoter
+
+    # Patch yarl.URL to not replace '%3D' with '=' which would break GCS pre-signed urls
+    URL._PATH_REQUOTER = _Quoter(safe="@:", protected="/+=")  # type: ignore
+except:
+    pass

--- a/python/dev/pytest
+++ b/python/dev/pytest
@@ -38,7 +38,9 @@ fi
 
 # Runs both doctests and unit tests by default, otherwise hands arguments over to pytest.
 if [ "$#" = 0 ]; then
-    $PYTHON_EXECUTABLE -m pytest --verbose --showlocals --color=yes --doctest-modules delta_sharing "${logopts[@]}"
+    # delta_sharing/_yarl_patch.py is a hack to support GCS pre-signed urls. Ask pytest to not
+    # import it automatically so that we can verify we are importing it on demand.
+    $PYTHON_EXECUTABLE -m pytest --ignore=delta_sharing/_yarl_patch.py --verbose --showlocals --color=yes --doctest-modules delta_sharing "${logopts[@]}"
 else
     $PYTHON_EXECUTABLE -m pytest "$@"
 fi


### PR DESCRIPTION
This PR moves the hack for yarl into `_yarl_patch.py` and import it only if the urls are GCS pre-signed urls. This will avoid modifying yarl when using S3 or Azure.