### PR TITLE
Remove python 3.6 support and test multiple python versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,9 +32,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python-version: [3.7, 3.8, 3.9]
         include:
-          - python-version: 3.8
-            pandas-version: 1.2.4
+          - pandas-version: 1.2.4
             pyarrow-version: 4.0.0
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/python/setup.py
+++ b/python/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=[
         'delta_sharing',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         'pandas',
         'pyarrow>=4.0.0',
@@ -75,7 +75,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
fsspec doesn't work with Python 3.6. It throws the following error when running in 3.6:

```
loop = <_UnixSelectorEventLoop running=True closed=False debug=False>
func = <bound method HTTPFileSystem.set_session of <fsspec.implementations.http.HTTPFileSystem object at 0x7f95c8e5b390>>
timeout = None, args = (), kwargs = ***

    def sync(loop, func, *args, timeout=None, **kwargs):
        """
        Make loop run coroutine until it returns. Runs in other thread
        """
        timeout = timeout if timeout else None  # convert 0 or 0.0 to None
        # NB: if the loop is not running *yet*, it is OK to submit work
        # and we will wait for it
        if loop is None or loop.is_closed():
            raise RuntimeError("Loop is not running")
        try:
>           loop0 = asyncio.events.get_running_loop()
E           AttributeError: module 'asyncio.events' has no attribute 'get_running_loop'
```

https://github.com/delta-io/delta-sharing/runs/5325698962?check_suite_focus=true

Hence, this PR changes the required Python version to >= 3.7 and also updates GitHub Actions to test Python 3.7, 3.8 and 3.9.