### PR TITLE
Extends Delta Sharing Metadata with field: configuration

### DIFF
--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -70,6 +70,7 @@ def test_list_tables(sharing_client: SharingClient):
         Table(name="table1", share="share1", schema="default"),
         Table(name="table3", share="share1", schema="default"),
         Table(name="table7", share="share1", schema="default"),
+        Table(name="cdf_table_cdf_enabled", share="share1", schema="default"),
     ]
 
     tables = sharing_client.list_tables(Schema(name="default", share="share2"))
@@ -81,6 +82,7 @@ def _verify_all_tables_result(tables: Sequence[Table]):
         Table(name="table1", share="share1", schema="default"),
         Table(name="table3", share="share1", schema="default"),
         Table(name="table7", share="share1", schema="default"),
+        Table(name="cdf_table_cdf_enabled", share="share1", schema="default"),
         Table(name="table2", share="share2", schema="default"),
         Table(name="table4", share="share3", schema="default"),
         Table(name="table5", share="share3", schema="default"),

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -129,6 +129,7 @@ def test_list_tables(rest_client: DataSharingRestClient):
         Table(name="table1", share="share1", schema="default"),
         Table(name="table3", share="share1", schema="default"),
         Table(name="table7", share="share1", schema="default"),
+        Table(name="cdf_table_cdf_enabled", share="share1", schema="default"),
     ]
 
     response = rest_client.list_tables(Schema(name="default", share="share2"))
@@ -147,6 +148,7 @@ def test_list_tables_with_pagination(rest_client: DataSharingRestClient):
     assert response.tables == [
         Table(name="table3", share="share1", schema="default"),
         Table(name="table7", share="share1", schema="default"),
+        Table(name="cdf_table_cdf_enabled", share="share1", schema="default"),
     ]
 
 

--- a/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
+++ b/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
@@ -214,7 +214,8 @@ case class SchemaConfig(
 
 case class TableConfig(
     @BeanProperty var name: String,
-    @BeanProperty var location: String) extends ConfigItem {
+    @BeanProperty var location: String,
+    @BeanProperty var cdfEnabled: Boolean = false) extends ConfigItem {
 
   def this() {
     this(null, null)

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -45,6 +45,7 @@ case class Metadata(
     description: String = null,
     format: Format = Format(),
     schemaString: String = null,
+    configuration: Map[String, String] = Map.empty,
     partitionColumns: Seq[String] = Nil) extends Action {
 
   override def wrap: SingleAction = SingleAction(metaData = this)

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -146,6 +146,7 @@ class DeltaSharedTable(
       description = state.metadata.description,
       format = model.Format(),
       schemaString = cleanUpTableSchema(state.metadata.schemaString),
+      configuration = getMetadataConfiguration,
       partitionColumns = state.metadata.partitionColumns
     )
     val actions = Seq(modelProtocol.wrap, modelMetadata.wrap) ++ {
@@ -181,6 +182,14 @@ class DeltaSharedTable(
 
   def update(): Unit = withClassLoader {
     deltaLog.update()
+  }
+
+  private def getMetadataConfiguration: Map[String, String ] = {
+    if (tableConfig.cdfEnabled) {
+      Map("enableChangeDataFeed" -> "true")
+    } else {
+      Map.empty
+    }
   }
 
   private def cleanUpTableSchema(schemaString: String): String = {

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -224,7 +224,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     val expected = ListTablesResponse(
       Table().withName("table1").withSchema("default").withShare("share1") ::
         Table().withName("table3").withSchema("default").withShare("share1") ::
-        Table().withName("table7").withSchema("default").withShare("share1") :: Nil)
+        Table().withName("table7").withSchema("default").withShare("share1") ::
+        Table().withName("cdf_table_cdf_enabled").withSchema("default").withShare("share1") :: Nil)
     assert(expected == JsonFormat.fromJsonString[ListTablesResponse](response))
   }
 
@@ -239,7 +240,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     val expected =
       Table().withName("table1").withSchema("default").withShare("share1") ::
         Table().withName("table3").withSchema("default").withShare("share1") ::
-        Table().withName("table7").withSchema("default").withShare("share1") :: Nil
+        Table().withName("table7").withSchema("default").withShare("share1") ::
+        Table().withName("cdf_table_cdf_enabled").withSchema("default").withShare("share1") :: Nil
     assert(expected == tables)
   }
 
@@ -504,6 +506,20 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       format = Format(),
       schemaString = """{"type":"struct","fields":[{"name":"eventTime","type":"timestamp","nullable":true,"metadata":{}},{"name":"date","type":"date","nullable":true,"metadata":{}},{"name":"type","type":"string","nullable":true,"metadata":{}}]}""",
       partitionColumns = Seq("date")).wrap
+    assert(expectedMetadata == JsonUtils.fromJson[SingleAction](metadata))
+  }
+
+  integrationTest("cdf_table_cdf_enabled - /shares/{share}/schemas/{schema}/tables/{table}/metadata") {
+    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/metadata"), expectedTableVersion = Some(5))
+    val Array(protocol, metadata) = response.split("\n")
+    val expectedProtocol = Protocol(minReaderVersion = 1).wrap
+    assert(expectedProtocol == JsonUtils.fromJson[SingleAction](protocol))
+    val expectedMetadata = Metadata(
+      id = "16736144-3306-4577-807a-d3f899b77670",
+      format = Format(),
+      schemaString = """{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}},{"name":"age","type":"integer","nullable":true,"metadata":{}},{"name":"birthday","type":"date","nullable":true,"metadata":{}}]}""",
+      configuration = Map("enableChangeDataFeed" -> "true"),
+      partitionColumns = Nil).wrap
     assert(expectedMetadata == JsonUtils.fromJson[SingleAction](metadata))
   }
 

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -69,7 +69,12 @@ object TestResource {
             java.util.Arrays.asList(
               TableConfig("table1", s"s3a://${AWS.bucket}/delta-exchange-test/table1"),
               TableConfig("table3", s"s3a://${AWS.bucket}/delta-exchange-test/table3"),
-              TableConfig("table7", s"s3a://${AWS.bucket}/delta-exchange-test/table7")
+              TableConfig("table7", s"s3a://${AWS.bucket}/delta-exchange-test/table7"),
+              TableConfig(
+                "cdf_table_cdf_enabled",
+                s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_cdf_enabled",
+                true
+              )
             )
           )
         )

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -33,6 +33,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Table(name = "table7", schema = "default", share = "share1"),
         Table(name = "table8", schema = "schema1", share = "share7"),
         Table(name = "table9", schema = "schema2", share = "share7"),
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),
         Table(name = "test_gzip", schema = "default", share = "share4"),
         Table(name = "table_wasb", schema = "default", share = "share_azure"),
         Table(name = "table_abfs", schema = "default", share = "share_azure"),


### PR DESCRIPTION
Extends Delta Sharing Metadata with field: configuration. It's a string to string map, which contains table properties.