### PR TITLE
Add support for converting CDF actions in DeltaSharingReader.

### DIFF
--- a/python/delta_sharing/protocol.py
+++ b/python/delta_sharing/protocol.py
@@ -170,7 +170,7 @@ class FileAction:
     version: Optional[int] = None
 
     def get_change_type_col_value(self) -> str:
-        raise ValueError(f"_change_type not supported for {url}")
+        raise ValueError(f"_change_type not supported for {self.url}")
 
 
 @dataclass(frozen=True)

--- a/python/delta_sharing/protocol.py
+++ b/python/delta_sharing/protocol.py
@@ -161,11 +161,17 @@ class Metadata:
 
 
 @dataclass(frozen=True)
-class AddFile:
+class FileAction:
     url: str
     id: str
     partition_values: Dict[str, str]
     size: int
+    timestamp: Optional[str] = None
+    version: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class AddFile(FileAction):
     stats: Optional[str] = None
 
     @staticmethod
@@ -178,4 +184,46 @@ class AddFile:
             partition_values=json["partitionValues"],
             size=int(json["size"]),
             stats=json.get("stats", None),
+            timestamp=json.get("timestamp", None),
+            version=json.get("version", None),
         )
+
+
+@dataclass(frozen=True)
+class AddCdcFile(FileAction):
+    @staticmethod
+    def from_json(json) -> "AddCdcFile":
+        if isinstance(json, (str, bytes, bytearray)):
+            json = loads(json)
+        return AddCdcFile(
+            url=json["url"],
+            id=json["id"],
+            partition_values=json["partitionValues"],
+            size=int(json["size"]),
+            timestamp=json["timestamp"],
+            version=json["version"],
+        )
+
+
+@dataclass(frozen=True)
+class RemoveFile(FileAction):
+    @staticmethod
+    def from_json(json) -> "RemoveFile":
+        if isinstance(json, (str, bytes, bytearray)):
+            json = loads(json)
+        return RemoveFile(
+            url=json["url"],
+            id=json["id"],
+            partition_values=json["partitionValues"],
+            size=int(json["size"]),
+            timestamp=json.get("timestamp", None),
+            version=json.get("version", None),
+        )
+
+
+@dataclass(frozen=True)
+class CdfOptions:
+    starting_version: Optional[int] = None
+    ending_version: Optional[int] = None
+    starting_timestamp: Optional[str] = None
+    ending_timestamp: Optional[str] = None

--- a/python/delta_sharing/protocol.py
+++ b/python/delta_sharing/protocol.py
@@ -166,8 +166,11 @@ class FileAction:
     id: str
     partition_values: Dict[str, str]
     size: int
-    timestamp: Optional[str] = None
+    timestamp: Optional[int] = None
     version: Optional[int] = None
+
+    def get_change_type_col_value(self) -> str:
+        raise ValueError(f"_change_type not supported for {url}")
 
 
 @dataclass(frozen=True)
@@ -187,6 +190,9 @@ class AddFile(FileAction):
             timestamp=json.get("timestamp", None),
             version=json.get("version", None),
         )
+
+    def get_change_type_col_value(self) -> str:
+        return "insert"
 
 
 @dataclass(frozen=True)
@@ -219,6 +225,9 @@ class RemoveFile(FileAction):
             timestamp=json.get("timestamp", None),
             version=json.get("version", None),
         )
+
+    def get_change_type_col_value(self) -> str:
+        return "delete"
 
 
 @dataclass(frozen=True)

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -71,13 +71,14 @@ class DeltaSharingReader:
 
         if self._limit is None:
             pdfs = [
-                DeltaSharingReader._to_pandas(file, converters, None) for file in response.add_files
+                DeltaSharingReader._to_pandas(
+                    file, converters, False, None) for file in response.add_files
             ]
         else:
             left = self._limit
             pdfs = []
             for file in response.add_files:
-                pdf = DeltaSharingReader._to_pandas(file, converters, left)
+                pdf = DeltaSharingReader._to_pandas(file, converters, False, left)
                 pdfs.append(pdf)
                 left -= len(pdf)
                 assert (
@@ -99,12 +100,12 @@ class DeltaSharingReader:
         schema_json = loads(response.metadata.schema_string)
 
         if len(response.actions) == 0:
-            return get_empty_table(schema_json)
+            return get_empty_table(self._add_special_cdf_schema(schema_json))
 
         converters = to_converters(schema_json)
         pdfs = []
         for action in response.actions:
-            pdf = DeltaSharingReader._to_pandas(action, converters, None)
+            pdf = DeltaSharingReader._to_pandas(action, converters, True, None)
             pdfs.append(pdf)
 
         return pd.concat(pdfs, axis=0, ignore_index=True, copy=False)
@@ -121,7 +122,10 @@ class DeltaSharingReader:
 
     @staticmethod
     def _to_pandas(
-        action: FileAction, converters: Dict[str, Callable[[str], Any]], limit: Optional[int]
+        action: FileAction,
+        converters: Dict[str, Callable[[str], Any]],
+        for_cdc: bool,
+        limit: Optional[int],
     ) -> pd.DataFrame:
         url = urlparse(action.url)
         if "storage.googleapis.com" in (url.netloc.lower()):
@@ -147,19 +151,20 @@ class DeltaSharingReader:
                 else:
                     pdf[col] = None
 
-        # Add the change type col name to non cdc actions.
-        if type(action) != AddCdcFile:
-            pdf[DeltaSharingReader._change_type_col_name()] = action.get_change_type_col_value()
+        if for_cdc:
+            # Add the change type col name to non cdc actions.
+            if type(action) != AddCdcFile:
+                pdf[DeltaSharingReader._change_type_col_name()] = action.get_change_type_col_value()
 
-        # If available, add timestamp and version columns from the action.
-        # All rows of the dataframe will get the same value.
-        if action.timestamp is not None:
-            assert DeltaSharingReader._current_timestamp_col_name() not in pdf.columns
-            pdf[DeltaSharingReader._current_timestamp_col_name()] = action.timestamp
+            # If available, add timestamp and version columns from the action.
+            # All rows of the dataframe will get the same value.
+            if action.timestamp is not None:
+                assert DeltaSharingReader._commit_timestamp_col_name() not in pdf.columns
+                pdf[DeltaSharingReader._commit_timestamp_col_name()] = action.timestamp
 
-        if action.version is not None:
-            assert DeltaSharingReader._current_version_col_name() not in pdf.columns
-            pdf[DeltaSharingReader._current_version_col_name()] = action.version
+            if action.version is not None:
+                assert DeltaSharingReader._commit_version_col_name() not in pdf.columns
+                pdf[DeltaSharingReader._commit_version_col_name()] = action.version
 
         return pdf
 
@@ -170,9 +175,17 @@ class DeltaSharingReader:
         return "_change_type"
 
     @staticmethod
-    def _current_timestamp_col_name():
-        return "_current_timestamp"
+    def _commit_timestamp_col_name():
+        return "_commit_timestamp"
 
     @staticmethod
-    def _current_version_col_name():
-        return "_current_version"
+    def _commit_version_col_name():
+        return "_commit_version"
+
+    @staticmethod
+    def _add_special_cdf_schema(schema_json: dict) -> dict:
+        fields = schema_json["fields"]
+        fields.append({"name" : DeltaSharingReader._change_type_col_name(), "type" : "string"})
+        fields.append({"name" : DeltaSharingReader._commit_version_col_name(), "type" : "long"})
+        fields.append({"name" : DeltaSharingReader._commit_timestamp_col_name(), "type" : "long"})
+        return schema_json

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -22,7 +22,7 @@ import pandas as pd
 from pyarrow.dataset import dataset
 
 from delta_sharing.converter import to_converters, get_empty_table
-from delta_sharing.protocol import AddFile, Table, CdfOptions, FileAction
+from delta_sharing.protocol import CdfOptions, FileAction, Table
 from delta_sharing.rest_client import DataSharingRestClient
 
 

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -124,7 +124,7 @@ class DeltaSharingReader:
     def _to_pandas(
         action: FileAction,
         converters: Dict[str, Callable[[str], Any]],
-        for_cdc: bool,
+        for_cdf: bool,
         limit: Optional[int],
     ) -> pd.DataFrame:
         url = urlparse(action.url)
@@ -151,7 +151,7 @@ class DeltaSharingReader:
                 else:
                     pdf[col] = None
 
-        if for_cdc:
+        if for_cdf:
             # Add the change type col name to non cdc actions.
             if type(action) != AddCdcFile:
                 pdf[DeltaSharingReader._change_type_col_name()] = action.get_change_type_col_value()

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -29,6 +29,8 @@ from requests.exceptions import HTTPError, ConnectionError
 
 from delta_sharing.protocol import (
     AddFile,
+    FileAction,
+    CdfOptions,
     DeltaSharingProfile,
     Metadata,
     Protocol,
@@ -78,6 +80,13 @@ class ListFilesInTableResponse:
     protocol: Protocol
     metadata: Metadata
     add_files: Sequence[AddFile]
+
+
+@dataclass(frozen=True)
+class ListTableChangesResponse:
+    protocol: Protocol
+    metadata: Metadata
+    actions: Sequence[FileAction]
 
 
 def retry_with_exponential_backoff(func):
@@ -263,6 +272,9 @@ class DataSharingRestClient:
                 metadata=Metadata.from_json(metadata_json["metaData"]),
                 add_files=[AddFile.from_json(json.loads(file)["file"]) for file in lines],
             )
+
+    def list_table_changes(self, table: Table, cdfOptions: CdfOptions) -> ListTableChangesResponse:
+        raise HTTPError("API not implemented yet!")
 
     def close(self):
         self._session.close()

--- a/python/delta_sharing/tests/test_converter.py
+++ b/python/delta_sharing/tests/test_converter.py
@@ -15,13 +15,14 @@
 #
 from datetime import date
 from decimal import Decimal
+from json import loads
 from typing import Any
 
 import numpy as np
 import pandas as pd
 import pytest
 
-from delta_sharing.converter import to_converter
+from delta_sharing.converter import to_converter, get_empty_table
 
 
 def test_to_converter_boolean():
@@ -70,3 +71,18 @@ def test_to_converter_timestamp():
     converter = to_converter("timestamp")
     assert converter("2021-04-28 23:36:47.599") == pd.Timestamp("2021-04-28 23:36:47.599")
     assert converter("") is pd.NaT
+
+
+def test_get_empty_table():
+    schema_string = (
+        '{"fields": ['
+        '{"metadata": {},"name": "a","nullable": true,"type": "long"},'
+        '{"metadata": {},"name": "b","nullable": true,"type": "string"}'
+        '],"type":"struct"}'
+    )
+    schema_json = loads(schema_string)
+    pdf = get_empty_table(schema_json)
+    assert pdf.empty
+    assert pdf.columns.values.size == 2
+    assert pdf.columns.values[0] == "a"
+    assert pdf.columns.values[1] == "b"

--- a/python/delta_sharing/tests/test_protocol.py
+++ b/python/delta_sharing/tests/test_protocol.py
@@ -242,7 +242,7 @@ def test_metadata():
                 "partitionValues" : {"b": "x"},
                 "size" : 120,
                 "stats" : "{\\"numRecords\\":2}",
-                "timestamp" : "2022-04-27T15:32:21.000-0800",
+                "timestamp" : 1652110000000,
                 "version" : 2
             }
             """,
@@ -252,7 +252,7 @@ def test_metadata():
                 partition_values={"b": "x"},
                 size=120,
                 stats=r'{"numRecords":2}',
-                timestamp="2022-04-27T15:32:21.000-0800",
+                timestamp=1652110000000,
                 version=2,
             ),
             id="timestamp and version",
@@ -273,7 +273,7 @@ def test_add_file(json: str, expected: AddFile):
                 "id" : "id",
                 "partitionValues" : {"b": "x"},
                 "size" : 120,
-                "timestamp" : "2022-04-27T15:32:21.000-0800",
+                "timestamp" : 1652110000000,
                 "version" : 2
             }
             """,
@@ -282,7 +282,7 @@ def test_add_file(json: str, expected: AddFile):
                 id="id",
                 partition_values={"b": "x"},
                 size=120,
-                timestamp="2022-04-27T15:32:21.000-0800",
+                timestamp=1652110000000,
                 version=2,
             ),
             id="partitioned",
@@ -294,7 +294,7 @@ def test_add_file(json: str, expected: AddFile):
                 "id" : "id",
                 "partitionValues" : {},
                 "size" : 120,
-                "timestamp" : "2022-04-27T15:32:21.000-0800",
+                "timestamp" : 1652110000000,
                 "version" : 2
             }
             """,
@@ -303,7 +303,7 @@ def test_add_file(json: str, expected: AddFile):
                 id="id",
                 partition_values={},
                 size=120,
-                timestamp="2022-04-27T15:32:21.000-0800",
+                timestamp=1652110000000,
                 version=2,
             ),
             id="no partitions",
@@ -324,7 +324,7 @@ def test_add_cdc_file(json: str, expected: AddCdcFile):
                 "id" : "id",
                 "partitionValues" : {"b": "x"},
                 "size" : 120,
-                "timestamp" : "2022-04-27T15:32:21.000-0800",
+                "timestamp" : 1652110000000,
                 "version" : 2
             }
             """,
@@ -333,7 +333,7 @@ def test_add_cdc_file(json: str, expected: AddCdcFile):
                 id="id",
                 partition_values={"b": "x"},
                 size=120,
-                timestamp="2022-04-27T15:32:21.000-0800",
+                timestamp=1652110000000,
                 version=2,
             ),
             id="partitioned",
@@ -345,7 +345,7 @@ def test_add_cdc_file(json: str, expected: AddCdcFile):
                 "id" : "id",
                 "partitionValues" : {},
                 "size" : 120,
-                "timestamp" : "2022-04-27T15:32:21.000-0800",
+                "timestamp" : 1652110000000,
                 "version" : 2
             }
             """,
@@ -354,7 +354,7 @@ def test_add_cdc_file(json: str, expected: AddCdcFile):
                 id="id",
                 partition_values={},
                 size=120,
-                timestamp="2022-04-27T15:32:21.000-0800",
+                timestamp=1652110000000,
                 version=2,
             ),
             id="no partitions",

--- a/python/delta_sharing/tests/test_protocol.py
+++ b/python/delta_sharing/tests/test_protocol.py
@@ -18,11 +18,13 @@ import io
 import pytest
 
 from delta_sharing.protocol import (
+    AddCdcFile,
     AddFile,
     DeltaSharingProfile,
     Format,
     Metadata,
     Protocol,
+    RemoveFile,
     Schema,
     Share,
     Table,
@@ -232,7 +234,132 @@ def test_metadata():
             ),
             id="no stats",
         ),
+        pytest.param(
+            """
+            {
+                "url" : "https://localhost/path/to/file.parquet",
+                "id" : "id",
+                "partitionValues" : {"b": "x"},
+                "size" : 120,
+                "stats" : "{\\"numRecords\\":2}",
+                "timestamp" : "2022-04-27T15:32:21.000-0800",
+                "version" : 2
+            }
+            """,
+            AddFile(
+                url="https://localhost/path/to/file.parquet",
+                id="id",
+                partition_values={"b": "x"},
+                size=120,
+                stats=r'{"numRecords":2}',
+                timestamp="2022-04-27T15:32:21.000-0800",
+                version=2,
+            ),
+            id="timestamp and version",
+        ),
     ],
 )
 def test_add_file(json: str, expected: AddFile):
     assert AddFile.from_json(json) == expected
+
+
+@pytest.mark.parametrize(
+    "json,expected",
+    [
+        pytest.param(
+            """
+            {
+                "url" : "https://localhost/path/to/file.parquet",
+                "id" : "id",
+                "partitionValues" : {"b": "x"},
+                "size" : 120,
+                "timestamp" : "2022-04-27T15:32:21.000-0800",
+                "version" : 2
+            }
+            """,
+            AddCdcFile(
+                url="https://localhost/path/to/file.parquet",
+                id="id",
+                partition_values={"b": "x"},
+                size=120,
+                timestamp="2022-04-27T15:32:21.000-0800",
+                version=2,
+            ),
+            id="partitioned",
+        ),
+        pytest.param(
+            """
+            {
+                "url" : "https://localhost/path/to/file.parquet",
+                "id" : "id",
+                "partitionValues" : {},
+                "size" : 120,
+                "timestamp" : "2022-04-27T15:32:21.000-0800",
+                "version" : 2
+            }
+            """,
+            AddCdcFile(
+                url="https://localhost/path/to/file.parquet",
+                id="id",
+                partition_values={},
+                size=120,
+                timestamp="2022-04-27T15:32:21.000-0800",
+                version=2,
+            ),
+            id="no partitions",
+        ),
+    ],
+)
+def test_add_cdc_file(json: str, expected: AddCdcFile):
+    assert AddCdcFile.from_json(json) == expected
+
+
+@pytest.mark.parametrize(
+    "json,expected",
+    [
+        pytest.param(
+            """
+            {
+                "url" : "https://localhost/path/to/file.parquet",
+                "id" : "id",
+                "partitionValues" : {"b": "x"},
+                "size" : 120,
+                "timestamp" : "2022-04-27T15:32:21.000-0800",
+                "version" : 2
+            }
+            """,
+            RemoveFile(
+                url="https://localhost/path/to/file.parquet",
+                id="id",
+                partition_values={"b": "x"},
+                size=120,
+                timestamp="2022-04-27T15:32:21.000-0800",
+                version=2,
+            ),
+            id="partitioned",
+        ),
+        pytest.param(
+            """
+            {
+                "url" : "https://localhost/path/to/file.parquet",
+                "id" : "id",
+                "partitionValues" : {},
+                "size" : 120,
+                "timestamp" : "2022-04-27T15:32:21.000-0800",
+                "version" : 2
+            }
+            """,
+            RemoveFile(
+                url="https://localhost/path/to/file.parquet",
+                id="id",
+                partition_values={},
+                size=120,
+                timestamp="2022-04-27T15:32:21.000-0800",
+                version=2,
+            ),
+            id="no partitions",
+        ),
+    ],
+)
+def test_remove_file(json: str, expected: RemoveFile):
+    assert RemoveFile.from_json(json) == expected

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -251,10 +251,8 @@ def test_table_changes_to_pandas_non_partitioned(tmp_path):
     pdf4 = pd.DataFrame({"a": [7, 8, 9], "b": ["x", "y", "z"]})
 
     # Add change type (which is present in the parquet files).
-    pdf1["_change_type"] = "Insert"
-    pdf2["_change_type"] = "Delete"
-    pdf3["_change_type"] = "update_preimage"
-    pdf4["_change_type"] = "update_postimage"
+    pdf3[DeltaSharingReader._change_type_col_name()] = "update_preimage"
+    pdf4[DeltaSharingReader._change_type_col_name()] = "update_postimage"
 
     # Save.
     pdf1.to_parquet(tmp_path / "pdf1.parquet")
@@ -263,15 +261,19 @@ def test_table_changes_to_pandas_non_partitioned(tmp_path):
     pdf4.to_parquet(tmp_path / "pdf4.parquet")
 
     # Version and timestamp are not in the parquet files; but are expected by the conversion.
-    timestamp1 = "2022-04-27T15:32:21.000-0800"
-    timestamp2 = "2022-04-28T15:32:21.000-0800"
-    timestamp3 = "2022-04-29T15:32:21.000-0800"
-    timestamp4 = "2022-04-29T15:32:21.000-0800"
+    timestamp1 = 1652110000000
+    timestamp2 = 1652120000000
+    timestamp3 = 1652130000000
+    timestamp4 = 1652140000000
 
     version1 = 1
     version2 = 2
     version3 = 3
     version4 = 4
+
+    # The change type is also expected for add/remove actions.
+    pdf1[DeltaSharingReader._change_type_col_name()] = "insert"
+    pdf2[DeltaSharingReader._change_type_col_name()] = "delete"
 
     pdf1[DeltaSharingReader._current_timestamp_col_name()] = timestamp1
     pdf2[DeltaSharingReader._current_timestamp_col_name()] = timestamp2
@@ -345,14 +347,14 @@ def test_table_changes_to_pandas_partitioned(tmp_path):
     pdf1 = pd.DataFrame({"a": [1, 2, 3]})
     pdf2 = pd.DataFrame({"a": [4, 5, 6]})
 
-    pdf1["_change_type"] = "update_preimage"
-    pdf2["_change_type"] = "update_postimage"
+    pdf1[DeltaSharingReader._change_type_col_name()] = "update_preimage"
+    pdf2[DeltaSharingReader._change_type_col_name()] = "update_postimage"
 
     pdf1.to_parquet(tmp_path / "pdf1.parquet")
     pdf2.to_parquet(tmp_path / "pdf2.parquet")
 
     # Version, timestamp, and partition are not in the parquet files; but will be populated.
-    timestamp = "2022-04-27T15:32:21.000-0800"
+    timestamp = 1652140000000
     version = 10
     pdf1["b"] = "x"
     pdf2["b"] = "x"

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -15,7 +15,6 @@
 #
 import pytest
 
-from dataclasses import dataclass
 from datetime import date
 from typing import Optional, Sequence
 

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -275,15 +275,15 @@ def test_table_changes_to_pandas_non_partitioned(tmp_path):
     pdf1[DeltaSharingReader._change_type_col_name()] = "insert"
     pdf2[DeltaSharingReader._change_type_col_name()] = "delete"
 
-    pdf1[DeltaSharingReader._current_timestamp_col_name()] = timestamp1
-    pdf2[DeltaSharingReader._current_timestamp_col_name()] = timestamp2
-    pdf3[DeltaSharingReader._current_timestamp_col_name()] = timestamp3
-    pdf4[DeltaSharingReader._current_timestamp_col_name()] = timestamp4
+    pdf1[DeltaSharingReader._commit_timestamp_col_name()] = timestamp1
+    pdf2[DeltaSharingReader._commit_timestamp_col_name()] = timestamp2
+    pdf3[DeltaSharingReader._commit_timestamp_col_name()] = timestamp3
+    pdf4[DeltaSharingReader._commit_timestamp_col_name()] = timestamp4
 
-    pdf1[DeltaSharingReader._current_version_col_name()] = version1
-    pdf2[DeltaSharingReader._current_version_col_name()] = version2
-    pdf3[DeltaSharingReader._current_version_col_name()] = version3
-    pdf4[DeltaSharingReader._current_version_col_name()] = version4
+    pdf1[DeltaSharingReader._commit_version_col_name()] = version1
+    pdf2[DeltaSharingReader._commit_version_col_name()] = version2
+    pdf3[DeltaSharingReader._commit_version_col_name()] = version3
+    pdf4[DeltaSharingReader._commit_version_col_name()] = version4
 
     class RestClientMock:
         def list_table_changes(
@@ -358,10 +358,10 @@ def test_table_changes_to_pandas_partitioned(tmp_path):
     version = 10
     pdf1["b"] = "x"
     pdf2["b"] = "x"
-    pdf1[DeltaSharingReader._current_timestamp_col_name()] = timestamp
-    pdf2[DeltaSharingReader._current_timestamp_col_name()] = timestamp
-    pdf1[DeltaSharingReader._current_version_col_name()] = version
-    pdf2[DeltaSharingReader._current_version_col_name()] = version
+    pdf1[DeltaSharingReader._commit_timestamp_col_name()] = timestamp
+    pdf2[DeltaSharingReader._commit_timestamp_col_name()] = timestamp
+    pdf1[DeltaSharingReader._commit_version_col_name()] = version
+    pdf2[DeltaSharingReader._commit_version_col_name()] = version
 
     class RestClientMock:
         def list_table_changes(
@@ -404,3 +404,31 @@ def test_table_changes_to_pandas_partitioned(tmp_path):
 
     expected = pd.concat([pdf1, pdf2]).reset_index(drop=True)
     pd.testing.assert_frame_equal(pdf, expected)
+
+
+def test_table_changes_empty(tmp_path):
+    class RestClientMock:
+        def list_table_changes(
+            self, table: Table, cdfOptions: CdfOptions
+        ) -> ListTableChangesResponse:
+            assert table == Table("table_name", "share_name", "schema_name")
+
+            metadata = Metadata(
+                schema_string=(
+                    '{"fields":['
+                    '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
+                    '{"metadata":{},"name":"b","nullable":true,"type":"string"}'
+                    '],"type":"struct"}'
+                )
+            )
+            return ListTableChangesResponse(protocol=None, metadata=metadata, actions=[])
+
+    reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
+    pdf = reader.table_changes_to_pandas(CdfOptions())
+    assert pdf.empty
+    assert pdf.columns.values.size == 5
+    assert pdf.columns.values[0] == "a"
+    assert pdf.columns.values[1] == "b"
+    assert pdf.columns.values[2] == DeltaSharingReader._change_type_col_name()
+    assert pdf.columns.values[3] == DeltaSharingReader._commit_version_col_name()
+    assert pdf.columns.values[4] == DeltaSharingReader._commit_timestamp_col_name()

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -15,14 +15,19 @@
 #
 import pytest
 
+from dataclasses import dataclass
 from datetime import date
 from typing import Optional, Sequence
 
 import pandas as pd
 
-from delta_sharing.protocol import AddFile, Metadata, Table
+from delta_sharing.protocol import AddFile, AddCdcFile, CdfOptions, Metadata, RemoveFile, Table
 from delta_sharing.reader import DeltaSharingReader
-from delta_sharing.rest_client import ListFilesInTableResponse, DataSharingRestClient
+from delta_sharing.rest_client import (
+    ListFilesInTableResponse,
+    ListTableChangesResponse,
+    DataSharingRestClient,
+)
 from delta_sharing.tests.conftest import ENABLE_INTEGRATION, SKIP_MESSAGE
 
 
@@ -236,4 +241,165 @@ def test_to_pandas_empty(rest_client: DataSharingRestClient):
     reader = DeltaSharingReader(Table(name="table7", share="share1", schema="default"), rest_client)
     expected = reader.to_pandas().iloc[0:0]
 
+    pd.testing.assert_frame_equal(pdf, expected)
+
+
+def test_table_changes_to_pandas_non_partitioned(tmp_path):
+    # Create basic data frame.
+    pdf1 = pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
+    pdf2 = pd.DataFrame({"a": [4, 5, 6], "b": ["d", "e", "f"]})
+    pdf3 = pd.DataFrame({"a": [7, 8, 9], "b": ["x", "y", "z"]})
+    pdf4 = pd.DataFrame({"a": [7, 8, 9], "b": ["x", "y", "z"]})
+
+    # Add change type (which is present in the parquet files).
+    pdf1["_change_type"] = "Insert"
+    pdf2["_change_type"] = "Delete"
+    pdf3["_change_type"] = "update_preimage"
+    pdf4["_change_type"] = "update_postimage"
+
+    # Save.
+    pdf1.to_parquet(tmp_path / "pdf1.parquet")
+    pdf2.to_parquet(tmp_path / "pdf2.parquet")
+    pdf3.to_parquet(tmp_path / "pdf3.parquet")
+    pdf4.to_parquet(tmp_path / "pdf4.parquet")
+
+    # Version and timestamp are not in the parquet files; but are expected by the conversion.
+    timestamp1 = "2022-04-27T15:32:21.000-0800"
+    timestamp2 = "2022-04-28T15:32:21.000-0800"
+    timestamp3 = "2022-04-29T15:32:21.000-0800"
+    timestamp4 = "2022-04-29T15:32:21.000-0800"
+
+    version1 = 1
+    version2 = 2
+    version3 = 3
+    version4 = 4
+
+    pdf1[DeltaSharingReader._current_timestamp_col_name()] = timestamp1
+    pdf2[DeltaSharingReader._current_timestamp_col_name()] = timestamp2
+    pdf3[DeltaSharingReader._current_timestamp_col_name()] = timestamp3
+    pdf4[DeltaSharingReader._current_timestamp_col_name()] = timestamp4
+
+    pdf1[DeltaSharingReader._current_version_col_name()] = version1
+    pdf2[DeltaSharingReader._current_version_col_name()] = version2
+    pdf3[DeltaSharingReader._current_version_col_name()] = version3
+    pdf4[DeltaSharingReader._current_version_col_name()] = version4
+
+    class RestClientMock:
+        def list_table_changes(
+            self, table: Table, cdfOptions: CdfOptions
+        ) -> ListTableChangesResponse:
+            assert table == Table("table_name", "share_name", "schema_name")
+
+            metadata = Metadata(
+                schema_string=(
+                    '{"fields":['
+                    '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
+                    '{"metadata":{},"name":"b","nullable":true,"type":"string"}'
+                    '],"type":"struct"}'
+                )
+            )
+            actions = [
+                AddFile(
+                    url=str(tmp_path / "pdf1.parquet"),
+                    id="pdf1",
+                    partition_values={},
+                    size=0,
+                    stats="",
+                    timestamp=timestamp1,
+                    version=version1,
+                ),
+                RemoveFile(
+                    url=str(tmp_path / "pdf2.parquet"),
+                    id="pdf2",
+                    partition_values={},
+                    size=0,
+                    timestamp=timestamp2,
+                    version=version2,
+                ),
+                AddCdcFile(
+                    url=str(tmp_path / "pdf3.parquet"),
+                    id="pdf3",
+                    partition_values={},
+                    size=0,
+                    timestamp=timestamp3,
+                    version=version3,
+                ),
+                AddCdcFile(
+                    url=str(tmp_path / "pdf4.parquet"),
+                    id="pdf4",
+                    partition_values={},
+                    size=0,
+                    timestamp=timestamp4,
+                    version=version4,
+                ),
+            ]
+            return ListTableChangesResponse(protocol=None, metadata=metadata, actions=actions)
+
+    reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
+    pdf = reader.table_changes_to_pandas(CdfOptions())
+
+    expected = pd.concat([pdf1, pdf2, pdf3, pdf4]).reset_index(drop=True)
+    pd.testing.assert_frame_equal(pdf, expected)
+
+
+def test_table_changes_to_pandas_partitioned(tmp_path):
+    pdf1 = pd.DataFrame({"a": [1, 2, 3]})
+    pdf2 = pd.DataFrame({"a": [4, 5, 6]})
+
+    pdf1["_change_type"] = "update_preimage"
+    pdf2["_change_type"] = "update_postimage"
+
+    pdf1.to_parquet(tmp_path / "pdf1.parquet")
+    pdf2.to_parquet(tmp_path / "pdf2.parquet")
+
+    # Version, timestamp, and partition are not in the parquet files; but will be populated.
+    timestamp = "2022-04-27T15:32:21.000-0800"
+    version = 10
+    pdf1["b"] = "x"
+    pdf2["b"] = "x"
+    pdf1[DeltaSharingReader._current_timestamp_col_name()] = timestamp
+    pdf2[DeltaSharingReader._current_timestamp_col_name()] = timestamp
+    pdf1[DeltaSharingReader._current_version_col_name()] = version
+    pdf2[DeltaSharingReader._current_version_col_name()] = version
+
+    class RestClientMock:
+        def list_table_changes(
+            self,
+            table: Table,
+            cdfOptions: CdfOptions,
+        ) -> ListTableChangesResponse:
+            assert table == Table("table_name", "share_name", "schema_name")
+
+            metadata = Metadata(
+                schema_string=(
+                    '{"fields":['
+                    '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
+                    '{"metadata":{},"name":"b","nullable":true,"type":"string"}'
+                    '],"type":"struct"}'
+                )
+            )
+            actions = [
+                AddCdcFile(
+                    url=str(tmp_path / "pdf1.parquet"),
+                    id="pdf1",
+                    partition_values={"b": "x"},
+                    size=0,
+                    timestamp=timestamp,
+                    version=version,
+                ),
+                AddCdcFile(
+                    url=str(tmp_path / "pdf2.parquet"),
+                    id="pdf2",
+                    partition_values={"b": "x"},
+                    size=0,
+                    timestamp=timestamp,
+                    version=version,
+                ),
+            ]
+            return ListTableChangesResponse(protocol=None, metadata=metadata, actions=actions)
+
+    reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
+    pdf = reader.table_changes_to_pandas(CdfOptions())
+
+    expected = pd.concat([pdf1, pdf2]).reset_index(drop=True)
     pd.testing.assert_frame_equal(pdf, expected)

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -20,6 +20,7 @@ from requests.exceptions import HTTPError, ConnectionError
 
 from delta_sharing.protocol import (
     AddFile,
+    CdfOptions,
     Format,
     Metadata,
     Protocol,
@@ -378,3 +379,13 @@ def test_list_files_in_table_partitioned_different_schemas(
             ),
         ),
     ]
+
+
+def test_list_table_changes(
+    rest_client: DataSharingRestClient,
+):
+    try:
+        rest_client.list_table_changes(Table(name="x", share="y", schema="z"), CdfOptions())
+        assert False
+    except Exception as e:
+        assert isinstance(e, HTTPError)


### PR DESCRIPTION
This PR has the following changes:

1) Adds CDF actions (AddCdcFile, RemoveFile)
2) Convert CDF actions into pandas.
3) Unit tests.

It still does not have the rest client support for the query table changes RPC.