### PR TITLE
Support load_table_changes_as_pandas in python connector

### DIFF
--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -19,6 +19,8 @@ from pathlib import Path
 
 import pandas as pd
 
+from delta_sharing.protocol import CdfOptions
+
 try:
     from pyspark.sql import DataFrame as PySparkDataFrame
 except ImportError:
@@ -88,6 +90,35 @@ def load_as_spark(url: str) -> "PySparkDataFrame":  # noqa: F821
         "`load_as_spark` requires running in a PySpark application."
     )
     return spark.read.format("deltaSharing").load(url)
+
+
+def load_table_changes_as_pandas(
+    url: str,
+    starting_version: Optional[int] = None,
+    ending_version: Optional[int] = None,
+    starting_timestamp: Optional[str] = None,
+    ending_timestamp: Optional[str] = None
+) -> pd.DataFrame:
+    """
+    Load the shared table using the give url as a pandas DataFrame.
+
+    :param url: a url under the format "<profile>#<share>.<schema>.<table>"
+    :param limit: a non-negative int. Load only the ``limit`` rows if the parameter is specified.
+      Use this optional parameter to explore the shared table without loading the entire table to
+      the memory.
+    :return: A pandas DataFrame representing the shared table.
+    """
+    profile_json, share, schema, table = _parse_url(url)
+    profile = DeltaSharingProfile.read_from_file(profile_json)
+    return DeltaSharingReader(
+        table=Table(name=table, share=share, schema=schema),
+        rest_client=DataSharingRestClient(profile),
+    ).table_changes_to_pandas(CdfOptions(
+        starting_version=starting_version,
+        ending_version=ending_version,
+        starting_timestamp=starting_timestamp,
+        ending_timestamp=ending_timestamp,
+    ))
 
 
 class SharingClient:

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -158,14 +158,13 @@ class DeltaSharingReader:
 
             # If available, add timestamp and version columns from the action.
             # All rows of the dataframe will get the same value.
-            if action.timestamp is not None:
-                assert DeltaSharingReader._commit_timestamp_col_name() not in pdf.columns
-                pdf[DeltaSharingReader._commit_timestamp_col_name()] = action.timestamp
-
             if action.version is not None:
                 assert DeltaSharingReader._commit_version_col_name() not in pdf.columns
                 pdf[DeltaSharingReader._commit_version_col_name()] = action.version
 
+            if action.timestamp is not None:
+                assert DeltaSharingReader._commit_timestamp_col_name() not in pdf.columns
+                pdf[DeltaSharingReader._commit_timestamp_col_name()] = action.timestamp
         return pdf
 
     # The names of special delta columns for cdf.

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -275,15 +275,15 @@ def test_table_changes_to_pandas_non_partitioned(tmp_path):
     pdf1[DeltaSharingReader._change_type_col_name()] = "insert"
     pdf2[DeltaSharingReader._change_type_col_name()] = "delete"
 
-    pdf1[DeltaSharingReader._commit_timestamp_col_name()] = timestamp1
-    pdf2[DeltaSharingReader._commit_timestamp_col_name()] = timestamp2
-    pdf3[DeltaSharingReader._commit_timestamp_col_name()] = timestamp3
-    pdf4[DeltaSharingReader._commit_timestamp_col_name()] = timestamp4
-
     pdf1[DeltaSharingReader._commit_version_col_name()] = version1
     pdf2[DeltaSharingReader._commit_version_col_name()] = version2
     pdf3[DeltaSharingReader._commit_version_col_name()] = version3
     pdf4[DeltaSharingReader._commit_version_col_name()] = version4
+
+    pdf1[DeltaSharingReader._commit_timestamp_col_name()] = timestamp1
+    pdf2[DeltaSharingReader._commit_timestamp_col_name()] = timestamp2
+    pdf3[DeltaSharingReader._commit_timestamp_col_name()] = timestamp3
+    pdf4[DeltaSharingReader._commit_timestamp_col_name()] = timestamp4
 
     class RestClientMock:
         def list_table_changes(
@@ -358,10 +358,10 @@ def test_table_changes_to_pandas_partitioned(tmp_path):
     version = 10
     pdf1["b"] = "x"
     pdf2["b"] = "x"
-    pdf1[DeltaSharingReader._commit_timestamp_col_name()] = timestamp
-    pdf2[DeltaSharingReader._commit_timestamp_col_name()] = timestamp
     pdf1[DeltaSharingReader._commit_version_col_name()] = version
     pdf2[DeltaSharingReader._commit_version_col_name()] = version
+    pdf1[DeltaSharingReader._commit_timestamp_col_name()] = timestamp
+    pdf2[DeltaSharingReader._commit_timestamp_col_name()] = timestamp
 
     class RestClientMock:
         def list_table_changes(

--- a/python/dev/pytest
+++ b/python/dev/pytest
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-PYTHON_EXECUTABLE="${PYTHON_EXECUTABLE:-python}"
+PYTHON_EXECUTABLE="${PYTHON_EXECUTABLE:-python3}"
 
 set -o pipefail
 set -e


### PR DESCRIPTION
Support load_table_changes_as_pandas in python connector.
Also updated the order, to ensure `_commit_version` is always before `_commit_timestamp`