### PR TITLE
Respect TableConfig.startVersion in OSS delta sharing server

### DIFF
--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -460,7 +460,7 @@ def test_list_files_in_table_version_exception(
         )
     except Exception as e:
         assert isinstance(e, HTTPError)
-        assert "reading table by version is not supported because change data" in (str(e))
+        assert "Reading table by version is not supported because change data" in (str(e))
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -471,7 +471,7 @@ def test_list_table_changes(
     cdf_table = Table(name="cdf_table_with_partition", share="share1", schema="default")
     response = rest_client.list_table_changes(
         cdf_table,
-        CdfOptions(starting_version=0, ending_version=3)
+        CdfOptions(starting_version=1, ending_version=3)
     )
 
     assert response.protocol == Protocol(min_reader_version=1)

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -251,7 +251,7 @@ class DeltaSharingService(serverConfig: ServerConfig) {
     val tableConfig = sharedTableManager.getTable(share, schema, table)
     if (queryTableRequest.version.isDefined) {
       if (!tableConfig.cdfEnabled) {
-        throw new DeltaSharingIllegalArgumentException("reading table by version is not supported" +
+        throw new DeltaSharingIllegalArgumentException("Reading table by version is not supported" +
           s" because change data feed is not enabled on table: $share.$schema.$table")
       }
       if (tableConfig.startVersion > queryTableRequest.version.get) {

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -249,9 +249,16 @@ class DeltaSharingService(serverConfig: ServerConfig) {
 
     val start = System.currentTimeMillis
     val tableConfig = sharedTableManager.getTable(share, schema, table)
-    if (queryTableRequest.version.isDefined && !tableConfig.cdfEnabled) {
-      throw new DeltaSharingIllegalArgumentException("reading table by version is not supported" +
-        s" because change data feed is not enabled on table: $share.$schema.$table")
+    if (queryTableRequest.version.isDefined) {
+      if (!tableConfig.cdfEnabled) {
+        throw new DeltaSharingIllegalArgumentException("reading table by version is not supported" +
+          s" because change data feed is not enabled on table: $share.$schema.$table")
+      }
+      if (tableConfig.startVersion > queryTableRequest.version.get) {
+        throw new DeltaSharingIllegalArgumentException(
+          s"You can only query table data since version ${tableConfig.startVersion}."
+        )
+      }
     }
     val (version, actions) = deltaSharedTableLoader.loadTable(tableConfig).query(
       includeFiles = true,
@@ -432,20 +439,10 @@ object DeltaSharingService {
     endingTimestamp: Option[String]): Map[String, String] = {
     checkCDFOptionsValidity(startingVersion, endingVersion, startingTimestamp, endingTimestamp)
 
-    val startingVersionOption = if (startingVersion.isDefined) {
-      Map(DeltaDataSource.CDF_START_VERSION_KEY -> startingVersion.get)
-     } else { Map.empty }
-    val startingTimestampOption = if (startingTimestamp.isDefined) {
-      Map(DeltaDataSource.CDF_START_TIMESTAMP_KEY -> startingTimestamp.get)
-    } else { Map.empty }
-    val endingVersionOption = if (endingVersion.isDefined) {
-      Map(DeltaDataSource.CDF_END_VERSION_KEY -> endingVersion.get)
-    } else { Map.empty }
-    val endingTimestampOption = if (endingTimestamp.isDefined) {
-      Map(DeltaDataSource.CDF_END_TIMESTAMP_KEY -> endingTimestamp.get)
-    } else { Map.empty }
-
-    startingVersionOption ++ startingTimestampOption ++ endingVersionOption ++ endingTimestampOption
+    (startingVersion.map(DeltaDataSource.CDF_START_VERSION_KEY -> _) ++
+    endingVersion.map(DeltaDataSource.CDF_END_VERSION_KEY -> _) ++
+    startingTimestamp.map(DeltaDataSource.CDF_START_TIMESTAMP_KEY -> _) ++
+    endingTimestamp.map(DeltaDataSource.CDF_END_TIMESTAMP_KEY -> _)).toMap
   }
 
   def main(args: Array[String]): Unit = {

--- a/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
+++ b/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
@@ -215,7 +215,8 @@ case class SchemaConfig(
 case class TableConfig(
     @BeanProperty var name: String,
     @BeanProperty var location: String,
-    @BeanProperty var cdfEnabled: Boolean = false) extends ConfigItem {
+    @BeanProperty var cdfEnabled: Boolean = false,
+    @BeanProperty var startVersion: Long = 0) extends ConfigItem {
 
   def this() {
     this(null, null)

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -186,6 +186,7 @@ class DeltaSharedTable(
   def queryCDF(cdfOptions: Map[String, String]): Seq[model.SingleAction] = withClassLoader {
     val actions = ListBuffer[model.SingleAction]()
 
+    // First: validate cdf options are greater than startVersion
     val cdcReader = new DeltaSharingCDCReader(deltaLog, conf)
     val (start, end) = cdcReader.validateCdfOptions(
       cdfOptions, tableVersion, tableConfig.startVersion)

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -207,7 +207,7 @@ class DeltaSharedTable(
     actions.append(modelMetadata.wrap)
 
     // Third: get files
-    val (changeFiles, addFiles, removeFiles) = cdcReader.queryCDF(start, end)
+    val (changeFiles, addFiles, removeFiles) = cdcReader.queryCDF(start, end, tableVersion)
     changeFiles.foreach { cdcDataSpec =>
       cdcDataSpec.actions.foreach { action =>
         val addCDCFile = action.asInstanceOf[AddCDCFile]

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharingCDCReader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharingCDCReader.scala
@@ -168,14 +168,33 @@ class DeltaSharingCDCReader(val deltaLog: DeltaLogImpl, val conf: Configuration)
    * @param cdfOptions to indicate the starting and ending parameters of the change data feed.
    * @param latestVersion the latest version of the delta table, which is used to validate the
    *                      starting and ending versions, and may be used as default ending version.
+   * @param validStartVersion indicates the valid start version of the query
+   * @return - start and end version parsed from cdfOptions if they are valid, otherwise throws
+   *           exception
    */
-  def queryCDF(cdfOptions: Map[String, String], latestVersion: Long): (
+  def validateCdfOptions(
+    cdfOptions: Map[String, String],
+    latestVersion: Long,
+    validStartVersion: Long): (Long, Long) = {
+    val (start, end) = getCDCVersions(cdfOptions, latestVersion)
+    if (validStartVersion > start) {
+      throw new DeltaCDFIllegalArgumentException(
+        s"You can only query table changes since version ${validStartVersion}.")
+    }
+    (start, end)
+  }
+
+  /**
+   * Replay Delta transaction logs and return cdf files
+   *
+   * @param start The start version of cdf
+   * @param end The end version of cdf
+   */
+  def queryCDF(start: Long, end: Long): (
     Seq[CDCDataSpec[AddCDCFile]],
     Seq[CDCDataSpec[AddFile]],
     Seq[CDCDataSpec[RemoveFile]]
   ) = {
-    val (start, end) = getCDCVersions(cdfOptions, latestVersion)
-
     if (!isCDCEnabledOnTable(deltaLog.getSnapshotForVersionAsOf(start).metadataScala)) {
       throw DeltaCDFErrors.changeDataNotRecordedException(start, start, end)
     }

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -661,7 +661,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   integrationTest("cdf_table_with_partition: query table changes") {
-    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/cdf_table_with_partition/changes?startingVersion=0&endingVersion=3"), Some("GET"), None, None)
+    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/cdf_table_with_partition/changes?startingVersion=1&endingVersion=3"), Some("GET"), None, None)
     val lines = response.split("\n")
     val files = lines.drop(2)
     assert(files.size == 6)
@@ -923,6 +923,26 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       data = None,
       expectedErrorCode = 400,
       expectedErrorMessage = "Error getting change data for range [4, 5] as change data was not recorded for version [4]"
+    )
+  }
+
+  integrationTest("cdf_table_with_partition - exceptions") {
+    assertHttpError(
+      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_with_partition/changes?startingVersion=0"),
+      method = "GET",
+      data = None,
+      expectedErrorCode = 400,
+      expectedErrorMessage = "You can only query table changes since version 1"
+    )
+
+    assertHttpError(
+      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_with_partition/query"),
+      method = "POST",
+      data = Some("""
+        {"version": "0"}
+      """),
+      expectedErrorCode = 400,
+      expectedErrorMessage = "You can only query table data since version 1"
     )
   }
 

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -390,7 +390,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       method = "POST",
       data = Some("""{"version": 1}"""),
       expectedErrorCode = 400,
-      expectedErrorMessage = "reading table by version is not supported because change data feed is not enabled on table: share2.default.table2"
+      expectedErrorMessage = "Reading table by version is not supported because change data feed is not enabled on table: share2.default.table2"
     )
   }
 

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -78,7 +78,8 @@ object TestResource {
               TableConfig(
                 "cdf_table_with_partition",
                 s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_with_partition",
-                true
+                true,
+                1
               )
             )
           )

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -187,7 +187,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
           Some(1L)
         )
       }.getMessage
-      assert(errorMessage.contains("reading table by version is not supported because change data feed is not enabled on table: share1.default.table1"))
+      assert(errorMessage.contains("Reading table by version is not supported because change data feed is not enabled on table: share1.default.table1"))
     } finally {
       client.close()
     }


### PR DESCRIPTION
Respect TableConfig.startVersion in OSS delta sharing server:

- Adds field startVersion with default 0 in TableConfig
- respect startVersion for listFiles in DeltaSharingService
- respect startVersion for listCDFFiles in DeltaSharedTableLoader
- Re-structure functions of DeltaSharingCDCReader to validateCdfOptions and then queryCDF