### PR TITLE
Support for per-share bearer token configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,18 +302,43 @@ Replace `KEY_PATH` with path of the JSON file that contains your service account
 
 ## Authorization
 
-The server supports a basic authorization with pre-configed bearer token. You can add the following config to your server yaml file:
-
+The server supports authorization with bearer tokens. For basic authorization, you can add the following config to your server yaml file:
 ```yaml
 authorization:
-  bearerToken: <token>
+  universalBearerToken: <token>
 ```
 
-Then any request should send with the above token, otherwise, the server will refuse the request.
+Then any request should be sent with the above token, otherwise, the server will refuse the request.
 
-If you don't config the bearer token in the server yaml file, all requests will be accepted without authorization.
-
+If you don't configure the `authorization` section in the server yaml file, all requests will be accepted without authorization.
 To be more secure, you recommend you to put the server behind a secure proxy such as [NGINX](https://www.nginx.com/) to set up [JWT Authentication](https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-jwt-authentication/).
+
+### Share based authorization
+
+For more fine-grained control, a unique bearer token can be specified for each share.
+
+ ```yaml
+ authorization:
+   universalBearerToken: <token>
+   shares:
+   - name: <share-name>
+     bearerToken: <token>
+ ```
+
+Any shares omitted from this list will require the `universalBearerToken` for access.
+
+To allow access without authorization to any unlisted share, you can change the `requireForAllShares` property.
+
+ ```yaml
+ authorization:
+   universalBearerToken: <token>
+   requireForAllShares: false
+   shares:
+   - name: <share-name>
+     bearerToken: <token>
+ ```
+
+In this configuration, any share other than the one listed will allow access without any form of authorization.
 
 ## Start the server
 

--- a/server/src/main/scala/io/delta/sharing/server/auth/AuthManager.scala
+++ b/server/src/main/scala/io/delta/sharing/server/auth/AuthManager.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.server.auth
+
+import io.delta.sharing.server.config.ServerConfig
+
+/**
+ * Load the authorization config from `ServerConfig` and provide methods to
+ * control access down to the share level.
+ */
+trait AuthManager {
+  def hasShareAccess(bearerToken: Option[String], share: String): Boolean
+  def getAuthorizedShares(bearerToken: Option[String]): Seq[String]
+}
+
+/**
+ * Returns relevant AuthManager implementation based on whether authorization has
+ * been configured.
+ */
+object AuthManager {
+  var INSTANCE: AuthManager = null
+
+  def apply(serverConfig: ServerConfig): AuthManager = {
+    INSTANCE = Option(serverConfig.authorization) match {
+      case Some(_) => new BearerTokenAuth(serverConfig)
+      case None => new NoAuth(serverConfig)
+    }
+
+    INSTANCE
+  }
+
+  def getInstance(): AuthManager = INSTANCE
+}

--- a/server/src/main/scala/io/delta/sharing/server/auth/BearerTokenAuth.scala
+++ b/server/src/main/scala/io/delta/sharing/server/auth/BearerTokenAuth.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.server.auth
+
+import java.util.Collections
+
+import scala.collection.immutable.HashMap
+import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
+
+import io.delta.sharing.server.config.ServerConfig
+import io.delta.sharing.server.util.AuthUtils
+
+class BearerTokenAuth(serverConfig: ServerConfig) extends AuthManager {
+  // Keep track of all shares (by lowercase name) to make "universal bearer" returns faster
+  private val shares: Seq[String] = serverConfig.getShares.asScala
+    .map(_.getName.toLowerCase())
+    .toSeq
+
+  private val universalToken: String = serverConfig.getAuthorization.getUniversalBearerToken
+
+  // Convert the auth shares list to map of token -> share set (if it exists)
+  private val tokenToShares = Option(serverConfig.getAuthorization.getShares)
+    .getOrElse(Collections.emptyList())
+    .asScala
+    // Convert to map of bearer token -> set of share names with that token
+    .foldLeft(HashMap[String, Set[String]]())((m, s) => {
+      val existingSet = m.getOrElse(s.getBearerToken, Set())
+      m + (s.getBearerToken -> (existingSet + s.getName))
+    })
+
+  // The list of shares accessible without a valid bearer token. This only needs
+  // to be populated when the "requireForAllShares" property is set to false
+  private var unsecuredShares = Set[String]()
+  if (!serverConfig.getAuthorization.getRequireForAllShares) {
+    // Names of shares with explicit auth
+    val securedShares = Option(serverConfig.getAuthorization.getShares)
+      .getOrElse(Collections.emptyList())
+      .asScala
+      .map(_.getName.toLowerCase())
+      .toSet
+
+    // Subtract explicitly secured shares from all shares to get the list of unsecured shares
+    unsecuredShares = shares.filter(s => !securedShares.contains(s)).toSet
+  }
+
+  private def hasUniversalAccess(bearerToken: Option[String]): Boolean = {
+    if (universalToken == null) return false
+
+    bearerToken.exists(bt =>
+      AuthUtils.compareBearerTokens(bt, universalToken)
+    )
+  }
+
+  override def hasShareAccess(bearerToken: Option[String], share: String): Boolean = {
+    if (hasUniversalAccess(bearerToken)) return true
+
+    if (unsecuredShares.contains(share.toLowerCase())) return true
+
+    bearerToken.exists(bt =>
+      tokenToShares.get(bt).exists(_.contains(share.toLowerCase()))
+    )
+  }
+
+  override def getAuthorizedShares(bearerToken: Option[String]): Seq[String] = {
+    if (hasUniversalAccess(bearerToken)) return shares
+
+    val authorizedShares = bearerToken.map(bt =>
+      tokenToShares.get(bt).map(_.toSeq).getOrElse(Seq())
+    ).getOrElse(Seq())
+
+    unsecuredShares.toSeq ++ authorizedShares
+  }
+}

--- a/server/src/main/scala/io/delta/sharing/server/auth/NoAuth.scala
+++ b/server/src/main/scala/io/delta/sharing/server/auth/NoAuth.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.server.auth
+
+import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
+
+import io.delta.sharing.server.config.ServerConfig
+
+class NoAuth(serverConfig: ServerConfig) extends AuthManager {
+  private val shares: Seq[String] = serverConfig.getShares.asScala
+    .map(_.getName.toLowerCase())
+    .toSeq
+
+  override def hasShareAccess(bearerToken: Option[String], share: String): Boolean = true
+
+  override def getAuthorizedShares(bearerToken: Option[String]): Seq[String] = shares
+}

--- a/server/src/main/scala/io/delta/sharing/server/util/AuthUtils.scala
+++ b/server/src/main/scala/io/delta/sharing/server/util/AuthUtils.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.server.util
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.security.MessageDigest
+
+object AuthUtils {
+  def compareBearerTokens(t1: String, t2: String): Boolean = {
+    // Use `MessageDigest.isEqual` to do a time-constant comparison to avoid
+    // timing attacks
+    if (t1 == null || t2 == null) return false
+
+    MessageDigest.isEqual(
+      t1.getBytes(UTF_8),
+      t2.getBytes(UTF_8)
+    )
+  }
+}

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -19,6 +19,7 @@ package io.delta.sharing.server
 import java.io.File
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
+import java.util.{Arrays}
 
 import org.apache.commons.io.FileUtils
 
@@ -44,7 +45,8 @@ object TestResource {
 
   val TEST_PORT = 12345
 
-  val testAuthorizationToken = "dapi5e3574ec767ca1548ae5bbed1a2dc04d"
+  val testUniversalAuthorizationToken = "dapi5e3574ec767ca1548ae5bbed1a2dc04d"
+  val testShareAuthorizationToken = "agdq3xsqpt01ggysegjv8dd86j08ohq5hmq9"
 
   def maybeSetupGoogleServiceAccountCredentials: Unit = {
     // Only setup Google Service Account credentials when it is provided through env variable.
@@ -168,7 +170,9 @@ object TestResource {
     val serverConfig = new ServerConfig()
     serverConfig.setVersion(1)
     serverConfig.setShares(shares)
-    serverConfig.setAuthorization(Authorization(testAuthorizationToken))
+    serverConfig.setAuthorization(Authorization(testUniversalAuthorizationToken, true, Arrays.asList(
+      ShareAuth("share1", testShareAuthorizationToken)
+    )))
     serverConfig.setPort(TEST_PORT)
     serverConfig.setSsl(SSLConfig(selfSigned = true, null, null, null))
     serverConfig.setEvaluatePredicateHints(true)

--- a/server/src/universal/conf/delta-sharing-server.yaml.template
+++ b/server/src/universal/conf/delta-sharing-server.yaml.template
@@ -27,9 +27,21 @@ shares:
     - name: "table4"
       # Google Cloud Storage (GCS). See https://github.com/delta-io/delta-sharing#google-cloud-storage for how to config the credentials
       location: "gs://<bucket-name>/<the-table-path>"
+# Authorization is enabled when this property is et
+authorization:
+ # This token grants access to all shares
+ universalBearerToken: "<change-me-universal-token>"
+ # Requires a valid bearer token for all shares. Disabling will allow unsecure access to shares not listed in this section
+ requireForAllShares: true
+ # Grants share-specific access using the configured bearer tokens
+ shares:
+ - name: "share1"
+   bearerToken: "<change-me-share1-token>"
+ - name: "share2"
+   bearerToken: "<change-me-share2-token>"
 # Set the host name that the server will use
 host: "localhost"
-# Set the port that the server will listen on. Note: using ports below 1024 
+# Set the port that the server will listen on. Note: using ports below 1024
 # may require a privileged user in some operating systems.
 port: 8080
 # Set the url prefix for the REST APIs


### PR DESCRIPTION
At the moment authorization is everything or nothing, with a single bearer token providing access to the entire server. This PR expands authorization to support per-share bearer token configs.

- changes the `authorization.bearerToken` property to `authorization.universalBearerToken`, and adds an `authorization.shares` array to configure additional tokens unique to a share
- adds an AuthManager trait and two implementations (BearerTokenAuth and NoAuth) to handle authorization
- expands unit tests to cover per-share authorization cases

There are certainly other approaches to this feature, so let me know if an alternative approach is deemed preferable.