### PR TITLE
Add ability to configure armeria server request timeout

### DIFF
--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -288,6 +288,7 @@ object DeltaSharingService {
         .defaultHostname(serverConfig.getHost)
         .disableDateHeader()
         .disableServerHeader()
+        .requestTimeout(java.time.Duration.ofSeconds(serverConfig.requestTimeoutSeconds))
         .annotatedService(serverConfig.endpoint, new DeltaSharingService(serverConfig): Any)
       if (serverConfig.ssl == null) {
         builder.http(serverConfig.getPort)

--- a/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
+++ b/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
@@ -53,7 +53,9 @@ case class ServerConfig(
     // static tables that will never be changed.
     @BeanProperty var stalenessAcceptable: Boolean,
     // Whether to evaluate user provided `predicateHints`
-    @BeanProperty var evaluatePredicateHints: Boolean
+    @BeanProperty var evaluatePredicateHints: Boolean,
+    // The timeout of an incoming web request in seconds. Set to 0 for no timeout
+    @BeanProperty var requestTimeoutSeconds: Long
 ) extends ConfigItem {
   import ServerConfig._
 
@@ -70,7 +72,8 @@ case class ServerConfig(
       preSignedUrlTimeoutSeconds = 3600,
       deltaTableCacheSize = 10,
       stalenessAcceptable = false,
-      evaluatePredicateHints = false
+      evaluatePredicateHints = false,
+      requestTimeoutSeconds = 30
     )
   }
 


### PR DESCRIPTION
This allows users to add requestTimeout override configuration to the `server-config.yaml` file in order to prevent armeria's default 30s timeout from killing responses.

https://javadoc.io/static/com.linecorp.armeria/armeria-javadoc/1.15.0/com/linecorp/armeria/server/ServerBuilder.html#requestTimeout(java.time.Duration)

Signed-off-by: Patrick McCauley <patrickjmccauley@gmail.com>