### PR TITLE
Replace deprecated logging.warn with logging.warning

### DIFF
--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -128,7 +128,9 @@ def _client_user_agent() -> str:
             + f" System/{platform.platform()}"
         )
     except Exception as e:
-        logging.warn(f"Unable to load version information for Delta Sharing because of error {e}")
+        logging.warning(
+            f"Unable to load version information for Delta Sharing because of error {e}"
+        )
         return "Delta-Sharing-Python/<unknown>"
 
 


### PR DESCRIPTION

Replace `logging.warn` (deprecated in [Python 2.7, 2011](https://github.com/python/cpython/commit/04d5bc00a219860c69ea17eaa633d3ab9917409f)) with `logging.warning` (added in [Python 2.3, 2003](https://github.com/python/cpython/commit/6fa635df7aa88ae9fd8b41ae42743341316c90f7)).

* https://docs.python.org/3/library/logging.html#logging.Logger.warning
* https://github.com/python/cpython/issues/57444
