### PR TITLE
Add ability to configure threshold for delta sharing JAR network timeouts

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -78,7 +78,8 @@ private[sharing] case class ListAllTablesResponse(
 /** A REST client to fetch Delta metadata from remote server. */
 private[spark] class DeltaSharingRestClient(
     profileProvider: DeltaSharingProfileProvider,
-    timeoutInSeconds: Int = 120,
+  timeoutInSeconds: Int =
+    scala.util.Properties.envOrElse("SPARK_DELTA_SHARING_NETWORK_TIMEOUT_SECONDS", "120").toInt,
     numRetries: Int = 10,
     sslTrustAll: Boolean = false) extends DeltaSharingClient {
 

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -78,7 +78,7 @@ private[sharing] case class ListAllTablesResponse(
 /** A REST client to fetch Delta metadata from remote server. */
 private[spark] class DeltaSharingRestClient(
     profileProvider: DeltaSharingProfileProvider,
-  timeoutInSeconds: Int =
+    timeoutInSeconds: Int =
     scala.util.Properties.envOrElse("SPARK_DELTA_SHARING_NETWORK_TIMEOUT_SECONDS", "120").toInt,
     numRetries: Int = 10,
     sslTrustAll: Boolean = false) extends DeltaSharingClient {

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -79,7 +79,7 @@ private[sharing] case class ListAllTablesResponse(
 private[spark] class DeltaSharingRestClient(
     profileProvider: DeltaSharingProfileProvider,
     timeoutInSeconds: Int =
-    scala.util.Properties.envOrElse("SPARK_DELTA_SHARING_NETWORK_TIMEOUT_SECONDS", "120").toInt,
+      scala.util.Properties.envOrElse("SPARK_DELTA_SHARING_NETWORK_TIMEOUT_SECONDS", "120").toInt,
     numRetries: Int = 10,
     sslTrustAll: Boolean = false) extends DeltaSharingClient {
 

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingFileSystem.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingFileSystem.scala
@@ -44,7 +44,8 @@ private[sharing] class DeltaSharingFileSystem extends FileSystem {
   }
 
   lazy private val timeoutInSeconds = {
-    val timeoutStr = getConf.get("spark.delta.sharing.network.timeout", "120s")
+    val timeoutStr = getConf.get("spark.delta.sharing.network.timeout",
+      scala.util.Properties.envOrElse("SPARK_DELTA_SHARING_NETWORK_TIMEOUT_SECONDS", "120") + "s")
     val timeoutInSeconds = JavaUtils.timeStringAs(timeoutStr, TimeUnit.SECONDS)
     if (timeoutInSeconds < 0) {
       throw new IllegalArgumentException(

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -146,7 +146,9 @@ private[sharing] object RemoteDeltaLog {
         "spark.delta.sharing.network.numRetries must not be negative")
     }
     val timeoutInSeconds = {
-      val timeoutStr = sqlConf.getConfString("spark.delta.sharing.network.timeout", "120s")
+      val timeoutStr = sqlConf.getConfString("spark.delta.sharing.network.timeout",
+        scala.util.Properties.envOrElse("SPARK_DELTA_SHARING_NETWORK_TIMEOUT_SECONDS", "120") + "s")
+
       val timeoutInSeconds = JavaUtils.timeStringAs(timeoutStr, TimeUnit.SECONDS)
       if (timeoutInSeconds < 0) {
         throw new IllegalArgumentException(


### PR DESCRIPTION
This allows users to configure an environmental variable `SPARK_DELTA_SHARING_NETWORK_TIMEOUT_SECONDS` to override the default 120s timeout threshold for the delta sharing JAR

Signed-off-by: Patrick McCauley [patrickjmccauley@gmail.com](mailto:patrickjmccauley@gmail.com)