### PR TITLE
Upgrade AWS SDK to 1.12.189

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,8 +97,10 @@ lazy val server = (project in file("server")) enablePlugins(JavaAppPackaging) se
     "org.apache.hadoop" % "hadoop-aws" % "2.10.1" excludeAll(
       ExclusionRule("com.fasterxml.jackson.core"),
       ExclusionRule("com.fasterxml.jackson.module"),
-      ExclusionRule("com.google.guava", "guava")
+      ExclusionRule("com.google.guava", "guava"),
+      ExclusionRule("com.amazonaws", "aws-java-sdk-bundle")
     ),
+    "com.amazonaws" % "aws-java-sdk-bundle" % "1.12.189",
     "org.apache.hadoop" % "hadoop-azure" % "2.10.1" excludeAll(
       ExclusionRule("com.fasterxml.jackson.core"),
       ExclusionRule("com.fasterxml.jackson.module"),


### PR DESCRIPTION
The current AWS SDK used by the server doesn't support [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html). This PR just upgrades it to a newer version 1.12.189 to support IMDSv2.