### PR TITLE
Update DeltaSharedTableLoader.scala

### DIFF
--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -78,6 +78,7 @@ class DeltaSharedTable(
 
   private val deltaLog = withClassLoader {
     val tablePath = new Path(tableConfig.getLocation)
+    //conf.set("fs.s3a.endpoint", "s3.us-gov-west-1.amazonaws.com") 
     DeltaLog.forTable(conf, tablePath).asInstanceOf[DeltaLogImpl]
   }
 


### PR DESCRIPTION
For S3 regions that only support Signature Version 4, a protocol for authenticating inbound API requests to AWS services, the the default S3 service endpoint will not work, the S3A client needs to be given the endpoint to use via the fs.s3a.endpoint property