### PR TITLE
Fix GCS path parsing

### DIFF
--- a/server/src/test/scala/io/delta/sharing/server/CloudFileSignerSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/CloudFileSignerSuite.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.server
+
+import org.apache.hadoop.fs.Path
+import org.scalatest.FunSuite
+
+class CloudFileSignerSuite extends FunSuite {
+
+  test("GCSFileSigner.getBucketAndObjectNames") {
+    assert(GCSFileSigner.getBucketAndObjectNames(new Path("gs://delta-sharing-test/foo"))
+      == ("delta-sharing-test", "foo"))
+    assert(GCSFileSigner.getBucketAndObjectNames(new Path("gs://delta_sharing_test/foo"))
+      == ("delta_sharing_test", "foo"))
+  }
+}


### PR DESCRIPTION
For a path such as `gs://delta_sharing_test/foo`, `getHost` will return null and trigger NPE. This PR changes the code to call GCS APIs to parse a path instead to avoid such issue (It calls `getAuthority` underlying instead).

This is not an issue for S3 or Azure because they do require the bucket name to be a valid host name (cannot contain `_`).