### PR TITLE
Support timestamp in table query request in oss delta sharing server

### DIFF
--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -464,7 +464,7 @@ def test_list_files_in_table_version_exception(
         )
     except Exception as e:
         assert isinstance(e, HTTPError)
-        assert "Reading table by version is not supported because change data" in (str(e))
+        assert "Reading table by version or timestamp is not supported" in (str(e))
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/server/src/main/protobuf/protocol.proto
+++ b/server/src/main/protobuf/protocol.proto
@@ -46,9 +46,12 @@ message QueryTableRequest {
     repeated string predicateHints = 1;
     optional int64 limitHint = 2;
 
+    // If neither version nor timestamp is specified, the query is for the latest version.
+    // Only one of the two parameters can be supported in a single query.
     // The table version being queried.
-    // If not specified, the query is assumed to be for the latest version.
     optional int64 version = 3;
+    // The table version corresponding to the timestamp being queried.
+    optional string timestamp = 4;
 }
 
 message ListSharesResponse {

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharingCDCReader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharingCDCReader.scala
@@ -79,15 +79,6 @@ class DeltaSharingCDCReader(val deltaLog: DeltaLogImpl, val conf: Configuration)
     (startingVersion.get, endingVersion.getOrElse(latestVersion))
   }
 
-  // Convert timestamp string in cdfOptions to Timestamp
-  private def getTimestamp(paramName: String, timeStampStr: String): Timestamp = {
-    try {
-      Timestamp.valueOf(timeStampStr)
-    } catch {
-      case e: IllegalArgumentException =>
-        throw DeltaCDFErrors.invalidTimestamp(paramName, e.getMessage)
-    }
-  }
 
   /**
    * - If a commit version exactly matches the provided timestamp, we return it.
@@ -131,7 +122,7 @@ class DeltaSharingCDCReader(val deltaLog: DeltaLogImpl, val conf: Configuration)
     if (options.contains(versionKey)) {
       Some(options(versionKey).toLong)
     } else if (options.contains(timestampKey)) {
-      val ts = getTimestamp(timestampKey, options(timestampKey))
+      val ts = DeltaSharingHistoryManager.getTimestamp(timestampKey, options(timestampKey))
       if (timestampKey == DeltaDataSource.CDF_START_TIMESTAMP_KEY) {
         // For the starting timestamp we need to find a version after the provided timestamp
         // we can use the same semantics as streaming.

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharingHistoryManager.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharingHistoryManager.scala
@@ -17,6 +17,8 @@
 // Putting these classes in this package to access Delta Standalone internal APIs
 package io.delta.standalone.internal
 
+import java.sql.Timestamp
+
 import io.delta.standalone.internal.actions.CommitMarker
 import io.delta.standalone.internal.util.FileNames
 import io.delta.standalone.storage.LogStore
@@ -44,6 +46,16 @@ object DeltaSharingHistoryManager {
     val monotonizationStart =
       Seq(start - POTENTIALLY_UNMONOTONIZED_TIMESTAMPS, 0).max
     getCommits(logStore, logPath, monotonizationStart, end, conf)
+  }
+
+  // Convert timestamp string to Timestamp
+  private[internal] def getTimestamp(paramName: String, timeStampStr: String): Timestamp = {
+    try {
+      Timestamp.valueOf(timeStampStr)
+    } catch {
+      case e: IllegalArgumentException =>
+        throw DeltaCDFErrors.invalidTimestamp(paramName, e.getMessage)
+    }
   }
 
   /**

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -189,7 +189,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
           Some(1L)
         )
       }.getMessage
-      assert(errorMessage.contains("Reading table by version is not supported because change data feed is not enabled on table: share1.default.table1"))
+      assert(errorMessage.contains("Reading table by version or timestamp is not supported because change data feed is not enabled on table: share1.default.table1"))
     } finally {
       client.close()
     }


### PR DESCRIPTION
Support timestamp in table query request in oss delta sharing server, only one of timestamp and version is supported, and they are only supported when cdfEnabled is true.