### PR TITLE
Support startingVersion in queryTable rpc in OSS Delta Sharing Server

### DIFF
--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -76,6 +76,8 @@ def test_list_tables(sharing_client: SharingClient):
         Table(name="cdf_table_with_partition", share="share1", schema="default"),
         Table(name="cdf_table_with_vacuum", share="share1", schema="default"),
         Table(name="cdf_table_missing_log", share="share1", schema="default"),
+        Table(name="streaming_table_with_optimize", share="share1", schema="default"),
+        Table(name="table_reader_version_increased", share="share1", schema="default"),
     ]
 
     tables = sharing_client.list_tables(Schema(name="default", share="share2"))
@@ -91,6 +93,8 @@ def _verify_all_tables_result(tables: Sequence[Table]):
         Table(name="cdf_table_with_partition", share="share1", schema="default"),
         Table(name="cdf_table_with_vacuum", share="share1", schema="default"),
         Table(name="cdf_table_missing_log", share="share1", schema="default"),
+        Table(name="streaming_table_with_optimize", share="share1", schema="default"),
+        Table(name="table_reader_version_increased", share="share1", schema="default"),
         Table(name="table2", share="share2", schema="default"),
         Table(name="table4", share="share3", schema="default"),
         Table(name="table5", share="share3", schema="default"),

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -391,7 +391,7 @@ def test_load_as_pandas_success(
             "share1.default.cdf_table_cdf_enabled",
             1,
             "random_timestamp",
-            "Please either provide",
+            "Please only provide one of",
             id="only one is supported",
         ),
         pytest.param(
@@ -624,7 +624,7 @@ def test_parse_url():
             "share1.default.cdf_table_cdf_enabled",
             1,
             "2000-01-01 00:00:00",
-            "Please either provide 'versionAsOf' or 'timestampAsOf'",
+            "Please either provide",
             [],
             "not-used-schema-str",
             id="cdf_table_cdf_enabled timestamp too early",

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -136,6 +136,8 @@ def test_list_tables(rest_client: DataSharingRestClient):
         Table(name="cdf_table_with_partition", share="share1", schema="default"),
         Table(name="cdf_table_with_vacuum", share="share1", schema="default"),
         Table(name="cdf_table_missing_log", share="share1", schema="default"),
+        Table(name="streaming_table_with_optimize", share="share1", schema="default"),
+        Table(name="table_reader_version_increased", share="share1", schema="default"),
     ]
 
     response = rest_client.list_tables(Schema(name="default", share="share2"))
@@ -158,6 +160,8 @@ def test_list_tables_with_pagination(rest_client: DataSharingRestClient):
         Table(name="cdf_table_with_partition", share="share1", schema="default"),
         Table(name="cdf_table_with_vacuum", share="share1", schema="default"),
         Table(name="cdf_table_missing_log", share="share1", schema="default"),
+        Table(name="streaming_table_with_optimize", share="share1", schema="default"),
+        Table(name="table_reader_version_increased", share="share1", schema="default"),
     ]
 
 

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -491,7 +491,7 @@ def test_list_files_in_table_timestamp(
         rest_client.list_files_in_table(cdf_table, version=1, timestamp="random_str")
     except Exception as e:
         assert isinstance(e, HTTPError)
-        assert "Please either provide" in (str(e))
+        assert "Please only provide one of" in (str(e))
 
     # Use a random string, and look for an appropriate error.
     # This will ensure that the timestamp is pass to server.

--- a/server/src/main/protobuf/protocol.proto
+++ b/server/src/main/protobuf/protocol.proto
@@ -46,12 +46,18 @@ message QueryTableRequest {
     repeated string predicateHints = 1;
     optional int64 limitHint = 2;
 
-    // If neither version nor timestamp is specified, the query is for the latest version.
-    // Only one of the two parameters can be supported in a single query.
+    // Only one of the three parameters can be supported in a single query.
+    // If none of them is specified, the query is for the latest version.
+    //
+    // - If either version or timestamp is specified, the query is for the snapshot at the version.
+    // - If startingVersion is specified, the query is for all dataChange files until the
+    //   current version.
     // The table version being queried.
     optional int64 version = 3;
     // The table version corresponding to the timestamp being queried.
     optional string timestamp = 4;
+    // Query all data change files since startingVersion
+    optional int64 startingVersion = 5;
 }
 
 message ListSharesResponse {

--- a/server/src/main/protobuf/protocol.proto
+++ b/server/src/main/protobuf/protocol.proto
@@ -50,8 +50,8 @@ message QueryTableRequest {
     // If none of them is specified, the query is for the latest version.
     //
     // - If either version or timestamp is specified, the query is for the snapshot at the version.
-    // - If startingVersion is specified, the query is for all dataChange files until the
-    //   current version.
+    // - If startingVersion is specified, the query is for all dataChange files from startingVersion
+    //   until the current version.
     // The table version being queried.
     optional int64 version = 3;
     // The table version corresponding to the timestamp being queried.

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -46,6 +46,7 @@ import io.delta.sharing.server.protocol._
 import io.delta.sharing.server.util.JsonUtils
 
 object ErrorCode {
+  val UNSUPPORTED_OPERATION = "UNSUPPORTED_OPERATION"
   val INTERNAL_ERROR = "INTERNAL_ERROR"
   val RESOURCE_DOES_NOT_EXIST = "RESOURCE_DOES_NOT_EXIST"
   val INVALID_PARAMETER_VALUE = "INVALID_PARAMETER_VALUE"
@@ -79,6 +80,14 @@ class DeltaSharingServiceExceptionHandler extends ExceptionHandlerFunction {
                 "errorCode" -> ErrorCode.RESOURCE_DOES_NOT_EXIST,
                 "message" -> cause.getMessage)))
         }
+      case _: DeltaSharingUnsupportedOperationException =>
+        HttpResponse.of(
+          HttpStatus.BAD_REQUEST,
+          MediaType.JSON_UTF_8,
+          JsonUtils.toJson(
+            Map(
+              "errorCode" -> ErrorCode.UNSUPPORTED_OPERATION,
+              "message" -> cause.getMessage)))
       case _: DeltaSharingIllegalArgumentException =>
         HttpResponse.of(
           HttpStatus.BAD_REQUEST,
@@ -167,8 +176,9 @@ class DeltaSharingService(serverConfig: ServerConfig) {
    */
   private def processRequest[T](func: => T): T = {
     try func catch {
-      case e: DeltaSharingNoSuchElementException => throw e
+      case e: DeltaSharingUnsupportedOperationException => throw e
       case e: DeltaSharingIllegalArgumentException => throw e
+      case e: DeltaSharingNoSuchElementException => throw e
       case e: DeltaCDFIllegalArgumentException => throw e
       case e: FileNotFoundException => throw e
       case e: AccessDeniedException => throw e
@@ -247,13 +257,14 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       @Param("table") table: String): HttpResponse = processRequest {
     import scala.collection.JavaConverters._
     val tableConfig = sharedTableManager.getTable(share, schema, table)
-    val (version, actions) = deltaSharedTableLoader.loadTable(tableConfig).query(
+    val (v, actions) = deltaSharedTableLoader.loadTable(tableConfig).query(
       includeFiles = false,
-      Nil,
-      None,
-      None,
-      None)
-    streamingOutput(Some(version), actions)
+      predicateHints = Nil,
+      limitHint = None,
+      version = None,
+      timestamp = None,
+      startingVersion = None)
+    streamingOutput(Some(v), actions)
   }
 
   @Post("/shares/{share}/schemas/{schema}/tables/{table}/query")
@@ -262,20 +273,31 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       @Param("share") share: String,
       @Param("schema") schema: String,
       @Param("table") table: String,
-      queryTableRequest: QueryTableRequest): HttpResponse = processRequest {
-    if (queryTableRequest.version.isDefined && queryTableRequest.version.get < 0) {
+      request: QueryTableRequest): HttpResponse = processRequest {
+    val numVersionParams = Seq(request.version, request.timestamp, request.startingVersion)
+      .filter(_.isDefined).size
+    if (numVersionParams >= 2) {
+      throw new DeltaSharingIllegalArgumentException(ErrorStrings.multipleParametersSetErrorMsg(
+        Seq("version", "timestamp", "startingVersion"))
+      )
+    }
+    if (request.version.isDefined && request.version.get < 0) {
       throw new DeltaSharingIllegalArgumentException("table version cannot be negative.")
+    }
+    if (request.startingVersion.isDefined && request.startingVersion.get < 0) {
+      throw new DeltaSharingIllegalArgumentException("startingVersion cannot be negative.")
     }
 
     val start = System.currentTimeMillis
     val tableConfig = sharedTableManager.getTable(share, schema, table)
-    if (queryTableRequest.version.isDefined || queryTableRequest.timestamp.isDefined) {
+    if (numVersionParams > 0) {
       if (!tableConfig.cdfEnabled) {
         throw new DeltaSharingIllegalArgumentException("Reading table by version or timestamp is" +
           " not supported because change data feed is not enabled on table: " +
           s"$share.$schema.$table")
       }
-      if (queryTableRequest.version.exists(_ < tableConfig.startVersion)) {
+      if (request.version.exists(_ < tableConfig.startVersion) ||
+        request.startingVersion.exists(_ < tableConfig.startVersion)) {
         throw new DeltaSharingIllegalArgumentException(
           s"You can only query table data since version ${tableConfig.startVersion}."
         )
@@ -283,10 +305,11 @@ class DeltaSharingService(serverConfig: ServerConfig) {
     }
     val (version, actions) = deltaSharedTableLoader.loadTable(tableConfig).query(
       includeFiles = true,
-      queryTableRequest.predicateHints,
-      queryTableRequest.limitHint,
-      queryTableRequest.version,
-      queryTableRequest.timestamp)
+      request.predicateHints,
+      request.limitHint,
+      request.version,
+      request.timestamp,
+      request.startingVersion)
     logger.info(s"Took ${System.currentTimeMillis - start} ms to load the table " +
       s"and sign ${actions.length - 2} urls for table $share/$schema/$table")
     streamingOutput(Some(version), actions)

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -276,7 +276,7 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       request: QueryTableRequest): HttpResponse = processRequest {
     val numVersionParams = Seq(request.version, request.timestamp, request.startingVersion)
       .filter(_.isDefined).size
-    if (numVersionParams >= 2) {
+    if (numVersionParams > 1) {
       throw new DeltaSharingIllegalArgumentException(ErrorStrings.multipleParametersSetErrorMsg(
         Seq("version", "timestamp", "startingVersion"))
       )

--- a/server/src/main/scala/io/delta/sharing/server/exceptions.scala
+++ b/server/src/main/scala/io/delta/sharing/server/exceptions.scala
@@ -36,6 +36,15 @@ class DeltaSharingIllegalArgumentException(message: String)
 class DeltaSharingNoSuchElementException(message: String)
   extends NoSuchElementException(message)
 
+/**
+ * A special exception for invalid requests happening in Delta Sharing Server. We define a special
+ * class rather than reusing `UnsupportedOperationException` so that we can ensure that the message
+ * in `UnsupportedOperationException` thrown from other libraries won't be returned to users.
+ *
+ * @note `message` will be in the response. Please make sure it doesn't contain any sensitive info.
+ */
+class DeltaSharingUnsupportedOperationException(message: String)
+  extends UnsupportedOperationException(message)
 
 /**
  * A special exception that wraps an unhandled exception when processing a request.
@@ -43,3 +52,13 @@ class DeltaSharingNoSuchElementException(message: String)
  * sensitive information.
  */
 class DeltaInternalException(e: Throwable) extends RuntimeException(e)
+
+object ErrorStrings {
+  def multipleParametersSetErrorMsg(params: Seq[String]): String = {
+    s"Please only provide one of: ${params.mkString(",")}"
+  }
+}
+
+object CausedBy {
+  def unapply(e: Throwable): Option[Throwable] = Option(e.getCause)
+}

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -131,3 +131,8 @@ case class RemoveFile(
 
   override def wrap: SingleAction = SingleAction(remove = this)
 }
+
+object Action {
+  /** The maximum version of the protocol that this version of Delta Standalone understands. */
+  val readerVersion = 1
+}

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -133,6 +133,9 @@ case class RemoveFile(
 }
 
 object Action {
-  /** The maximum version of the protocol that this version of Delta Standalone understands. */
-  val readerVersion = 1
+  // The maximum version of the protocol that this version of Delta Standalone understands.
+  val maxReaderVersion = 1
+  // The maximum writer version that this version of Delta Sharing Standalone supports.
+  // Basically delta sharing doesn't support write for now.
+  val maxWriterVersion = 0
 }

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -276,7 +276,7 @@ class DeltaSharedTable(
           )
           actions.append(modelRemoveFile.wrap)
         case p: Protocol =>
-          protocolRead(p)
+          assertProtocolRead(p)
         case m: Metadata =>
         // TODO(lin.zhou) make a copy of SchemaUtils.isReadCompatible in another PR
         case _ => ()
@@ -367,9 +367,10 @@ class DeltaSharedTable(
     deltaLog.update()
   }
 
-  private def protocolRead(protocol: Protocol): Unit = {
-    if (protocol.minReaderVersion > model.Action.readerVersion) {
-      val e = new DeltaErrors.InvalidProtocolVersionException(Protocol(1, 2), protocol)
+  private def assertProtocolRead(protocol: Protocol): Unit = {
+    if (protocol.minReaderVersion > model.Action.maxReaderVersion) {
+      val e = new DeltaErrors.InvalidProtocolVersionException(Protocol(
+        model.Action.maxReaderVersion, model.Action.maxWriterVersion), protocol)
       throw new DeltaSharingUnsupportedOperationException(e.getMessage)
     }
   }

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -90,6 +90,16 @@ object TestResource {
                 "cdf_table_missing_log",
                 s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_missing_log",
                 true
+              ),
+              TableConfig(
+                "streaming_table_with_optimize",
+                s"s3a://${AWS.bucket}/delta-exchange-test/streaming_table_with_optimize",
+                true
+              ),
+              TableConfig(
+                "table_reader_version_increased",
+                s"s3a://${AWS.bucket}/delta-exchange-test/table_reader_version_increased",
+                true
               )
             )
           )

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -48,6 +48,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Table(name = "cdf_table_with_partition", schema = "default", share = "share1"),
         Table(name = "cdf_table_with_vacuum", schema = "default", share = "share1"),
         Table(name = "cdf_table_missing_log", schema = "default", share = "share1"),
+        Table(name = "streaming_table_with_optimize", schema = "default", share = "share1"),
+        Table(name = "table_reader_version_increased", schema = "default", share = "share1"),
         Table(name = "test_gzip", schema = "default", share = "share4"),
         Table(name = "table_wasb", schema = "default", share = "share_azure"),
         Table(name = "table_abfs", schema = "default", share = "share_azure"),


### PR DESCRIPTION
Support startingVersion in queryTable rpc in OSS Delta Sharing Server, to query data change since startingVersion until the current version of the table.

Also, converted InvalidProtocolVersionException to be a client error instead of internal error in oss delta sharing server. 