### PR TITLE
Add a Custom Http Header Provider

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -35,7 +35,6 @@ import org.apache.http.conn.ssl.{SSLConnectionSocketFactory, SSLContextBuilder, 
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.{HttpClientBuilder, HttpClients}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import io.delta.sharing.spark.model._

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -34,7 +34,6 @@ import org.apache.http.client.protocol.HttpClientContext
 import org.apache.http.conn.ssl.{SSLConnectionSocketFactory, SSLContextBuilder, TrustSelfSignedStrategy}
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.{HttpClientBuilder, HttpClients}
-import org.apache.http.message.BasicHeader
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.util.CaseInsensitiveStringMap

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingProfileProvider.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingProfileProvider.scala
@@ -40,6 +40,10 @@ object DeltaSharingProfile {
  */
 trait DeltaSharingProfileProvider {
   def getProfile: DeltaSharingProfile
+
+  // A set of custom HTTP headers to get included in the HTTP requests sent to the delta sharing
+  // server. This can be used to add extra information to the requests.
+  def getCustomHeaders: Map[String, String] = Map.empty
 }
 
 /**

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -35,17 +35,6 @@ import io.delta.sharing.spark.util.UnexpectedHttpStatus
 // scalastyle:off maxLineLength
 class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
 
-  test("no custom headers are provided by default") {
-    assert(new BaseCustomHttpHeadersProvider().getHeaders == Map.empty)
-  }
-
-  integrationTest("authorization and user agent headers are set") {
-    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
-    val headers = client.getHttpHeaders(testProfileProvider.getProfile)
-    assert(headers.contains(HttpHeaders.AUTHORIZATION))
-    assert(headers.contains(HttpHeaders.USER_AGENT))
-  }
-
   integrationTest("listAllTables") {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
     try {

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -18,6 +18,8 @@ package io.delta.sharing.spark
 
 import java.sql.Timestamp
 
+import org.apache.http.HttpHeaders
+
 import io.delta.sharing.spark.model.{
   AddCDCFile,
   AddFile,
@@ -32,6 +34,17 @@ import io.delta.sharing.spark.util.UnexpectedHttpStatus
 
 // scalastyle:off maxLineLength
 class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
+
+  test("no custom headers are provided by default") {
+    assert(new BaseCustomHttpHeadersProvider().getHeaders == Map.empty)
+  }
+
+  integrationTest("authorization and user agent headers are set") {
+    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
+    val headers = client.getHttpHeaders(testProfileProvider.getProfile)
+    assert(headers.contains(HttpHeaders.AUTHORIZATION))
+    assert(headers.contains(HttpHeaders.USER_AGENT))
+  }
 
   integrationTest("listAllTables") {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -18,8 +18,6 @@ package io.delta.sharing.spark
 
 import java.sql.Timestamp
 
-import org.apache.http.HttpHeaders
-
 import io.delta.sharing.spark.model.{
   AddCDCFile,
   AddFile,


### PR DESCRIPTION
So that the spark connector can be forked and customized to send arbitrary HTTP headers to any specific implementation of Delta Sharing Server.