### PR TITLE
Return starting version instead of current table version in the header for time travel queries

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1683,7 +1683,9 @@ See [below](#request-body) for more details.
 
 `Delta-Table-Version: {version}`
 
-**{version}** is a long value which represents the current table version.
+**{version}** is a long value, it represents the current table version when no time travel 
+parameters are provided in the request, it represents the starting version of files returned in the
+response when there are time travel parameters provided.
 
 </td>
 </tr>
@@ -1976,7 +1978,7 @@ Query Parameters | **startingVersion** (type: Int64, optional): The starting ver
 
 `Delta-Table-Version: {version}`
 
-**{version}** is a Long which represents the current table version.
+**{version}** is a long value which represents the starting version of files in the response.
 
 </td>
 </tr>

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1683,9 +1683,11 @@ See [below](#request-body) for more details.
 
 `Delta-Table-Version: {version}`
 
-**{version}** is a long value, it represents the current table version when no time travel 
-parameters are provided in the request, it represents the starting version of files returned in the
-response when there are time travel parameters provided.
+**{version}** is a long value:
+- when no time travel parameters are provided in the request, it 
+represents the current table version.
+- otherwise, it represents the starting version of files 
+returned in the response.
 
 </td>
 </tr>

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -331,7 +331,7 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       throw new DeltaSharingIllegalArgumentException("cdf is not enabled on table " +
         s"$share.$schema.$table")
     }
-    val actions = deltaSharedTableLoader.loadTable(tableConfig).queryCDF(
+    val (v, actions) = deltaSharedTableLoader.loadTable(tableConfig).queryCDF(
       getCdfOptionsMap(
         Option(startingVersion),
         Option(endingVersion),
@@ -341,7 +341,7 @@ class DeltaSharingService(serverConfig: ServerConfig) {
     )
     logger.info(s"Took ${System.currentTimeMillis - start} ms to load the table cdf " +
       s"and sign ${actions.length - 2} urls for table $share/$schema/$table")
-    streamingOutput(None, actions)
+    streamingOutput(Some(v), actions)
   }
 
   private def streamingOutput(version: Option[Long], actions: Seq[SingleAction]): HttpResponse = {

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -170,8 +170,8 @@ class DeltaSharedTable(
         ErrorStrings.multipleParametersSetErrorMsg(Seq("version", "timestamp", "startingVersion"))
       )
     }
-    val snapshot = if (version.isDefined) {
-      deltaLog.getSnapshotForVersionAsOf(version.get)
+    val snapshot = if (version.orElse(startingVersion).isDefined) {
+      deltaLog.getSnapshotForVersionAsOf(version.orElse(startingVersion).get)
     } else if (timestamp.isDefined) {
       val ts = DeltaSharingHistoryManager.getTimestamp("timestamp", timestamp.get)
       try {
@@ -202,7 +202,7 @@ class DeltaSharedTable(
       if (startingVersion.isDefined) {
         // Only read changes up to snapshot.version, and ignore changes that are committed during
         // queryDataChangeSinceStartVersion.
-        queryDataChangeSinceStartVersion(startingVersion.get, snapshot.version)
+        queryDataChangeSinceStartVersion(startingVersion.get)
       } else if (includeFiles) {
         val selectedFiles = state.activeFiles.toSeq
         val filteredFilters =
@@ -234,9 +234,8 @@ class DeltaSharedTable(
     snapshot.version -> actions
   }
 
-  private def queryDataChangeSinceStartVersion(
-    startingVersion: Long,
-    latestVersion: Long): Seq[model.SingleAction] = {
+  private def queryDataChangeSinceStartVersion(startingVersion: Long): Seq[model.SingleAction] = {
+    val latestVersion = tableVersion
     if (startingVersion > latestVersion) {
       throw DeltaCDFErrors.startVersionAfterLatestVersion(startingVersion, latestVersion)
     }
@@ -285,7 +284,7 @@ class DeltaSharedTable(
     actions.toSeq
   }
 
-  def queryCDF(cdfOptions: Map[String, String]): Seq[model.SingleAction] = withClassLoader {
+  def queryCDF(cdfOptions: Map[String, String]): (Long, Seq[model.SingleAction]) = withClassLoader {
     val actions = ListBuffer[model.SingleAction]()
 
     // First: validate cdf options are greater than startVersion
@@ -295,7 +294,7 @@ class DeltaSharedTable(
       cdfOptions, latestVersion, tableConfig.startVersion)
 
     // Second: get Protocol and Metadata
-    val snapshot = deltaLog.snapshot
+    val snapshot = deltaLog.getSnapshotForVersionAsOf(start)
     val modelProtocol = model.Protocol(snapshot.protocolScala.minReaderVersion)
     val modelMetadata = model.Metadata(
       id = snapshot.metadataScala.id,
@@ -360,7 +359,7 @@ class DeltaSharedTable(
         actions.append(modelRemoveFile.wrap)
       }
     }
-    actions.toSeq
+    snapshot.version -> actions.toSeq
   }
 
   def update(): Unit = withClassLoader {

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -749,7 +749,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
          | "startingVersion": 0
          |}
          |""".stripMargin
-    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/streaming_table_with_optimize/query"), Some("POST"), Some(p), Some(6))
+    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/streaming_table_with_optimize/query"), Some("POST"), Some(p), Some(0))
     val lines = response.split("\n")
     val protocol = lines(0)
     val metadata = lines(1)
@@ -842,7 +842,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   integrationTest("cdf_table_cdf_enabled_changes - query table changes") {
-    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=0&endingVersion=3"), Some("GET"), None, None)
+    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=0&endingVersion=3"), Some("GET"), None, Some(0))
     val lines = response.split("\n")
     val protocol = lines(0)
     val metadata = lines(1)
@@ -907,7 +907,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     // 1651272660000, PST: 2022-04-29 15:51:00.0 -> version 3
     val endStr = URLEncoder.encode(new Timestamp(1651272660000L).toString)
 
-    val response = readNDJson(requestPath(s"/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingTimestamp=${startStr}&endingTimestamp=${endStr}"), Some("GET"), None, None)
+    val response = readNDJson(requestPath(s"/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingTimestamp=${startStr}&endingTimestamp=${endStr}"), Some("GET"), None, Some(0))
     val lines = response.split("\n")
     val protocol = lines(0)
     val metadata = lines(1)
@@ -925,7 +925,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   integrationTest("cdf_table_with_partition: query table changes") {
-    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/cdf_table_with_partition/changes?startingVersion=1&endingVersion=3"), Some("GET"), None, None)
+    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/cdf_table_with_partition/changes?startingVersion=1&endingVersion=3"), Some("GET"), None, Some(1))
     val lines = response.split("\n")
     val files = lines.drop(2)
     assert(files.size == 6)

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -237,7 +237,7 @@ private[spark] class DeltaSharingRestClient(
       case f => throw new IllegalStateException(s"Unexpected File:${f}")
     }
     DeltaTableFiles(
-      0L,
+      version,
       protocol,
       metadata,
       addFiles = addFiles,
@@ -253,7 +253,7 @@ private[spark] class DeltaSharingRestClient(
 
     val target = getTargetUrl(
       s"/shares/$encodedShare/schemas/$encodedSchema/tables/$encodedTable/changes?$encodedParams")
-    val (_, lines) = getNDJson(target, requireVersion = false)
+    val (version, lines) = getNDJson(target, requireVersion = false)
     val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
     checkProtocol(protocol)
     val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
@@ -268,7 +268,7 @@ private[spark] class DeltaSharingRestClient(
       case f => throw new IllegalStateException(s"Unexpected File:${f}")
     }
     DeltaTableFiles(
-      0L,
+      version,
       protocol,
       metadata,
       addFiles = addFiles,

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -113,6 +113,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     try {
       val tableFiles =
         client.getFiles(Table(name = "table2", schema = "default", share = "share2"), Nil, None, None, None)
+      assert(tableFiles.version == 2)
       assert(Protocol(minReaderVersion = 1) == tableFiles.protocol)
       val expectedMetadata = Metadata(
         id = "f8d5c169-3d01-4ca3-ad9e-7dc3355aedb2",
@@ -152,6 +153,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         None,
         Some(1L),
         None)
+      assert(tableFiles.version == 1)
       assert(tableFiles.files.size == 3)
       val expectedFiles = Seq(
         AddFile(
@@ -245,6 +247,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       val tableFiles = client.getFiles(
         Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"), 1L
       )
+      assert(tableFiles.version == 1)
       assert(tableFiles.addFiles.size == 4)
       val expectedAddFiles = Seq(
         AddFileForCDF(
@@ -342,6 +345,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),
         cdfOptions
       )
+      assert(tableFiles.version == 0)
       assert(Protocol(minReaderVersion = 1) == tableFiles.protocol)
       val expectedMetadata = Metadata(
         id = "16736144-3306-4577-807a-d3f899b77670",
@@ -414,6 +418,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Table(name = "cdf_table_with_vacuum", schema = "default", share = "share1"),
         cdfOptions
       )
+      assert(tableFiles.version == 0)
       assert(Protocol(minReaderVersion = 1) == tableFiles.protocol)
       assert(tableFiles.addFiles.size == 4)
       assert(tableFiles.cdfFiles.size == 2)


### PR DESCRIPTION
Return starting version instead of current table version in the header for time travel queries: 

- for queryTable with time travel parameters: version/timestamp/startingVersion
- for queryTableChanges 