### PR TITLE
Support startingTimestamp and GET method for getTableVersion

### DIFF
--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -17,7 +17,7 @@ import collections
 from contextlib import contextmanager
 from dataclasses import dataclass
 import json
-from typing import Any, ClassVar, Dict, Generator, List, Optional, Sequence
+from typing import Any, ClassVar, Dict, List, Optional, Sequence
 from urllib.parse import quote, urlparse
 import time
 import logging

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -365,7 +365,7 @@ class DataSharingRestClient:
         return_headers,
         target: str,
         **kwargs,
-    ) -> Generator[str, None, None]:
+    ):
         assert target.startswith("/"), "Targets should start with '/'"
         response = request(f"{self._profile.endpoint}{target}", **kwargs)
         try:

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -249,7 +249,8 @@ class DataSharingRestClient:
     def query_table_version(
         self,
         table: Table,
-        starting_timestamp: Optional[str] = None) -> QueryTableVersionResponse:
+        starting_timestamp: Optional[str] = None,
+    ) -> QueryTableVersionResponse:
         query_str = f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}"
         if starting_timestamp is not None:
             query_str += f"?startingTimestamp={quote(starting_timestamp)}"
@@ -343,20 +344,28 @@ class DataSharingRestClient:
         self,
         target: str,
         data: Optional[Dict[str, Any]] = None,
-        return_headers: bool = False):
+        return_headers: bool = False,
+    ):
         return self._request_internal(
-        request=self._session.get, return_headers=return_headers, target=target, params=data)
+            request=self._session.get, return_headers=return_headers, target=target, params=data)
 
     def _post_internal(
         self,
         target: str,
         data: Optional[Dict[str, Any]] = None,
-        return_headers: bool = False):
+        return_headers: bool = False,
+    ):
         return self._request_internal(
-        request=self._session.post, return_headers=return_headers, target=target, json=data)
+            request=self._session.post, return_headers=return_headers, target=target, json=data)
 
     @contextmanager
-    def _request_internal(self, request, return_headers, target: str, **kwargs) -> Generator[str, None, None]:
+    def _request_internal(
+        self,
+        request,
+        return_headers,
+        target: str,
+        **kwargs,
+    ) -> Generator[str, None, None]:
         assert target.startswith("/"), "Targets should start with '/'"
         response = request(f"{self._profile.endpoint}{target}", **kwargs)
         try:

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -73,7 +73,9 @@ def test_to_pandas_non_partitioned(tmp_path):
                     stats="",
                 ),
             ]
-            return ListFilesInTableResponse(protocol=None, metadata=metadata, add_files=add_files)
+            return ListFilesInTableResponse(
+                delta_table_version=1, protocol=None, metadata=metadata, add_files=add_files
+            )
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.to_pandas()
@@ -126,7 +128,9 @@ def test_to_pandas_partitioned(tmp_path):
                     stats="",
                 ),
             ]
-            return ListFilesInTableResponse(protocol=None, metadata=metadata, add_files=add_files)
+            return ListFilesInTableResponse(
+                delta_table_version=1, protocol=None, metadata=metadata, add_files=add_files
+            )
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.to_pandas()
@@ -184,7 +188,9 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
                     stats="",
                 ),
             ]
-            return ListFilesInTableResponse(protocol=None, metadata=metadata, add_files=add_files)
+            return ListFilesInTableResponse(
+                delta_table_version=1, protocol=None, metadata=metadata, add_files=add_files
+            )
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.to_pandas()
@@ -238,7 +244,9 @@ def test_to_pandas_empty(rest_client: DataSharingRestClient):
                 )
             )
             add_files: Sequence[AddFile] = []
-            return ListFilesInTableResponse(protocol=None, metadata=metadata, add_files=add_files)
+            return ListFilesInTableResponse(
+                delta_table_version=1, protocol=None, metadata=metadata, add_files=add_files
+            )
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock()  # type: ignore

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -170,6 +170,7 @@ def test_query_table_metadata_non_partitioned(rest_client: DataSharingRestClient
     response = rest_client.query_table_metadata(
         Table(name="table1", share="share1", schema="default")
     )
+    assert response.delta_table_version > 1
     assert response.protocol == Protocol(min_reader_version=1)
     assert response.metadata == Metadata(
         id="ed96aa41-1d81-4b7f-8fb5-846878b4b0cf",
@@ -189,6 +190,7 @@ def test_query_table_metadata_partitioned(rest_client: DataSharingRestClient):
     response = rest_client.query_table_metadata(
         Table(name="table2", share="share2", schema="default")
     )
+    assert response.delta_table_version > 1
     assert response.protocol == Protocol(min_reader_version=1)
     assert response.metadata == Metadata(
         id="f8d5c169-3d01-4ca3-ad9e-7dc3355aedb2",
@@ -210,6 +212,7 @@ def test_query_table_metadata_partitioned_different_schemas(
     response = rest_client.query_table_metadata(
         Table(name="table3", share="share1", schema="default")
     )
+    assert response.delta_table_version > 1
     assert response.protocol == Protocol(min_reader_version=1)
     assert response.metadata == Metadata(
         id="7ba6d727-a578-4234-a138-953f790b427c",
@@ -235,6 +238,28 @@ def test_query_existed_table_version(rest_client: DataSharingRestClient):
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
+def test_query_table_version_with_timestamp(rest_client: DataSharingRestClient):
+    response = rest_client.query_table_version(
+        Table(name="cdf_table_cdf_enabled", share="share1", schema="default"),
+        starting_timestamp="2020-01-01 00:00:00.0"
+    )
+    assert isinstance(response.delta_table_version, int)
+    assert response.delta_table_version == 0
+
+
+@pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
+def test_query_table_version_with_timestamp_exception(rest_client: DataSharingRestClient):
+    try:
+        rest_client.query_table_version(
+            Table(name="table1", share="share1", schema="default"),
+            starting_timestamp="2020-01-1 00:00:00.0"
+        )
+    except Exception as e:
+        assert isinstance(e, HTTPError)
+        assert "Reading table by version or timestamp is not supported" in (str(e))
+
+
+@pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_query_nonexistent_table_version(rest_client: DataSharingRestClient):
     with pytest.raises(HTTPError):
         rest_client.query_table_version(
@@ -248,6 +273,7 @@ def test_list_files_in_table_non_partitioned(rest_client: DataSharingRestClient)
         Table(name="table1", share="share1", schema="default"),
         predicateHints=["date = '2021-01-31'"],
     )
+    assert response.delta_table_version > 1
     assert response.protocol == Protocol(min_reader_version=1)
     assert response.metadata == Metadata(
         id="ed96aa41-1d81-4b7f-8fb5-846878b4b0cf",
@@ -295,6 +321,7 @@ def test_list_files_in_table_partitioned(rest_client: DataSharingRestClient):
         predicateHints=["date = '2021-01-31'"],
         limitHint=123,
     )
+    assert response.delta_table_version > 1
     assert response.protocol == Protocol(min_reader_version=1)
     assert response.metadata == Metadata(
         id="f8d5c169-3d01-4ca3-ad9e-7dc3355aedb2",
@@ -342,6 +369,7 @@ def test_list_files_in_table_partitioned_different_schemas(
     response = rest_client.list_files_in_table(
         Table(name="table3", share="share1", schema="default")
     )
+    assert response.delta_table_version > 1
     assert response.protocol == Protocol(min_reader_version=1)
     assert response.metadata == Metadata(
         id="7ba6d727-a578-4234-a138-953f790b427c",
@@ -403,6 +431,7 @@ def test_list_files_in_table_version(
         Table(name="cdf_table_cdf_enabled", share="share1", schema="default"),
         version=1
     )
+    assert response.delta_table_version == 1
     assert response.protocol == Protocol(min_reader_version=1)
     assert response.metadata == Metadata(
         id="16736144-3306-4577-807a-d3f899b77670",

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -243,9 +243,23 @@ class DeltaSharingService(serverConfig: ServerConfig) {
   def getTableVersion(
     @Param("share") share: String,
     @Param("schema") schema: String,
-    @Param("table") table: String): HttpResponse = processRequest {
+    @Param("table") table: String,
+    @Param("startingTimestamp") @Nullable startingTimestamp: String
+  ): HttpResponse = processRequest {
     val tableConfig = sharedTableManager.getTable(share, schema, table)
-    val version = deltaSharedTableLoader.loadTable(tableConfig).tableVersion
+    if (startingTimestamp != null && !tableConfig.cdfEnabled) {
+      throw new DeltaSharingIllegalArgumentException("Reading table by version or timestamp is" +
+        " not supported because change data feed is not enabled on table: " +
+        s"$share.$schema.$table")
+    }
+    val version = deltaSharedTableLoader.loadTable(tableConfig).getTableVersion(
+      Option(startingTimestamp)
+    )
+    if (startingTimestamp != null && version < tableConfig.startVersion) {
+      throw new DeltaSharingIllegalArgumentException(
+        s"You can only query table data since version ${tableConfig.startVersion}."
+      )
+    }
     val headers = createHeadersBuilderForTableVersion(version).build()
     HttpResponse.of(headers)
   }
@@ -310,6 +324,11 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       request.version,
       request.timestamp,
       request.startingVersion)
+    if (version < tableConfig.startVersion) {
+      throw new DeltaSharingIllegalArgumentException(
+        s"You can only query table data since version ${tableConfig.startVersion}."
+      )
+    }
     logger.info(s"Took ${System.currentTimeMillis - start} ms to load the table " +
       s"and sign ${actions.length - 2} urls for table $share/$schema/$table")
     streamingOutput(Some(version), actions)

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -240,6 +240,7 @@ class DeltaSharingService(serverConfig: ServerConfig) {
   }
 
   @Head("/shares/{share}/schemas/{schema}/tables/{table}")
+  @Get("/shares/{share}/schemas/{schema}/tables/{table}")
   def getTableVersion(
     @Param("share") share: String,
     @Param("schema") schema: String,

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -257,7 +257,8 @@ class DeltaSharingService(serverConfig: ServerConfig) {
     )
     if (startingTimestamp != null && version < tableConfig.startVersion) {
       throw new DeltaSharingIllegalArgumentException(
-        s"You can only query table data since version ${tableConfig.startVersion}."
+        s"You can only query table data since version ${tableConfig.startVersion}." +
+        s"The provided timestamp($startingTimestamp) corresponds to $version."
       )
     }
     val headers = createHeadersBuilderForTableVersion(version).build()

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -150,6 +150,9 @@ class DeltaSharedTable(
     }
   }
 
+  /** Get table version at or after startingTimestamp if it's provided, otherwise return
+   *  the latest table version.
+   */
   def getTableVersion(startingTimestamp: Option[String]): Long = withClassLoader {
     if (startingTimestamp.isEmpty) {
       tableVersion

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -150,6 +150,24 @@ class DeltaSharedTable(
     }
   }
 
+  def getTableVersion(startingTimestamp: Option[String]): Long = withClassLoader {
+    if (startingTimestamp.isEmpty) {
+      tableVersion
+    } else {
+      val ts = DeltaSharingHistoryManager.getTimestamp("startingTimestamp", startingTimestamp.get)
+      // get a version at or after the provided timestamp, if the timestamp is early than version 0,
+      // return 0.
+      try {
+        deltaLog.getVersionAtOrAfterTimestamp(ts.getTime())
+      } catch {
+        // Convert to DeltaSharingIllegalArgumentException to return 4xx instead of 5xx error code
+        // Only convert known exceptions around timestamp too late or too early
+        case e: IllegalArgumentException =>
+          throw new DeltaSharingIllegalArgumentException(e.getMessage)
+      }
+    }
+  }
+
   /** Return the current table version */
   def tableVersion: Long = withClassLoader {
     val snapshot = deltaLog.snapshot

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -1108,6 +1108,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       connection.getInputStream()
     }
     assert(e.getMessage.contains(s"Server returned HTTP response code: $expectedErrorCode"))
+    // If the http method is HEAD, error message is not returned from the server.
     assert(method == "HEAD" || IOUtils.toString(connection.getErrorStream()).contains(expectedErrorMessage))
   }
 

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -174,7 +174,7 @@ private[spark] class DeltaSharingRestClient(
     val target =
       getTargetUrl(s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/" +
         s"$encodedTableName$encodedParam")
-    val (version, _) = getResponse(new HttpHead(target))
+    val (version, _) = getResponse(new HttpGet(target))
     version.getOrElse {
       throw new IllegalStateException("Cannot find Delta-Table-Version in the header")
     }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -69,7 +69,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       assert(client.getTableVersion(Table(name = "table1", schema = "default", share = "share1")) == 2)
       assert(client.getTableVersion(Table(name = "table3", schema = "default", share = "share1")) == 4)
       assert(client.getTableVersion(Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),
-        startingTimestamp=Some("2020-01-01 00:00:00")) == 0)
+        startingTimestamp = Some("2020-01-01 00:00:00")) == 0)
     } finally {
       client.close()
     }
@@ -80,7 +80,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     try {
       val errorMessage = intercept[UnexpectedHttpStatus] {
         client.getTableVersion(Table(name = "table1", schema = "default", share = "share1"),
-          startingTimestamp=Some("2020-01-01 00:00:00"))
+          startingTimestamp = Some("2020-01-01 00:00:00"))
       }.getMessage
       assert(errorMessage.contains("400 Bad Request"))
     } finally {

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -83,6 +83,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
           startingTimestamp = Some("2020-01-01 00:00:00"))
       }.getMessage
       assert(errorMessage.contains("400 Bad Request"))
+      assert(errorMessage.contains("Reading table by version or timestamp is not supported"))
     } finally {
       client.close()
     }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -62,12 +62,27 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  integrationTest("getTableVersion") {
+  integrationTest("getTableVersion - success") {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
     try {
       assert(client.getTableVersion(Table(name = "table2", schema = "default", share = "share2")) == 2)
       assert(client.getTableVersion(Table(name = "table1", schema = "default", share = "share1")) == 2)
       assert(client.getTableVersion(Table(name = "table3", schema = "default", share = "share1")) == 4)
+      assert(client.getTableVersion(Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),
+        startingTimestamp=Some("2020-01-01 00:00:00")) == 0)
+    } finally {
+      client.close()
+    }
+  }
+
+  integrationTest("getTableVersion - exceptions") {
+    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
+    try {
+      val errorMessage = intercept[UnexpectedHttpStatus] {
+        client.getTableVersion(Table(name = "table1", schema = "default", share = "share1"),
+          startingTimestamp=Some("2020-01-01 00:00:00"))
+      }.getMessage
+      assert(errorMessage.contains("400 Bad Request"))
     } finally {
       client.close()
     }

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -51,7 +51,7 @@ class TestDeltaSharingClient(
     DeltaTableMetadata(0, Protocol(0), metadata)
   }
 
-  override def getTableVersion(table: Table): Long = 0
+  override def getTableVersion(table: Table, startingTimestamp: Option[String] = None): Long = 0
 
   override def getFiles(
     table: Table,


### PR DESCRIPTION
- Support startingTimestamp for getTableVersion
- Support GET http method for getTableVersion, and update DeltaSharingClient to use GET instead of HEAD
- Update both python and spark python client to issue GET instead of HEAD request for getTableVersion
- in python rest client, include table version in the response for list_files_in_table and query_table_metadata
- Check that queryTable with "timestamp" cannot exceeds TableConfig.startVersion