### PR TITLE
Adds DeltasharingSource

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
@@ -55,6 +55,7 @@ private[sharing] class DeltaSharingDataSource
     deltaLog.createRelation(options.versionAsOf, options.timestampAsOf, options.cdfOptions)
   }
 
+  // Returns the schema of the latest table snapshot.
   override def sourceSchema(
     sqlContext: SQLContext,
     schema: Option[StructType],

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
@@ -65,23 +65,21 @@ private[sharing] class DeltaSharingDataSource
       throw DeltaSharingErrors.specifySchemaAtReadTimeException
     }
     val options = new DeltaSharingOptions(parameters)
-    val path = options.options.getOrElse("path", throw DeltaSharingErrors.pathNotSpecifiedException)
-
-    val deltaLog = RemoteDeltaLog(path)
-
     if (options.isTimeTravel) {
       throw DeltaSharingErrors.timeTravelNotSupportedException
     }
+    if (options.readChangeFeed) {
+      throw DeltaSharingErrors.CDFNotSupportedInStreaming
+    }
 
+    val path = options.options.getOrElse("path", throw DeltaSharingErrors.pathNotSpecifiedException)
+    val deltaLog = RemoteDeltaLog(path)
     val schemaToUse = deltaLog.snapshot().schema
     if (schemaToUse.isEmpty) {
       throw DeltaSharingErrors.schemaNotSetException
     }
-    if (options.readChangeFeed) {
-      throw DeltaSharingErrors.CDFNotSupportedInStreaming
-    } else {
-      (shortName(), schemaToUse)
-    }
+
+    (shortName(), schemaToUse)
   }
 
   override def createSource(

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+object DeltaSharingErrors {
+  def nonExistentDeltaTable(tableId: String): Throwable = {
+    new IllegalStateException(s"Delta table ${tableId} doesn't exist. " +
+      s"Please delete your streaming query checkpoint and restart.")
+  }
+
+  def invalidSourceVersion(version: String): Throwable = {
+    new IllegalStateException(s"sourceVersion($version) is invalid.")
+  }
+
+  def cannotFindSourceVersionException(json: String): Throwable = {
+    new IllegalStateException(s"Cannot find 'sourceVersion' in $json")
+  }
+
+  def unsupportedTableReaderVersion(supportedVersion: Long, tableVersion: Long): Throwable = {
+    new IllegalStateException(s"The table reader version ${tableVersion} is larger than " +
+      s"supported reader version $supportedVersion. Please upgrade to a new release."
+    )
+  }
+
+  def illegalDeltaOptionException(name: String, input: String, explain: String): Throwable = {
+    new IllegalArgumentException(s"Invalid value '$input' for option '$name', $explain")
+  }
+
+  def versionAndTimestampBothSetException(
+    versionOptKey: String,
+    timestampOptKey: String): Throwable = {
+    new IllegalArgumentException(s"Please either provide '$versionOptKey' or '$timestampOptKey'")
+  }
+
+  def CDFNotSupportedInStreaming: Throwable = {
+    new UnsupportedOperationException("CDF is not supported in Delta Sharing Streaming yet.")
+  }
+
+  def deltaSourceIgnoreDeleteError(version: Long): Throwable = {
+    new UnsupportedOperationException("Detected deleted data from streaming source at version " +
+      s"$version. This is currently not supported. If you'd like to ignore deletes, set the " +
+      s"option 'ignoreDeletes' to 'true'.")
+  }
+
+  def deltaSourceIgnoreChangesError(version: Long): Throwable = {
+    new UnsupportedOperationException("Detected a data update in the source table at version " +
+      s"$version. This is currently not supported. If you'd like to ignore updates, set the " +
+      s"option 'ignoreChanges' to 'true'. If you would like the data update to be reflected, " +
+      s"please restart the query from latest snapshot with a fresh checkpoint directory.")
+  }
+
+  def unknownReadLimit(limit: String): Throwable = {
+    new UnsupportedOperationException(s"Unknown ReadLimit: $limit")
+  }
+
+  def specifySchemaAtReadTimeException: Throwable = {
+    new UnsupportedOperationException("Delta sharing does not support specifying the schema at " +
+      "read time.")
+  }
+
+  def pathNotSpecifiedException: Throwable = {
+    new IllegalArgumentException("'path' is not specified. If you use SQL to create a Delta " +
+      "Sharing table, LOCATION must be specified")
+  }
+
+  def timeTravelNotSupportedException: Throwable = {
+    new UnsupportedOperationException("Cannot time travel streams.")
+  }
+
+  def schemaNotSetException: Throwable = {
+    new IllegalStateException("Shared table schema is not set. Please contact your data provider.")
+  }
+}

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+// scalastyle:off import.ordering.noEmptyLine
+import java.util.Locale
+
+import scala.util.Try
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.{ByteUnit, JavaUtils}
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+
+trait DeltaSharingOptionParser {
+  protected def options: CaseInsensitiveMap[String]
+
+  def toBoolean(input: String, name: String): Boolean = {
+    Try(input.toBoolean).toOption.getOrElse {
+      throw DeltaSharingErrors.illegalDeltaOptionException(name, input, "must be 'true' or 'false'")
+    }
+  }
+}
+
+trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
+  import DeltaSharingOptions._
+
+  val maxFilesPerTrigger = options.get(MAX_FILES_PER_TRIGGER_OPTION).map { str =>
+    Try(str.toInt).toOption.filter(_ > 0).getOrElse {
+      throw DeltaSharingErrors.illegalDeltaOptionException(
+        MAX_FILES_PER_TRIGGER_OPTION, str, "must be a positive integer")
+    }
+  }
+
+  val maxBytesPerTrigger = options.get(MAX_BYTES_PER_TRIGGER_OPTION).map { str =>
+    Try(JavaUtils.byteStringAs(str, ByteUnit.BYTE)).toOption.filter(_ > 0).getOrElse {
+      throw DeltaSharingErrors.illegalDeltaOptionException(
+        MAX_BYTES_PER_TRIGGER_OPTION, str, "must be a size configuration such as '10g'")
+    }
+  }
+
+  val ignoreChanges = options.get(IGNORE_CHANGES_OPTION).exists(toBoolean(_, IGNORE_CHANGES_OPTION))
+
+  val ignoreDeletes = options.get(IGNORE_DELETES_OPTION).exists(toBoolean(_, IGNORE_DELETES_OPTION))
+
+  val readChangeFeed = options.get(CDF_READ_OPTION).exists(toBoolean(_, CDF_READ_OPTION)) ||
+    options.get(CDF_READ_OPTION_LEGACY).exists(toBoolean(_, CDF_READ_OPTION_LEGACY))
+
+  val startingVersion: Option[DeltaStartingVersion] = options.get(STARTING_VERSION_OPTION).map {
+    case "latest" => StartingVersionLatest
+    case str =>
+      Try(str.toLong).toOption.filter(_ >= 0).map(StartingVersion).getOrElse{
+        throw DeltaSharingErrors.illegalDeltaOptionException(
+          STARTING_VERSION_OPTION, str, "must be greater than or equal to zero")
+      }
+  }
+
+  val startingTimestamp = options.get(STARTING_TIMESTAMP_OPTION)
+
+  val cdfOptions: Map[String, String] = prepareCdfOptions()
+
+  val versionAsOf = options.get(TIME_TRAVEL_VERSION).map { str =>
+    Try(str.toLong).toOption.filter(_ > 0).getOrElse {
+      throw DeltaSharingErrors.illegalDeltaOptionException(
+        TIME_TRAVEL_VERSION, str, "must be a positive integer")
+    }
+  }
+
+  val timestampAsOf = options.get(TIME_TRAVEL_TIMESTAMP)
+
+  def isTimeTravel: Boolean = versionAsOf.isDefined || timestampAsOf.isDefined
+
+  private def prepareCdfOptions(): Map[String, String] = {
+    if (readChangeFeed) {
+      validCdfOptions.filter(option => options.contains(option._1)).map(option =>
+        option._1 -> options.get(option._1).get
+      )
+    } else {
+      Map.empty[String, String]
+    }
+  }
+
+  private def provideOneStartingOption(): Unit = {
+    if (startingTimestamp.isDefined && startingVersion.isDefined) {
+      throw DeltaSharingErrors.versionAndTimestampBothSetException(
+        STARTING_VERSION_OPTION,
+        STARTING_TIMESTAMP_OPTION)
+    }
+  }
+
+  private def provideOneTimeTravelOption(): Unit = {
+    if (versionAsOf.isDefined && timestampAsOf.isDefined) {
+      throw DeltaSharingErrors.versionAndTimestampBothSetException(
+        TIME_TRAVEL_VERSION,
+        TIME_TRAVEL_TIMESTAMP)
+    }
+  }
+
+  provideOneStartingOption()
+  provideOneTimeTravelOption()
+}
+
+
+/**
+ * Options for the Delta Sharing data source.
+ */
+class DeltaSharingOptions(
+  @transient protected[spark] val options: CaseInsensitiveMap[String])
+  extends DeltaSharingReadOptions with Serializable {
+
+  // skipping verifyOptions(options) as delta sharing client doesn't support log yet.
+
+  def this(options: Map[String, String]) = this(CaseInsensitiveMap(options))
+}
+
+object DeltaSharingOptions extends Logging {
+
+  val MAX_FILES_PER_TRIGGER_OPTION = "maxFilesPerTrigger"
+  val MAX_FILES_PER_TRIGGER_OPTION_DEFAULT = 1000
+  val MAX_BYTES_PER_TRIGGER_OPTION = "maxBytesPerTrigger"
+  val IGNORE_CHANGES_OPTION = "ignoreChanges"
+  val IGNORE_DELETES_OPTION = "ignoreDeletes"
+
+  val STARTING_VERSION_OPTION = "startingVersion"
+  val STARTING_TIMESTAMP_OPTION = "startingTimestamp"
+  val CDF_START_VERSION = "startingVersion"
+  val CDF_START_TIMESTAMP = "startingTimestamp"
+  val CDF_END_VERSION = "endingVersion"
+  val CDF_END_TIMESTAMP = "endingTimestamp"
+  val CDF_READ_OPTION = "readChangeFeed"
+  val CDF_READ_OPTION_LEGACY = "readChangeData"
+
+  val TIME_TRAVEL_VERSION = "versionAsOf"
+  val TIME_TRAVEL_TIMESTAMP = "timestampAsOf"
+
+  val validOptionKeys : Set[String] = Set(
+    IGNORE_CHANGES_OPTION,
+    IGNORE_DELETES_OPTION,
+    STARTING_TIMESTAMP_OPTION,
+    STARTING_VERSION_OPTION,
+    CDF_READ_OPTION,
+    CDF_READ_OPTION_LEGACY,
+    CDF_START_TIMESTAMP,
+    CDF_END_TIMESTAMP,
+    CDF_START_VERSION,
+    CDF_END_VERSION,
+    "queryName",
+    "checkpointLocation",
+    "path",
+    "timestampAsOf",
+    "versionAsOf"
+  )
+
+  val validCdfOptions = Map(
+    CDF_READ_OPTION -> "",
+    CDF_READ_OPTION_LEGACY -> "",
+    CDF_START_TIMESTAMP -> "",
+    CDF_END_TIMESTAMP -> "",
+    CDF_START_VERSION -> "",
+    CDF_END_VERSION -> ""
+  )
+}
+
+/**
+ * Definitions for the starting version of a Delta stream.
+ */
+sealed trait DeltaStartingVersion
+case object StartingVersionLatest extends DeltaStartingVersion
+case class StartingVersion(version: Long) extends DeltaStartingVersion

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -1,0 +1,518 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{DataFrame, DeltaSharingScanUtils, SparkSession}
+
+import org.apache.spark.sql.connector.read.streaming
+import org.apache.spark.sql.connector.read.streaming.{
+  ReadAllAvailable,
+  ReadLimit,
+  ReadMaxFiles,
+  SupportsAdmissionControl
+}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.execution.streaming._
+import org.apache.spark.sql.types.StructType
+
+import io.delta.sharing.spark.model.{AddFile, AddFileForCDF, DeltaTableFiles}
+
+/**
+ * A case class to help with `Dataset` operations regarding Offset indexing, representing AddFile
+ * actions in a Delta log.
+ * For proper offset tracking(move the offset to the next version if all data is consumed in the
+ * current version), there are also special sentinel values with index = -1 and add = null.
+ *
+ * This class is not designed to be persisted in offset logs or such.
+ *
+ * @param version The version of the Delta log containing this AddFile.
+ * @param index The index of this AddFile in the Delta log.
+ * @param add The AddFile.
+ * @param isLast A flag to indicate whether this is the last AddFile in the version. This is used
+ *               to resolve an off-by-one issue in the streaming offset interface; once we've read
+ *               to the end of a log version file, we check this flag to advance immediately to the
+ *               next one in the persisted offset. Without this special case we would re-read the
+ *               already completed log file.
+ */
+private[sharing] case class IndexedFile(
+  version: Long,
+  index: Long,
+  add: AddFile,
+  isLast: Boolean = false) {
+
+  def getFileAction: AddFile = { add }
+}
+
+/**
+ * Base trait for the Delta Sharing Source, that contains methods that deal with
+ * getting changes from the delta sharing server.
+ * TODO(lin.zhou) Support SupportsTriggerAvailableNow
+ */
+trait DeltaSharingSourceBase extends Source
+  with SupportsAdmissionControl
+  with Logging { self: DeltaSharingSource =>
+
+  val snapshot: RemoteSnapshot = deltaLog.snapshot()
+
+  override val schema: StructType = {
+    val schemaWithoutCDC = snapshot.schema
+    if (options.readChangeFeed) {
+      throw DeltaSharingErrors.CDFNotSupportedInStreaming
+    } else {
+      schemaWithoutCDC
+    }
+  }
+
+  protected var sortedFetchedFiles: Seq[IndexedFile] = Seq.empty
+
+  /**
+   * Fetch the changes from delta sharing server starting from (fromVersion, fromIndex).
+   * The start point should not be included in the result, it should be consumed in the last batch.
+   *
+   * If sortedFetchedFiles is not empty, return directly.
+   * Else, fetch file changes from the delta sharing server and store them in sortedFetchedFiles.
+   */
+  protected def getFileChanges(
+    fromVersion: Long,
+    fromIndex: Long,
+    isStartingVersion: Boolean): Unit = {
+    if (!sortedFetchedFiles.isEmpty) { return }
+
+    if (fromVersion > deltaLog.client.getTableVersion(deltaLog.table)) {
+      return
+    }
+
+    def sortAddFile(f1: AddFile, f2: AddFile): Boolean = { f1.url < f2.url }
+
+    def sortAddFileForCDF(f1: AddFileForCDF, f2: AddFileForCDF): Boolean = {
+      f1.version < f2.version || (f1.version == f2.version && f1.url < f2.url)
+    }
+
+    def appendToSortedFetchedFiles(indexedFile: IndexedFile): Unit = {
+      sortedFetchedFiles = sortedFetchedFiles :+ indexedFile
+    }
+
+    if (isStartingVersion) {
+      val tableFiles = deltaLog.client.getFiles(deltaLog.table, Nil, None, Some(fromVersion), None)
+      val numFiles = tableFiles.files.size
+      tableFiles.files.sortWith(sortAddFile).zipWithIndex.foreach{
+        case (file, index) if (index > fromIndex) =>
+          if (sortedFetchedFiles.isEmpty) {
+            // TODO(check if -1 is necessary)
+            appendToSortedFetchedFiles(IndexedFile(fromVersion, -1, null))
+          }
+          appendToSortedFetchedFiles(
+            IndexedFile(fromVersion, index, file, isLast = (index + 1 == numFiles)))
+      }
+    } else {
+      // TODO(lin.zhou) return metadata for each version, and check schema read compatibility
+      val tableFiles = deltaLog.client.getFiles(deltaLog.table, fromVersion)
+      val addFiles = verifyStreamHygieneAndFilterAddFiles(tableFiles)
+      var firstFileForVersion = true
+      addFiles.groupBy(a => a.version).toSeq.sortWith(_._1 < _._1).foreach{
+        case (v, adds) =>
+          firstFileForVersion = true
+          val numFiles = adds.size
+          adds.sortWith(sortAddFileForCDF).zipWithIndex.foreach{
+            case (add, index) if (v > fromVersion || index > fromIndex) =>
+              if (firstFileForVersion) {
+                appendToSortedFetchedFiles(IndexedFile(v, -1, null))
+                firstFileForVersion = false
+              }
+              appendToSortedFetchedFiles(IndexedFile(
+                add.version,
+                index,
+                AddFile(add.url, add.id, add.partitionValues, add.size, add.stats),
+                isLast = (index + 1 == numFiles))
+              )
+          }
+      }
+    }
+  }
+
+  protected def getLastFileChangeWithRateLimit(
+    fromVersion: Long,
+    fromIndex: Long,
+    isStartingVersion: Boolean,
+    limits: Option[AdmissionLimits] = Some(new AdmissionLimits())): Option[IndexedFile] = {
+    if (options.readChangeFeed) {
+      throw DeltaSharingErrors.CDFNotSupportedInStreaming
+    } else {
+      getFileChanges(fromVersion, fromIndex, isStartingVersion)
+
+      if (limits.isEmpty) return sortedFetchedFiles.lastOption
+
+      // Check each change until we've seen the configured number of addFiles. Return the last one
+      // for the caller to build offset.
+      var admissionControl = limits.get
+      var lastFileChange: Option[IndexedFile] = None
+      sortedFetchedFiles.foreach{indexedFile =>
+        if (admissionControl.admit(Option(indexedFile.add))) {
+          lastFileChange = Some(indexedFile)
+        } else {
+          return lastFileChange
+        }
+      }
+
+      lastFileChange
+    }
+  }
+
+  /**
+   * Get the changes from startVersion, startIndex to the endOffset, and create DataFrame
+   * @param startVersion - calculated starting version
+   * @param startIndex - calculated starting index
+   * @param isStartingVersion - whether the stream has to return the initial snapshot or not
+   * @param endOffset - Offset that signifies the end of the stream.
+   * @return
+   */
+  protected def getFileChangesAndCreateDataFrame(
+    startVersion: Long,
+    startIndex: Long,
+    isStartingVersion: Boolean,
+    endOffset: DeltaSharingSourceOffset): DataFrame = {
+    if (options.readChangeFeed) {
+      throw DeltaSharingErrors.CDFNotSupportedInStreaming
+    } else {
+      getFileChanges(startVersion, startIndex, isStartingVersion)
+
+      val fileActions = sortedFetchedFiles.takeWhile {
+        case IndexedFile(version, index, _, _) =>
+          version < endOffset.reservoirVersion ||
+            (version == endOffset.reservoirVersion && index <= endOffset.index)
+      }
+      sortedFetchedFiles = sortedFetchedFiles.drop(fileActions.size)
+
+      // filter out the first indexedFile of each version, where index = -1 and add = null
+      // TODO(check if it's necessary to add a starter file)
+      val filteredIndexedFiles = fileActions.filter { indexedFile =>
+        indexedFile.getFileAction != null
+      }
+
+      createDataFrame(filteredIndexedFiles)
+    }
+  }
+
+  /**
+   * Given an list of file actions, create a DataFrame representing the files added to a table
+   * Only AddFile actions will be used to create the DataFrame.
+   * @param indexedFiles actions list from which to generate the DataFrame.
+   */
+  protected def createDataFrame(indexedFiles: Seq[IndexedFile]): DataFrame = {
+    val addFilesList = indexedFiles.map(_.getFileAction)
+
+    val params = new RemoteDeltaFileIndexParams(spark, snapshot)
+    val fileIndex = new RemoteDeltaBatchFileIndex(params, addFilesList)
+
+    val relation = HadoopFsRelation(
+      fileIndex,
+      partitionSchema = snapshot.partitionSchema,
+      dataSchema = snapshot.schema,
+      bucketSpec = None,
+      snapshot.fileFormat,
+      Map.empty)(spark)
+
+    DeltaSharingScanUtils.ofRows(spark, LogicalRelation(relation, isStreaming = true))
+  }
+
+  /**
+   * Returns the offset that starts from a specific delta table version. This function is
+   * called when starting a new stream query.
+   * @param fromVersion The version of the delta table to calculate the offset from.
+   * @param isStartingVersion Whether the delta version is for the initial snapshot or not.
+   * @param limits Indicates how much data can be processed by a micro batch.
+   */
+  protected def getStartingOffsetFromSpecificDeltaVersion(
+    fromVersion: Long,
+    isStartingVersion: Boolean,
+    limits: Option[AdmissionLimits]): Option[Offset] = {
+    val lastFileChange = getLastFileChangeWithRateLimit(
+      fromVersion,
+      fromIndex = -1L,
+      isStartingVersion = isStartingVersion,
+      limits)
+    if (lastFileChange.isEmpty) {
+      None
+    } else {
+      buildOffsetFromIndexedFile(lastFileChange.get, fromVersion, isStartingVersion)
+    }
+  }
+
+  /**
+   * Return the next offset when previous offset exists.
+   */
+  protected def getNextOffsetFromPreviousOffset(
+    previousOffset: DeltaSharingSourceOffset,
+    limits: Option[AdmissionLimits]): Option[Offset] = {
+    val lastFileChange = getLastFileChangeWithRateLimit(
+      previousOffset.reservoirVersion,
+      previousOffset.index,
+      previousOffset.isStartingVersion,
+      limits)
+
+    if (lastFileChange.isEmpty) {
+      Some(previousOffset)
+    } else {
+      buildOffsetFromIndexedFile(lastFileChange.get, previousOffset.reservoirVersion,
+        previousOffset.isStartingVersion)
+    }
+  }
+
+  /**
+   * Build the latest offset based on the last indexedFile. The function also checks if latest
+   * version is valid by comparing with previous version.
+   * @param indexedFile The last indexed file used to build offset from.
+   * @param version Previous offset reservoir version.
+   * @param isStartingVersion Whether previous offset is starting version or not.
+   */
+  private def buildOffsetFromIndexedFile(
+    indexedFile: IndexedFile,
+    version: Long,
+    isStartingVersion: Boolean): Option[DeltaSharingSourceOffset] = {
+    val IndexedFile(v, i, _, isLastFileInVersion) = indexedFile
+    assert(v >= version,
+      s"buildOffsetFromIndexedFile receives an invalid version: $v (expected: >= $version), " +
+        s"tableId: $tableId")
+
+    // If the last file in previous batch is the last file of that version, automatically bump
+    // to next version to skip accessing that version file altogether.
+    if (isLastFileInVersion) {
+      // isStartingVersion must be false here as we have bumped the version.
+      Some(DeltaSharingSourceOffset(DeltaSharingSourceOffset.VERSION_1, tableId, v + 1, index = -1,
+        isStartingVersion = false))
+    } else {
+      // isStartingVersion will be true only if previous isStartingVersion is true and the next file
+      // is still at the same version (i.e v == version).
+      Some(DeltaSharingSourceOffset(DeltaSharingSourceOffset.VERSION_1, tableId, v, i,
+        isStartingVersion = v == version && isStartingVersion))
+    }
+  }
+}
+
+/**
+ * A streaming source for a Delta Sharing table.
+ *
+ * When a new stream is started, delta sharing starts by constructing a [[RemoteDeltaSnapshot]]
+ * at the current version of the table. This snapshot is broken up into batches until
+ * all existing data has been processed. Subsequent processing is done by tailing
+ * the change log looking for new data. This results in the streaming query returning
+ * the same answer as a batch query that had processed the entire dataset at any given point.
+ */
+case class DeltaSharingSource(
+  spark: SparkSession,
+  deltaLog: RemoteDeltaLog,
+  options: DeltaSharingOptions)
+  extends DeltaSharingSourceBase {
+
+  /** A check on the source table that disallows deletes on the source data. */
+  private val ignoreChanges = options.ignoreChanges
+
+  /** A check on the source table that disallows commits that only include deletes to the data. */
+  private val ignoreDeletes = options.ignoreDeletes || ignoreChanges
+
+  // This is checked before creating ReservoirSource
+  assert(schema.nonEmpty)
+
+  protected val tableId = snapshot.metadata.id
+
+  private var previousOffset: DeltaSharingSourceOffset = null
+
+  protected def verifyStreamHygieneAndFilterAddFiles(
+    tableFiles: DeltaTableFiles): Seq[AddFileForCDF] = {
+    if (!tableFiles.removeFiles.isEmpty) {
+      val groupedRemoveFiles = tableFiles.removeFiles.groupBy(r => r.version)
+      val groupedAddFiles = tableFiles.addFiles.groupBy(a => a.version)
+      groupedRemoveFiles.foreach{
+        case (version, _) =>
+          if (groupedAddFiles.contains(version) && !ignoreChanges) {
+            throw DeltaSharingErrors.deltaSourceIgnoreChangesError(version)
+          } else if (!groupedAddFiles.contains(version) && !ignoreDeletes) {
+            throw DeltaSharingErrors.deltaSourceIgnoreDeleteError(version)
+          }
+      }
+    }
+
+    tableFiles.addFiles
+  }
+
+  private def getStartingOffset(
+    limits: Option[AdmissionLimits] = Some(new AdmissionLimits())): Option[Offset] = {
+
+    val (version, isStartingVersion) = getStartingVersion match {
+      case Some(v) => (v, false)
+      case None => (deltaLog.client.getTableVersion(deltaLog.table), true)
+    }
+    if (version < 0) {
+      return None
+    }
+
+    getStartingOffsetFromSpecificDeltaVersion(version, isStartingVersion, limits)
+  }
+
+  override def getDefaultReadLimit: ReadLimit = {
+    new AdmissionLimits().toReadLimit
+  }
+
+  override def latestOffset(startOffset: streaming.Offset, limit: ReadLimit): streaming.Offset = {
+    val limits = AdmissionLimits(limit)
+
+    val currentOffset = if (previousOffset == null) {
+      getStartingOffset(limits)
+    } else {
+      getNextOffsetFromPreviousOffset(previousOffset, limits)
+    }
+    logDebug(s"previousOffset -> currentOffset: $previousOffset -> $currentOffset")
+    currentOffset.orNull
+  }
+
+  override def getOffset: Option[Offset] = {
+    throw new UnsupportedOperationException(
+      "latestOffset(Offset, ReadLimit) should be called instead of this method")
+  }
+
+  override def getBatch(startOffsetOption: Option[Offset], end: Offset): DataFrame = {
+    val endOffset = DeltaSharingSourceOffset(tableId, end)
+    previousOffset = endOffset // Proceed the offset, and for recovery,
+
+    val (startVersion,
+    startIndex,
+    isStartingVersion,
+    startSourceVersion) = if (startOffsetOption.isEmpty) {
+      getStartingVersion match {
+        case Some(v) =>
+          // startingVersion is provided by the user
+          (v, -1L, false, None)
+
+        case _ =>
+          // startingVersion is NOT provided by the user
+          if (endOffset.isStartingVersion) {
+            // get all files in this version if endOffset is startingVersion
+            (endOffset.reservoirVersion, -1L, true, None)
+          } else {
+            assert(
+              endOffset.reservoirVersion > 0, s"invalid reservoirVersion in endOffset: $endOffset")
+            // Load from snapshot `endOffset.reservoirVersion - 1L` if endOffset is not
+            // startingVersion
+            (endOffset.reservoirVersion - 1L, -1L, true, None)
+          }
+      }
+    } else {
+      val startOffset = DeltaSharingSourceOffset(tableId, startOffsetOption.get)
+      if (startOffset == endOffset) {
+        // This happens only if we recover from a failure and `MicroBatchExecution` tries to call
+        // us with the previous offsets. The returned DataFrame will be dropped immediately, so we
+        // can return any DataFrame.
+        return DeltaSharingScanUtils.internalCreateDataFrame(spark, schema)
+      }
+      (startOffset.reservoirVersion, startOffset.index, startOffset.isStartingVersion,
+        Some(startOffset.sourceVersion))
+    }
+    logDebug(s"start: $startOffsetOption end: $end")
+    val createdDf = getFileChangesAndCreateDataFrame(
+      startVersion, startIndex, isStartingVersion, endOffset
+    )
+
+    createdDf
+  }
+
+  override def stop(): Unit = {}
+
+  override def toString(): String = s"DeltaSharingSource[${deltaLog.table.toString}]"
+
+  trait DeltaSharingSourceAdmissionBase { self: AdmissionLimits =>
+    /** Whether to admit the next file */
+    def admit(addFile: Option[AddFile]): Boolean = {
+      if (addFile.isEmpty) return true
+      val shouldAdmit = filesToTake > 0 && bytesToTake > 0
+      filesToTake -= 1
+
+      bytesToTake -= addFile.get.size
+      shouldAdmit
+    }
+  }
+
+  /**
+   * Class that helps controlling how much data should be processed by a single micro-batch.
+   */
+  class AdmissionLimits(
+    maxFiles: Option[Int] = options.maxFilesPerTrigger,
+    var bytesToTake: Long = options.maxBytesPerTrigger.getOrElse(Long.MaxValue)
+  ) extends DeltaSharingSourceAdmissionBase {
+
+    var filesToTake = maxFiles.getOrElse {
+      if (options.maxBytesPerTrigger.isEmpty) {
+        DeltaSharingOptions.MAX_FILES_PER_TRIGGER_OPTION_DEFAULT
+      } else {
+        Int.MaxValue - 8 // - 8 to prevent JVM Array allocation OOM
+      }
+    }
+
+    def toReadLimit: ReadLimit = {
+      if (options.maxFilesPerTrigger.isDefined && options.maxBytesPerTrigger.isDefined) {
+        CompositeLimit(
+          ReadMaxBytes(options.maxBytesPerTrigger.get),
+          ReadLimit.maxFiles(options.maxFilesPerTrigger.get).asInstanceOf[ReadMaxFiles])
+      } else if (options.maxBytesPerTrigger.isDefined) {
+        ReadMaxBytes(options.maxBytesPerTrigger.get)
+      } else {
+        ReadLimit.maxFiles(
+          options.maxFilesPerTrigger.getOrElse(
+            DeltaSharingOptions.MAX_FILES_PER_TRIGGER_OPTION_DEFAULT))
+      }
+    }
+  }
+
+  object AdmissionLimits {
+    def apply(limit: ReadLimit): Option[AdmissionLimits] = limit match {
+      case _: ReadAllAvailable => None
+      case maxFiles: ReadMaxFiles => Some(new AdmissionLimits(Some(maxFiles.maxFiles())))
+      case maxBytes: ReadMaxBytes => Some(new AdmissionLimits(None, maxBytes.maxBytes))
+      case composite: CompositeLimit =>
+        Some(new AdmissionLimits(Some(composite.files.maxFiles()), composite.bytes.maxBytes))
+      case other => throw DeltaSharingErrors.unknownReadLimit(other.toString())
+    }
+  }
+
+  /**
+   * Extracts whether users provided the option to time travel a relation. If a query restarts from
+   * a checkpoint and the checkpoint has recorded the offset, this method should never been called.
+   */
+  protected lazy val getStartingVersion: Option[Long] = {
+    /** DeltaOption validates input and ensures that only one is provided. */
+    if (options.startingVersion.isDefined) {
+      val v = options.startingVersion.get match {
+        case StartingVersionLatest =>
+          deltaLog.client.getTableVersion(deltaLog.table) + 1
+        case StartingVersion(version) =>
+          version
+      }
+      Some(v)
+    } else if (options.startingTimestamp.isDefined) {
+      throw new UnsupportedOperationException("startingTimestamp is not supported yet")
+    } else {
+      None
+    }
+  }
+}
+
+/** A read limit that admits a soft-max of `maxBytes` per micro-batch. */
+case class ReadMaxBytes(maxBytes: Long) extends ReadLimit
+
+/** A read limit that admits the given soft-max of `bytes` or max `files`. */
+case class CompositeLimit(bytes: ReadMaxBytes, files: ReadMaxFiles) extends ReadLimit

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -491,7 +491,7 @@ case class DeltaSharingSource(
   class AdmissionLimits(
     maxFiles: Option[Int] = options.maxFilesPerTrigger,
     var bytesToTake: Long = options.maxBytesPerTrigger.getOrElse(Long.MaxValue)
-  ) extends DeltaSharingSourceAdmissionBase {
+  ) {
 
     var filesToTake = maxFiles.getOrElse {
       if (options.maxBytesPerTrigger.isEmpty) {

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSourceOffset.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSourceOffset.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.connector.read.streaming.{Offset => OffsetV2}
+import org.apache.spark.sql.execution.streaming.{Offset, SerializedOffset}
+import org.json4s._
+import org.json4s.jackson.JsonMethods.parse
+
+import io.delta.sharing.spark.util.JsonUtils
+
+/**
+ * Tracks how far we processed in when reading changes from the [[Delta Sharing Server]].
+ *
+ * Note this class retains the naming of `Reservoir` to maintain compatibility
+ * with serialized offsets from the beta period.
+ *
+ * @param sourceVersion     The version of serialization that this offset is encoded with.
+ * @param reservoirId       The id of the table we are reading from. Used to detect
+ *                          misconfiguration when restarting a query.
+ * @param reservoirVersion  The version of the table that we are current processing.
+ * @param index             The index in the sequence of AddFiles in this version. Used to
+ *                          break large commits into multiple batches. This index is created by
+ *                          sorting on modificationTimestamp and path.
+ * @param isStartingVersion Whether this offset denotes a query that is starting rather than
+ *                          processing changes. When starting a new query, we first process
+ *                          all data present in the table at the start and then move on to
+ *                          processing new data that has arrived.
+ */
+case class DeltaSharingSourceOffset(
+  sourceVersion: Long,
+  reservoirId: String,
+  reservoirVersion: Long,
+  index: Long,
+  isStartingVersion: Boolean
+) extends Offset {
+
+  override def json: String = JsonUtils.toJson(this)
+
+  /**
+   * Compare two DeltaSharingSourceOffsets which are on the same table.
+   * @return 0 for equivalent offsets. negative if this offset is less than `otherOffset`. Positive
+   *         if this offset is greater than `otherOffset`
+   */
+  def compare(otherOffset: DeltaSharingSourceOffset): Int = {
+    assert(reservoirId == otherOffset.reservoirId, "Comparing offsets that do not refer to the" +
+      " same table is disallowed.")
+    implicitly[Ordering[(Long, Long)]].compare((reservoirVersion, index),
+      (otherOffset.reservoirVersion, otherOffset.index))
+  }
+}
+
+object DeltaSharingSourceOffset {
+
+  val VERSION_1 = 1
+
+  def apply(
+    sourceVersion: Long,
+    reservoirId: String,
+    reservoirVersion: Long,
+    index: Long,
+    isStartingVersion: Boolean
+  ): DeltaSharingSourceOffset = {
+    new DeltaSharingSourceOffset(
+      sourceVersion,
+      reservoirId,
+      reservoirVersion,
+      index,
+      isStartingVersion
+    )
+  }
+
+  def apply(reservoirId: String, offset: OffsetV2): DeltaSharingSourceOffset = {
+    offset match {
+      case o: DeltaSharingSourceOffset => o
+      case s =>
+        validateSourceVersion(s.json)
+        val o = JsonUtils.fromJson[DeltaSharingSourceOffset](s.json)
+        if (o.reservoirId != reservoirId) {
+          throw DeltaSharingErrors.nonExistentDeltaTable(o.reservoirId)
+        }
+        o
+    }
+  }
+
+  private def validateSourceVersion(json: String): Unit = {
+    val parsedJson = parse(json)
+    val versionOpt = jsonOption(parsedJson \ "sourceVersion").map {
+      case i: JInt => i.num.longValue
+      case other => throw DeltaSharingErrors.invalidSourceVersion(other.toString)
+    }
+    if (versionOpt.isEmpty) {
+      throw DeltaSharingErrors.cannotFindSourceVersionException(json)
+    }
+
+    val maxVersion = VERSION_1
+
+    if (versionOpt.get > maxVersion) {
+      throw DeltaSharingErrors.unsupportedTableReaderVersion(maxVersion, versionOpt.get)
+    }
+  }
+
+  /** Return an option that translates JNothing to None */
+  private def jsonOption(json: JValue): Option[JValue] = {
+    json match {
+      case JNothing => None
+      case value: JValue => Some(value)
+    }
+  }
+}

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -41,9 +41,9 @@ import io.delta.sharing.spark.perf.DeltaSharingLimitPushDown
 
 /** Used to query the current state of the transaction logs of a remote shared Delta table. */
 private[sharing] class RemoteDeltaLog(
-    table: DeltaSharingTable,
-    path: Path,
-    client: DeltaSharingClient) {
+  val table: DeltaSharingTable,
+  val path: Path,
+  val client: DeltaSharingClient) {
 
   @volatile private var currentSnapshot: RemoteSnapshot = new RemoteSnapshot(path, client, table)
 

--- a/spark/src/main/scala/io/delta/sharing/spark/model.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/model.scala
@@ -54,7 +54,9 @@ private[sharing] case class Share(name: String)
 
 private[sharing] case class Schema(name: String, share: String)
 
-private[sharing] case class Table(name: String, schema: String, share: String)
+private[sharing] case class Table(name: String, schema: String, share: String) {
+  override def toString(): String = { s"$share.$schema.$name" }
+}
 
 private[sharing] case class SingleAction(
     file: AddFile = null,

--- a/spark/src/main/scala/org/apache/spark/sql/DeltaSharingScanUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/DeltaSharingScanUtils.scala
@@ -16,12 +16,20 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.types.StructType
 
 object DeltaSharingScanUtils {
   // A wrapper to expose Dataset.ofRows function.
   // This is needed because Dataset object is in private[sql] scope.
   def ofRows(spark: SparkSession, plan: LogicalRelation): DataFrame = {
     Dataset.ofRows(spark, plan)
+  }
+
+  // A wraper to expose sqlContext.internalCreateDataFrame
+  def internalCreateDataFrame(spark: SparkSession, schema: StructType): DataFrame = {
+    spark.sqlContext.internalCreateDataFrame(
+      spark.sparkContext.emptyRDD[InternalRow], schema, isStreaming = true)
   }
 }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingIntegrationTest.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingIntegrationTest.scala
@@ -99,6 +99,7 @@ trait DeltaSharingIntegrationTest extends SparkFunSuite with BeforeAndAfterAll {
   override def afterAll(): Unit = {
     if (shouldRunIntegrationTest) {
       try {
+        org.apache.hadoop.fs.FileSystem.closeAll()
         if (process != null) {
           process.destroy()
           process = null

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -1,0 +1,410 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+import java.util.UUID
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.read.streaming.ReadMaxFiles
+import org.apache.spark.sql.execution.streaming.SerializedOffset
+import org.apache.spark.sql.streaming.{DataStreamReader, StreamingQueryException, Trigger}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{StringType, StructField, StructType, TimestampType}
+import org.scalatest.time.SpanSugar._
+
+class DeltaSharingSourceSuite extends QueryTest
+  with SharedSparkSession with DeltaSharingIntegrationTest {
+
+  import testImplicits._
+
+  lazy val tablePath = testProfileFile.getCanonicalPath + "#share1.default.cdf_table_cdf_enabled"
+
+  lazy val deltaLog = RemoteDeltaLog(tablePath)
+
+  val streamingTimeout = 60.seconds
+
+  def getSource(parameters: Map[String, String]): DeltaSharingSource = {
+
+    val options = new DeltaSharingOptions(parameters)
+
+    DeltaSharingSource(SparkSession.active, deltaLog, options)
+  }
+
+  def withStreamReaderAtVersion(startingVersion: String = "0"): DataStreamReader = {
+    spark.readStream.format("deltaSharing").option("path", tablePath)
+      .option("startingVersion", startingVersion)
+      .option("ignoreDeletes", "true")
+      .option("ignoreChanges", "true")
+  }
+
+  // TODO: add test on a shared table without schema
+  // TODO: support dir so we can test checkpoint, restart the stream, etc.
+  // TODO: test TriggerAvailableNow
+
+  /**
+   * Test defaultReadLimit
+   */
+  integrationTest("DeltaSharingSource - defaultLimit") {
+    val source = getSource(Map.empty[String, String])
+
+    val defaultLimit = source.getDefaultReadLimit
+    assert(defaultLimit.isInstanceOf[ReadMaxFiles])
+    assert(defaultLimit.asInstanceOf[ReadMaxFiles].maxFiles ==
+      DeltaSharingOptions.MAX_FILES_PER_TRIGGER_OPTION_DEFAULT)
+  }
+
+  /**
+   * Test latestOffset
+   */
+  integrationTest("DeltaSharingSource.latestOffset - startingVersion 0") {
+    val source = getSource(Map(
+      "ignoreChanges" -> "true",
+      "ignoreDeletes" -> "true",
+      "startingVersion" -> "0"
+    ))
+    val latestOffset = source.latestOffset(null, source.getDefaultReadLimit)
+
+    assert(latestOffset.isInstanceOf[DeltaSharingSourceOffset])
+    val offset = latestOffset.asInstanceOf[DeltaSharingSourceOffset]
+    assert(offset.sourceVersion == 1)
+    assert(offset.reservoirId == deltaLog.snapshot(Some(0)).metadata.id)
+    assert(offset.reservoirVersion == 4)
+    assert(offset.index == -1)
+    assert(!offset.isStartingVersion)
+  }
+
+  integrationTest("DeltaSharingSource.lastestOffset - startingVersion latest") {
+    val source = getSource(Map(
+      "ignoreChanges" -> "true",
+      "ignoreDeletes" -> "true",
+      "startingVersion" -> "latest"
+    ))
+    val latestOffset = source.latestOffset(null, source.getDefaultReadLimit)
+    assert(latestOffset == null)
+  }
+
+  integrationTest("DeltaSharingSource.latestOffset - no startingVersion") {
+    val source = getSource(Map(
+      "ignoreChanges" -> "true",
+      "ignoreDeletes" -> "true"
+    ))
+    val latestOffset = source.latestOffset(null, source.getDefaultReadLimit)
+
+    assert(latestOffset.isInstanceOf[DeltaSharingSourceOffset])
+    val offset = latestOffset.asInstanceOf[DeltaSharingSourceOffset]
+    assert(offset.sourceVersion == 1)
+    assert(offset.reservoirId == deltaLog.snapshot().metadata.id)
+    assert(offset.reservoirVersion == 6)
+    assert(offset.index == -1)
+    assert(!offset.isStartingVersion)
+  }
+
+  /**
+   * Test getBatch
+   */
+  integrationTest("DeltaSharingSource.getBatch - exception") {
+    // getBatch cannot be called without writestream
+  }
+
+  /**
+   * Test schema exception
+   */
+  integrationTest("disallow user specified schema") {
+    var message = intercept[UnsupportedOperationException] {
+      val query = spark.readStream.format("deltaSharing").option("path", tablePath)
+        .schema(StructType(Array(StructField("a", TimestampType), StructField("b", StringType))))
+        .load()
+    }.getMessage
+    assert(message.contains("Delta sharing does not support specifying the schema at read time"))
+  }
+
+  /**
+   * Test basic streaming functionality
+   */
+  integrationTest("basic - success") {
+    val query = withStreamReaderAtVersion()
+      .load().writeStream.format("console").start()
+
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === 1)
+      progress.foreach { p =>
+        assert(p.numInputRows === 4)
+      }
+    } finally {
+      query.stop()
+    }
+  }
+
+  /**
+   * Test maxFilesPerTrigger and maxBytesPerTrigger
+   */
+  integrationTest("maxFilesPerTrigger - success") {
+    val query = withStreamReaderAtVersion()
+      .option("maxFilesPerTrigger", "1")
+      .load().writeStream.format("console").start()
+
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === 4)
+      progress.foreach { p =>
+        assert(p.numInputRows === 1)
+      }
+    } finally {
+      query.stop()
+    }
+  }
+
+  testQuietly("maxFilesPerTrigger - invalid parameter") {
+    Seq("0", "-1", "string").foreach { invalidMaxFilesPerTrigger =>
+      val e = intercept[IllegalArgumentException] {
+        val query = withStreamReaderAtVersion()
+          .option("maxFilesPerTrigger", invalidMaxFilesPerTrigger)
+          .load().writeStream.format("console").start()
+      }
+      for (msg <- Seq("Invalid", DeltaSharingOptions.MAX_FILES_PER_TRIGGER_OPTION, "positive")) {
+        assert(e.getMessage.contains(msg))
+      }
+    }
+  }
+
+  test("maxFilesPerTrigger - ignored when using Trigger.Once") {
+    val query = withStreamReaderAtVersion()
+      .option("maxFilesPerTrigger", "1")
+      .load().writeStream.format("console")
+      .trigger(Trigger.Once)
+      .start()
+
+    try {
+      assert(query.awaitTermination(streamingTimeout.toMillis))
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === 1) // only one trigger was run
+      progress.foreach { p =>
+        assert(p.numInputRows === 4)
+      }
+    } finally {
+      query.stop()
+    }
+  }
+
+  integrationTest("maxBytesPerTrigger - at least one file") {
+    val query = withStreamReaderAtVersion()
+      .option("maxBytesPerTrigger", "1b")
+      .load().writeStream.format("console").start()
+
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === 4)
+      progress.foreach { p =>
+        assert(p.numInputRows === 1)
+      }
+    } finally {
+      query.stop()
+    }
+  }
+
+  testQuietly("maxBytesPerTrigger - invalid parameter") {
+    Seq("0", "-1", "string").foreach { invalidMaxFilesPerTrigger =>
+      val e = intercept[IllegalArgumentException] {
+        val query = withStreamReaderAtVersion()
+          .option("maxBytesPerTrigger", invalidMaxFilesPerTrigger)
+          .load().writeStream.format("console").start()
+      }
+      for (msg <- Seq("Invalid", DeltaSharingOptions.MAX_BYTES_PER_TRIGGER_OPTION, "size")) {
+        assert(e.getMessage.contains(msg))
+      }
+    }
+  }
+
+  test("maxBytesPerTrigger - ignored when using Trigger.Once") {
+    val query = withStreamReaderAtVersion()
+      .option("maxBytesPerTrigger", "1b")
+      .load().writeStream.format("console")
+      .trigger(Trigger.Once)
+      .start()
+
+    try {
+      assert(query.awaitTermination(streamingTimeout.toMillis))
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === 1) // only one trigger was run
+      progress.foreach { p =>
+        assert(p.numInputRows === 4)
+      }
+    } finally {
+      query.stop()
+    }
+  }
+
+  test("maxBytesPerTrigger - max bytes and max files together") {
+    val q = withStreamReaderAtVersion()
+      .option(DeltaSharingOptions.MAX_FILES_PER_TRIGGER_OPTION, "1") // should process a file at a time
+      .option(DeltaSharingOptions.MAX_BYTES_PER_TRIGGER_OPTION, "100gb")
+      .load().writeStream.format("console").start()
+    try {
+      q.processAllAvailable()
+      val progress = q.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === 4)
+      progress.foreach { p =>
+        assert(p.numInputRows === 1)
+      }
+    } finally {
+      q.stop()
+    }
+
+    val q2 = withStreamReaderAtVersion()
+      .option(DeltaSharingOptions.MAX_FILES_PER_TRIGGER_OPTION, "2")
+      .option(DeltaSharingOptions.MAX_BYTES_PER_TRIGGER_OPTION, "1b")
+      .load().writeStream.format("console").start()
+    try {
+      q2.processAllAvailable()
+      val progress = q2.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === 4)
+      progress.foreach { p =>
+        assert(p.numInputRows === 1)
+      }
+    } finally {
+      q2.stop()
+    }
+  }
+
+  /**
+   * Test ignoreChanges/ignoreDeletes
+   */
+  integrationTest("ignoreDeletes/ignoreChanges - are needed to process deletes/updates") {
+    // There are deletes at version 2 of cdf_table_cdf_enabled
+    val tablePath = testProfileFile.getCanonicalPath + "#share1.default.cdf_table_cdf_enabled"
+    var query = spark.readStream.format("deltaSharing").option("path", tablePath)
+      .option("startingVersion", "0")
+      .load().writeStream.format("console").start()
+    var errorMessage = intercept[StreamingQueryException] {
+      query.awaitTermination() // block until query is terminated, with stop() or with error
+    }.getMessage
+    assert(errorMessage.contains("Detected deleted data from streaming source at version 2"))
+
+    // There are updates at version 3 of cdf_table_cdf_enabled
+    query = spark.readStream.format("deltaSharing").option("path", tablePath)
+      .option("startingVersion", "0")
+      .option("ignoreDeletes", "true")
+      .load().writeStream.format("console").start()
+    errorMessage = intercept[StreamingQueryException] {
+      query.awaitTermination() // block until query is terminated, with stop() or with error
+    }.getMessage
+    assert(errorMessage.contains("Detected a data update in the source table at version 3"))
+  }
+
+  /**
+   * Test readChangeFeed/readchangeData
+   */
+  integrationTest("readChangeFeed/readchangeData - not supported yet") {
+    var errorMessage = intercept[UnsupportedOperationException] {
+      val query = spark.readStream.format("deltaSharing").option("path", tablePath)
+        .option("startingVersion", "0")
+        .option("readChangeFeed", "true")
+        .load().writeStream.format("console").start()
+    }.getMessage
+    assert(errorMessage.contains("CDF is not supported in Delta Sharing Streaming yet"))
+
+    errorMessage = intercept[UnsupportedOperationException] {
+      val query = spark.readStream.format("deltaSharing").option("path", tablePath)
+        .option("startingVersion", "0")
+        .option("readChangeData", "true")
+        .load().writeStream.format("console").start()
+    }.getMessage
+    assert(errorMessage.contains("CDF is not supported in Delta Sharing Streaming yet"))
+  }
+
+  /**
+   * Test startingVersion/startingTimestamp
+   */
+  integrationTest("startingVersion/startingTimestamp - exceptions") {
+    Seq("-1", "string").foreach { invalidStartingVersion =>
+      val errorMessage = intercept[IllegalArgumentException] {
+        val query = spark.readStream.format("deltaSharing").option("path", tablePath)
+          .option("startingVersion", invalidStartingVersion)
+          .load().writeStream.format("console").start()
+      }.getMessage
+      for (msg <- Seq("Invalid", DeltaSharingOptions.STARTING_VERSION_OPTION, "greater")) {
+        assert(errorMessage.contains(msg))
+      }
+    }
+
+
+    var errorMessage = intercept[StreamingQueryException] {
+      val query = spark.readStream.format("deltaSharing").option("path", tablePath)
+        .option("startingTimestamp", "-1")
+        .load().writeStream.format("console").start()
+      query.awaitTermination(streamingTimeout.toMillis)
+    }.getMessage
+    assert(errorMessage.contains("startingTimestamp is not supported yet"))
+  }
+
+  integrationTest("startingVersion - succeeds") {
+    var query = withStreamReaderAtVersion("1")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === 1)
+      progress.foreach { p =>
+        assert(p.numInputRows === 4)
+      }
+    } finally {
+      query.stop()
+    }
+
+    query = withStreamReaderAtVersion("2")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === 1)
+      progress.foreach { p =>
+        assert(p.numInputRows === 1)
+      }
+    } finally {
+      query.stop()
+    }
+
+    query = withStreamReaderAtVersion("3")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === 1)
+      progress.foreach { p =>
+        assert(p.numInputRows === 1)
+      }
+    } finally {
+      query.stop()
+    }
+
+    // there are 3 versions in total
+    query = withStreamReaderAtVersion("4")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === 0)
+    } finally {
+      query.stop()
+    }
+  }
+}

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -374,6 +374,25 @@ class DeltaSharingSourceSuite extends QueryTest
   }
 
   /**
+   * Test versionAsOf/timestampAsOf
+   */
+  integrationTest("versionAsOf/timestampAsOf - not supported") {
+    var message = intercept[UnsupportedOperationException] {
+      val query = spark.readStream.format("deltaSharing").option("path", tablePath)
+        .option("versionAsOf", "1")
+        .load().writeStream.format("console").start()
+    }.getMessage
+    assert(message.contains("Cannot time travel streams"))
+
+    message = intercept[UnsupportedOperationException] {
+      val query = spark.readStream.format("deltaSharing").option("path", tablePath)
+        .option("timestampAsOf", "2022-10-01 00:00:00.0")
+        .load().writeStream.format("console").start()
+    }.getMessage
+    assert(message.contains("Cannot time travel streams"))
+  }
+
+  /**
    * Test startingVersion/startingTimestamp
    */
   integrationTest("startingVersion/startingTimestamp - exceptions") {

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -18,6 +18,7 @@ package io.delta.sharing.spark
 
 import java.util.UUID
 
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.read.streaming.ReadMaxFiles
@@ -25,8 +26,6 @@ import org.apache.spark.sql.execution.streaming.SerializedOffset
 import org.apache.spark.sql.streaming.{DataStreamReader, StreamingQueryException, Trigger}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructField, StructType, TimestampType}
-import org.apache.spark.sql.AnalysisException
-
 import org.scalatest.time.SpanSugar._
 
 class DeltaSharingSourceSuite extends QueryTest
@@ -297,8 +296,9 @@ class DeltaSharingSourceSuite extends QueryTest
   }
 
   test("maxBytesPerTrigger - max bytes and max files together") {
+    // should process one file at a time
     val q = withStreamReaderAtVersion()
-      .option(DeltaSharingOptions.MAX_FILES_PER_TRIGGER_OPTION, "1") // should process a file at a time
+      .option(DeltaSharingOptions.MAX_FILES_PER_TRIGGER_OPTION, "1")
       .option(DeltaSharingOptions.MAX_BYTES_PER_TRIGGER_OPTION, "100gb")
       .load().writeStream.format("console").start()
     try {

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -185,6 +185,8 @@ class DeltaSharingSourceSuite extends QueryTest
    * Test maxFilesPerTrigger and maxBytesPerTrigger
    */
   integrationTest("maxFilesPerTrigger - success with different values") {
+    // Map from maxFilesPerTrigger to a list, the size of the list is the number of progresses of
+    // the stream query, and each element in the list is the numInputRows for each progress.
     Map(1 -> Seq(1, 1, 1, 1), 2 -> Seq(2, 2), 3 -> Seq(3, 1), 4 -> Seq(4), 5 -> Seq(4)).foreach{
       case (k, v) =>
         val query = withStreamReaderAtVersion()
@@ -237,6 +239,8 @@ class DeltaSharingSourceSuite extends QueryTest
   }
 
   integrationTest("maxBytesPerTrigger - at least one file") {
+    // Map from maxBytesPerTrigger to a list, the size of the list is the number of progresses of
+    // the stream query, and each element in the list is the numInputRows for each progress.
     Map(1 -> Seq(1, 1, 1, 1), 1000 -> Seq(1, 1, 1, 1), 2000 -> Seq(2, 2),
       3000 -> Seq(3, 1), 4000 -> Seq(4), 5000 -> Seq(4)).foreach {
       case (k, v) =>


### PR DESCRIPTION
Adds DeltasharingSource, similar to DeltaSource, supports streaming addfiles, 

- local cache: sortedFetchedFiles
- 30 seconds interval is added for getTableVersion
- ignoreChanges/ignoreDeletes/maxFilesPerTrigger/maxBytesPerTrigger are supported

Not in this PR, will be supported in a separate PR
- readChangeFeed/readChangeData
- read compatibility check on schema
- SupportsTriggerAvailableNow
- startingTimestamp