### PR TITLE
Return metadata for each table version on queryTable with startingVersion 

### DIFF
--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -53,6 +53,7 @@ def test_list_shares(sharing_client: SharingClient):
         Share(name="share7"),
         Share(name="share_azure"),
         Share(name="share_gcp"),
+        Share(name="share8")
     ]
 
 
@@ -71,13 +72,7 @@ def test_list_tables(sharing_client: SharingClient):
     assert tables == [
         Table(name="table1", share="share1", schema="default"),
         Table(name="table3", share="share1", schema="default"),
-        Table(name="table7", share="share1", schema="default"),
-        Table(name="cdf_table_cdf_enabled", share="share1", schema="default"),
-        Table(name="cdf_table_with_partition", share="share1", schema="default"),
-        Table(name="cdf_table_with_vacuum", share="share1", schema="default"),
-        Table(name="cdf_table_missing_log", share="share1", schema="default"),
-        Table(name="streaming_table_with_optimize", share="share1", schema="default"),
-        Table(name="table_reader_version_increased", share="share1", schema="default"),
+        Table(name="table7", share="share1", schema="default")
     ]
 
     tables = sharing_client.list_tables(Schema(name="default", share="share2"))
@@ -89,12 +84,6 @@ def _verify_all_tables_result(tables: Sequence[Table]):
         Table(name="table1", share="share1", schema="default"),
         Table(name="table3", share="share1", schema="default"),
         Table(name="table7", share="share1", schema="default"),
-        Table(name="cdf_table_cdf_enabled", share="share1", schema="default"),
-        Table(name="cdf_table_with_partition", share="share1", schema="default"),
-        Table(name="cdf_table_with_vacuum", share="share1", schema="default"),
-        Table(name="cdf_table_missing_log", share="share1", schema="default"),
-        Table(name="streaming_table_with_optimize", share="share1", schema="default"),
-        Table(name="table_reader_version_increased", share="share1", schema="default"),
         Table(name="table2", share="share2", schema="default"),
         Table(name="table4", share="share3", schema="default"),
         Table(name="table5", share="share3", schema="default"),
@@ -104,6 +93,13 @@ def _verify_all_tables_result(tables: Sequence[Table]):
         Table(name="table_wasb", share="share_azure", schema="default"),
         Table(name="table_abfs", share="share_azure", schema="default"),
         Table(name="table_gcs", share="share_gcp", schema="default"),
+        Table(name="cdf_table_cdf_enabled", share="share8", schema="default"),
+        Table(name="cdf_table_with_partition", share="share8", schema="default"),
+        Table(name="cdf_table_with_vacuum", share="share8", schema="default"),
+        Table(name="cdf_table_missing_log", share="share8", schema="default"),
+        Table(name="streaming_table_with_optimize", share="share8", schema="default"),
+        Table(name="streaming_table_metadata_protocol", share="share8", schema="default"),
+        Table(name="table_reader_version_increased", share="share8", schema="default")
     ]
 
 
@@ -272,7 +268,7 @@ def test_list_all_tables_with_fallback(profile: DeltaSharingProfile):
             id="limit 4",
         ),
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             None,
             None,
             pd.DataFrame(
@@ -285,7 +281,7 @@ def test_list_all_tables_with_fallback(profile: DeltaSharingProfile):
             id="cdf_table_cdf_enabled",
         ),
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             None,
             1,
             pd.DataFrame(
@@ -388,14 +384,14 @@ def test_load_as_pandas_success(
             id="timestamp not supported",
         ),
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             1,
             "random_timestamp",
             "Please only provide one of",
             id="only one is supported",
         ),
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             None,
             "2000-01-01 00:00:00",
             "Please use a timestamp greater",
@@ -423,7 +419,7 @@ def test_load_as_pandas_exception(
     "fragments,starting_version,ending_version,starting_timestamp,ending_timestamp,error,expected",
     [
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             0,
             3,
             None,
@@ -463,7 +459,7 @@ def test_load_as_pandas_exception(
             id="cdf_table_cdf_enabled table changes:[0, 3]",
         ),
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             5,
             None,
             None,
@@ -482,7 +478,7 @@ def test_load_as_pandas_exception(
             id="cdf_table_cdf_enabled table changes:[5, ]",
         ),
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             None,
             None,
             "2000-01-01 00:00:00",
@@ -492,7 +488,7 @@ def test_load_as_pandas_exception(
             id="cdf_table_cdf_enabled table changes with starting_timestamp",
         ),
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             0,
             None,
             None,
@@ -599,7 +595,7 @@ def test_parse_url():
             id="table1 timestamp not supported",
         ),
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             1,
             None,
             None,
@@ -612,7 +608,7 @@ def test_parse_url():
             id="cdf_table_cdf_enabled version 1 spark",
         ),
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             None,
             "2000-01-01 00:00:00",
             "Please use a timestamp greater",
@@ -621,7 +617,7 @@ def test_parse_url():
             id="cdf_table_cdf_enabled timestamp too early",
         ),
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             1,
             "2000-01-01 00:00:00",
             "Please either provide",
@@ -673,7 +669,7 @@ def test_load_as_spark(
     "expected_data,expected_schema_str",
     [
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             0,
             3,
             None,
@@ -692,7 +688,7 @@ def test_load_as_spark(
             id="cdf_table_cdf_enabled table changes",
         ),
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             None,
             None,
             "2000-01-01 00:00:00",
@@ -703,7 +699,7 @@ def test_load_as_spark(
             id="cdf_table_cdf_enabled starting_timestamp correctly passed",
         ),
         pytest.param(
-            "share1.default.cdf_table_cdf_enabled",
+            "share8.default.cdf_table_cdf_enabled",
             0,
             None,
             None,

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -99,6 +99,7 @@ def _verify_all_tables_result(tables: Sequence[Table]):
         Table(name="cdf_table_missing_log", share="share8", schema="default"),
         Table(name="streaming_table_with_optimize", share="share8", schema="default"),
         Table(name="streaming_table_metadata_protocol", share="share8", schema="default"),
+        Table(name="streaming_table_read_incompatible", share="share8", schema="default"),
         Table(name="table_reader_version_increased", share="share8", schema="default")
     ]
 

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -113,6 +113,7 @@ def test_list_shares(rest_client: DataSharingRestClient):
         Share(name="share7"),
         Share(name="share_azure"),
         Share(name="share_gcp"),
+        Share(name="share8")
     ]
 
 
@@ -131,13 +132,7 @@ def test_list_tables(rest_client: DataSharingRestClient):
     assert response.tables == [
         Table(name="table1", share="share1", schema="default"),
         Table(name="table3", share="share1", schema="default"),
-        Table(name="table7", share="share1", schema="default"),
-        Table(name="cdf_table_cdf_enabled", share="share1", schema="default"),
-        Table(name="cdf_table_with_partition", share="share1", schema="default"),
-        Table(name="cdf_table_with_vacuum", share="share1", schema="default"),
-        Table(name="cdf_table_missing_log", share="share1", schema="default"),
-        Table(name="streaming_table_with_optimize", share="share1", schema="default"),
-        Table(name="table_reader_version_increased", share="share1", schema="default"),
+        Table(name="table7", share="share1", schema="default")
     ]
 
     response = rest_client.list_tables(Schema(name="default", share="share2"))
@@ -156,12 +151,6 @@ def test_list_tables_with_pagination(rest_client: DataSharingRestClient):
     assert response.tables == [
         Table(name="table3", share="share1", schema="default"),
         Table(name="table7", share="share1", schema="default"),
-        Table(name="cdf_table_cdf_enabled", share="share1", schema="default"),
-        Table(name="cdf_table_with_partition", share="share1", schema="default"),
-        Table(name="cdf_table_with_vacuum", share="share1", schema="default"),
-        Table(name="cdf_table_missing_log", share="share1", schema="default"),
-        Table(name="streaming_table_with_optimize", share="share1", schema="default"),
-        Table(name="table_reader_version_increased", share="share1", schema="default"),
     ]
 
 
@@ -400,7 +389,7 @@ def test_list_files_in_table_version(
     rest_client: DataSharingRestClient,
 ):
     response = rest_client.list_files_in_table(
-        Table(name="cdf_table_cdf_enabled", share="share1", schema="default"),
+        Table(name="cdf_table_cdf_enabled", share="share8", schema="default"),
         version=1
     )
     assert response.protocol == Protocol(min_reader_version=1)
@@ -484,7 +473,7 @@ def test_list_files_in_table_timestamp(
         assert isinstance(e, HTTPError)
         assert "Reading table by version or timestamp is not supported" in (str(e))
 
-    cdf_table = Table(name="cdf_table_with_partition", share="share1", schema="default")
+    cdf_table = Table(name="cdf_table_with_partition", share="share8", schema="default")
 
     # Only one of version and timestamp is supported
     try:
@@ -525,7 +514,7 @@ def test_list_table_changes(
     rest_client: DataSharingRestClient,
 ):
     # The following table query will return all types of actions.
-    cdf_table = Table(name="cdf_table_with_partition", share="share1", schema="default")
+    cdf_table = Table(name="cdf_table_with_partition", share="share8", schema="default")
     response = rest_client.list_table_changes(
         cdf_table,
         CdfOptions(starting_version=1, ending_version=3)
@@ -619,7 +608,7 @@ def test_list_table_changes(
 def test_list_table_changes_with_timestamp(
     rest_client: DataSharingRestClient
 ):
-    cdf_table = Table(name="cdf_table_with_partition", share="share1", schema="default")
+    cdf_table = Table(name="cdf_table_with_partition", share="share8", schema="default")
 
     # Use a really old start time, and look for an appropriate error.
     # This will ensure that the timestamps are parsed correctly.

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -229,7 +229,7 @@ def test_query_existed_table_version(rest_client: DataSharingRestClient):
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_query_table_version_with_timestamp(rest_client: DataSharingRestClient):
     response = rest_client.query_table_version(
-        Table(name="cdf_table_cdf_enabled", share="share1", schema="default"),
+        Table(name="cdf_table_cdf_enabled", share="share8", schema="default"),
         starting_timestamp="2020-01-01 00:00:00.0"
     )
     assert isinstance(response.delta_table_version, int)

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -55,7 +55,8 @@ case class Metadata(
     format: Format = Format(),
     schemaString: String = null,
     configuration: Map[String, String] = Map.empty,
-    partitionColumns: Seq[String] = Nil) extends Action {
+    partitionColumns: Seq[String] = Nil,
+    version: java.lang.Long = null) extends Action {
 
   override def wrap: SingleAction = SingleAction(metaData = this)
 }
@@ -65,7 +66,7 @@ sealed trait Action {
   def wrap: SingleAction
 }
 
-case class Protocol(minReaderVersion: Int) extends Action {
+case class Protocol(minReaderVersion: Int, version: java.lang.Long = null) extends Action {
   override def wrap: SingleAction = SingleAction(protocol = this)
 }
 

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -66,7 +66,7 @@ sealed trait Action {
   def wrap: SingleAction
 }
 
-case class Protocol(minReaderVersion: Int, version: java.lang.Long = null) extends Action {
+case class Protocol(minReaderVersion: Int) extends Action {
   override def wrap: SingleAction = SingleAction(protocol = this)
 }
 

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -209,14 +209,7 @@ class DeltaSharedTable(
     // TODO Open the `state` field in Delta Standalone library.
     val stateMethod = snapshot.getClass.getMethod("state")
     val state = stateMethod.invoke(snapshot).asInstanceOf[SnapshotImpl.State]
-    val modelProtocol = model.Protocol(
-      snapshot.protocolScala.minReaderVersion,
-      version = if (startingVersion.isDefined) {
-        startingVersion.get
-      } else {
-        null
-      }
-    )
+    val modelProtocol = model.Protocol(snapshot.protocolScala.minReaderVersion)
     val modelMetadata = model.Metadata(
       id = snapshot.metadataScala.id,
       name = snapshot.metadataScala.name,
@@ -309,10 +302,6 @@ class DeltaSharedTable(
           actions.append(modelRemoveFile.wrap)
         case p: Protocol =>
           assertProtocolRead(p)
-          if (v > startingVersion) {
-            val modelProtocol = model.Protocol(p.minReaderVersion, v)
-            actions.append(modelProtocol.wrap)
-          }
         case m: Metadata =>
           if (v > startingVersion) {
             val modelMetadata = model.Metadata(

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -205,7 +205,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         Share().withName("share6"),
         Share().withName("share7"),
         Share().withName("share_azure"),
-        Share().withName("share_gcp")
+        Share().withName("share_gcp"),
+        Share().withName("share8")
       )
     )
     assert(expected == JsonFormat.fromJsonString[ListSharesResponse](response))
@@ -229,7 +230,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         Share().withName("share6"),
         Share().withName("share7"),
         Share().withName("share_azure"),
-        Share().withName("share_gcp")
+        Share().withName("share_gcp"),
+        Share().withName("share8")
     )
     assert(expected == shares)
   }
@@ -252,13 +254,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     val expected = ListTablesResponse(
       Table().withName("table1").withSchema("default").withShare("share1") ::
         Table().withName("table3").withSchema("default").withShare("share1") ::
-        Table().withName("table7").withSchema("default").withShare("share1") ::
-        Table().withName("cdf_table_cdf_enabled").withSchema("default").withShare("share1") ::
-        Table().withName("cdf_table_with_partition").withSchema("default").withShare("share1") ::
-        Table().withName("cdf_table_with_vacuum").withSchema("default").withShare("share1") ::
-        Table().withName("cdf_table_missing_log").withSchema("default").withShare("share1") ::
-        Table().withName("streaming_table_with_optimize").withSchema("default").withShare("share1") ::
-        Table().withName("table_reader_version_increased").withSchema("default").withShare("share1") :: Nil)
+        Table().withName("table7").withSchema("default").withShare("share1") :: Nil)
     assert(expected == JsonFormat.fromJsonString[ListTablesResponse](response))
   }
 
@@ -273,13 +269,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     val expected =
       Table().withName("table1").withSchema("default").withShare("share1") ::
         Table().withName("table3").withSchema("default").withShare("share1") ::
-        Table().withName("table7").withSchema("default").withShare("share1") ::
-        Table().withName("cdf_table_cdf_enabled").withSchema("default").withShare("share1") ::
-        Table().withName("cdf_table_with_partition").withSchema("default").withShare("share1") ::
-        Table().withName("cdf_table_with_vacuum").withSchema("default").withShare("share1") ::
-        Table().withName("cdf_table_missing_log").withSchema("default").withShare("share1") ::
-        Table().withName("streaming_table_with_optimize").withSchema("default").withShare("share1") ::
-        Table().withName("table_reader_version_increased").withSchema("default").withShare("share1") :: Nil
+        Table().withName("table7").withSchema("default").withShare("share1") :: Nil
     assert(expected == tables)
   }
 
@@ -531,7 +521,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   integrationTest("cdf_table_cdf_enabled - /shares/{share}/schemas/{schema}/tables/{table}/metadata") {
-    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/metadata"), expectedTableVersion = Some(5))
+    val response = readNDJson(requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/metadata"), expectedTableVersion = Some(5))
     val Array(protocol, metadata) = response.split("\n")
     val expectedProtocol = Protocol(minReaderVersion = 1).wrap
     assert(expectedProtocol == JsonUtils.fromJson[SingleAction](protocol))
@@ -551,7 +541,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         | "version": 1
         |}
         |""".stripMargin
-    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/query"), Some("POST"), Some(p), Some(1))
+    val response = readNDJson(requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/query"), Some("POST"), Some(p), Some(1))
     val lines = response.split("\n")
     val protocol = lines(0)
     val metadata = lines(1)
@@ -599,7 +589,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   integrationTest("query table with version/tiemstamp/startingVersion - exceptions") {
     // only one of version/timestamp/startingVersion is supported
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/query"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/query"),
       method = "POST",
       data = Some("""{"timestamp": "abc", "version": "3"}"""),
       expectedErrorCode = 400,
@@ -607,7 +597,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         Seq("version", "timestamp", "startingVersion"))
     )
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/query"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/query"),
       method = "POST",
       data = Some("""{"timestamp": "abc", "startingVersion": "3"}"""),
       expectedErrorCode = 400,
@@ -615,7 +605,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         Seq("version", "timestamp", "startingVersion"))
     )
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/query"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/query"),
       method = "POST",
       data = Some("""{"startingVersion": 2, "version": "3"}"""),
       expectedErrorCode = 400,
@@ -623,7 +613,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         Seq("version", "timestamp", "startingVersion"))
     )
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/query"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/query"),
       method = "POST",
       data = Some("""{"timestamp": "abc", "version": "3", "startingVersion": "2"}"""),
       expectedErrorCode = 400,
@@ -671,7 +661,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
 
     // timestamp before the earliest version
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/query"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/query"),
       method = "POST",
       data = Some("""{"timestamp": "2000-01-01 00:00:00"}"""),
       expectedErrorCode = 400,
@@ -680,7 +670,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
 
     // timestamp after the latest version
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/query"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/query"),
       method = "POST",
       data = Some("""{"timestamp": "9999-01-01 00:00:00"}"""),
       expectedErrorCode = 400,
@@ -697,7 +687,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         | "timestamp": "$tsStr"
         |}
         |""".stripMargin
-    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/query"), Some("POST"), Some(p), Some(1))
+    val response = readNDJson(requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/query"), Some("POST"), Some(p), Some(1))
     val lines = response.split("\n")
     val protocol = lines(0)
     val metadata = lines(1)
@@ -749,18 +739,19 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
          | "startingVersion": 0
          |}
          |""".stripMargin
-    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/streaming_table_with_optimize/query"), Some("POST"), Some(p), Some(0))
+    val response = readNDJson(requestPath("/shares/share8/schemas/default/tables/streaming_table_with_optimize/query"), Some("POST"), Some(p), Some(0))
     val lines = response.split("\n")
     val protocol = lines(0)
     val metadata = lines(1)
-    val expectedProtocol = Protocol(minReaderVersion = 1).wrap
+    val expectedProtocol = Protocol(minReaderVersion = 1, version = 0).wrap
     assert(expectedProtocol == JsonUtils.fromJson[SingleAction](protocol))
     val expectedMetadata = Metadata(
       id = "4929d09e-b085-4d22-a95e-7416fb2f78ab",
       format = Format(),
       schemaString = """{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}},{"name":"age","type":"integer","nullable":true,"metadata":{}},{"name":"birthday","type":"date","nullable":true,"metadata":{}}]}""",
       configuration = Map("enableChangeDataFeed" -> "true"),
-      partitionColumns = Nil).wrap
+      partitionColumns = Nil,
+      version = 0).wrap
     assert(expectedMetadata == JsonUtils.fromJson[SingleAction](metadata))
     val files = lines.drop(2)
     assert(files.size == 7)
@@ -831,9 +822,56 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
   }
 
+  integrationTest("streaming_table_metadata_protocol - startingVersion success") {
+    val p =
+      s"""
+         |{
+         | "startingVersion": 0
+         |}
+         |""".stripMargin
+    val response = readNDJson(requestPath("/shares/share8/schemas/default/tables/streaming_table_metadata_protocol/query"), Some("POST"), Some(p), Some(0))
+    val actions = response.split("\n").map(JsonUtils.fromJson[SingleAction](_))
+    assert(actions.size == 8)
+
+    // version 0: CREATE TABLE, protocol/metadata
+    // version 1: INSERT
+    // version 2: ALTER TABLE, protocol/metadata
+    // version 3: ALTER TABLE, protocol/metadata
+    // version 4: INSERT
+    var expectedProtocol = Protocol(minReaderVersion = 1, version = 0)
+    assert(expectedProtocol == actions(0).protocol)
+    var expectedMetadata = Metadata(
+      id = "eaca659e-28ac-4c68-8c72-0c96205c8160",
+      format = Format(),
+      schemaString = """{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}},{"name":"age","type":"integer","nullable":true,"metadata":{}},{"name":"birthday","type":"date","nullable":true,"metadata":{}}]}""",
+      partitionColumns = Nil,
+      version = 0)
+    assert(expectedMetadata == actions(1).metaData)
+
+    assert(actions(2).add != null)
+
+    // check protocol and metadata for version 2.
+    expectedProtocol = Protocol(minReaderVersion = 1, version = 2)
+    assert(expectedProtocol == actions(3).protocol)
+    expectedMetadata = expectedMetadata.copy(
+      configuration = Map("enableChangeDataFeed" -> "true"),
+      version = 2)
+    assert(expectedMetadata == actions(4).metaData)
+
+    // check protocol and metadata for version 3.
+    expectedProtocol = Protocol(minReaderVersion = 1, version = 3)
+    assert(expectedProtocol == actions(5).protocol)
+    expectedMetadata = expectedMetadata.copy(
+      configuration = Map.empty,
+      version = 3)
+    assert(expectedMetadata == actions(6).metaData)
+
+    assert(actions(7).add != null)
+  }
+
   integrationTest("table_reader_version_increased - exception") {
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/table_reader_version_increased/query"),
+      url = requestPath("/shares/share8/schemas/default/tables/table_reader_version_increased/query"),
       method = "POST",
       data = Some("""{"startingVersion": 0}"""),
       expectedErrorCode = 400,
@@ -842,7 +880,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   integrationTest("cdf_table_cdf_enabled_changes - query table changes") {
-    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=0&endingVersion=3"), Some("GET"), None, Some(0))
+    val response = readNDJson(requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=0&endingVersion=3"), Some("GET"), None, Some(0))
     val lines = response.split("\n")
     val protocol = lines(0)
     val metadata = lines(1)
@@ -907,7 +945,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     // 1651272660000, PST: 2022-04-29 15:51:00.0 -> version 3
     val endStr = URLEncoder.encode(new Timestamp(1651272660000L).toString)
 
-    val response = readNDJson(requestPath(s"/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingTimestamp=${startStr}&endingTimestamp=${endStr}"), Some("GET"), None, Some(0))
+    val response = readNDJson(requestPath(s"/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingTimestamp=${startStr}&endingTimestamp=${endStr}"), Some("GET"), None, Some(0))
     val lines = response.split("\n")
     val protocol = lines(0)
     val metadata = lines(1)
@@ -925,7 +963,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   integrationTest("cdf_table_with_partition: query table changes") {
-    val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/cdf_table_with_partition/changes?startingVersion=1&endingVersion=3"), Some("GET"), None, Some(1))
+    val response = readNDJson(requestPath("/shares/share8/schemas/default/tables/cdf_table_with_partition/changes?startingVersion=1&endingVersion=3"), Some("GET"), None, Some(1))
     val lines = response.split("\n")
     val files = lines.drop(2)
     assert(files.size == 6)
@@ -1102,7 +1140,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
 
   integrationTest("cdf_table_cdf_enabled_changes - exceptions") {
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingTimestamp=2000-01-01%2000:00:00"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingTimestamp=2000-01-01%2000:00:00"),
       method = "GET",
       data = None,
       expectedErrorCode = 400,
@@ -1110,7 +1148,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
 
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingTimestamp=9999-01-01%2000:00:00"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingTimestamp=9999-01-01%2000:00:00"),
       method = "GET",
       data = None,
       expectedErrorCode = 400,
@@ -1118,7 +1156,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
 
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes"),
       method = "GET",
       data = None,
       expectedErrorCode = 400,
@@ -1126,7 +1164,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
 
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=1&startingTimestamp=2022-02-02%2000:00:00"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=1&startingTimestamp=2022-02-02%2000:00:00"),
       method = "GET",
       data = None,
       expectedErrorCode = 400,
@@ -1134,7 +1172,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
 
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=1&endingVersion=3&endingTimestamp=randomString"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=1&endingVersion=3&endingTimestamp=randomString"),
       method = "GET",
       data = None,
       expectedErrorCode = 400,
@@ -1142,7 +1180,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
 
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingTimestamp=2022-04-29"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingTimestamp=2022-04-29"),
       method = "GET",
       data = None,
       expectedErrorCode = 400,
@@ -1150,7 +1188,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
 
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=2&endingVersion=1"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=2&endingVersion=1"),
       method = "GET",
       data = None,
       expectedErrorCode = 400,
@@ -1158,7 +1196,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
 
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=6"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=6"),
       method = "GET",
       data = None,
       expectedErrorCode = 400,
@@ -1166,7 +1204,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
 
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=0&endingVersion=5"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=0&endingVersion=5"),
       method = "GET",
       data = None,
       expectedErrorCode = 400,
@@ -1174,7 +1212,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
 
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=4"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=4"),
       method = "GET",
       data = None,
       expectedErrorCode = 400,
@@ -1184,7 +1222,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
 
   integrationTest("cdf_table_with_partition - exceptions on startVersion") {
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_with_partition/changes?startingVersion=0"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_with_partition/changes?startingVersion=0"),
       method = "GET",
       data = None,
       expectedErrorCode = 400,
@@ -1192,7 +1230,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
 
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_with_partition/query"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_with_partition/query"),
       method = "POST",
       data = Some("""
         {"version": "0"}
@@ -1202,7 +1240,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
 
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_with_partition/query"),
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_with_partition/query"),
       method = "POST",
       data = Some("""
         {"startingVersion": "0"}

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -69,38 +69,7 @@ object TestResource {
             java.util.Arrays.asList(
               TableConfig("table1", s"s3a://${AWS.bucket}/delta-exchange-test/table1"),
               TableConfig("table3", s"s3a://${AWS.bucket}/delta-exchange-test/table3"),
-              TableConfig("table7", s"s3a://${AWS.bucket}/delta-exchange-test/table7"),
-              TableConfig(
-                "cdf_table_cdf_enabled",
-                s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_cdf_enabled",
-                true
-              ),
-              TableConfig(
-                "cdf_table_with_partition",
-                s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_with_partition",
-                true,
-                1
-              ),
-              TableConfig(
-                "cdf_table_with_vacuum",
-                s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_with_vacuum",
-                true
-              ),
-              TableConfig(
-                "cdf_table_missing_log",
-                s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_missing_log",
-                true
-              ),
-              TableConfig(
-                "streaming_table_with_optimize",
-                s"s3a://${AWS.bucket}/delta-exchange-test/streaming_table_with_optimize",
-                true
-              ),
-              TableConfig(
-                "table_reader_version_increased",
-                s"s3a://${AWS.bucket}/delta-exchange-test/table_reader_version_increased",
-                true
-              )
+              TableConfig("table7", s"s3a://${AWS.bucket}/delta-exchange-test/table7")
             )
           )
         )
@@ -180,6 +149,51 @@ object TestResource {
             "default",
             java.util.Arrays.asList(
               TableConfig("table_gcs", s"gs://${GCP.bucket}/delta-sharing-test/table1")
+            )
+          )
+        )
+      ),
+      ShareConfig("share8",
+        java.util.Arrays.asList(
+          SchemaConfig(
+            "default",
+            java.util.Arrays.asList(
+              TableConfig(
+                "cdf_table_cdf_enabled",
+                s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_cdf_enabled",
+                true
+              ),
+              TableConfig(
+                "cdf_table_with_partition",
+                s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_with_partition",
+                true,
+                1
+              ),
+              TableConfig(
+                "cdf_table_with_vacuum",
+                s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_with_vacuum",
+                true
+              ),
+              TableConfig(
+                "cdf_table_missing_log",
+                s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_missing_log",
+                true
+              ),
+              TableConfig(
+                "streaming_table_with_optimize",
+                s"s3a://${AWS.bucket}/delta-exchange-test/streaming_table_with_optimize",
+                true
+              ),
+              TableConfig(
+                "streaming_table_metadata_protocol",
+                s"s3a://${AWS.bucket}/delta-exchange-test/streaming_table_metadata_protocol",
+                true
+              ),
+              TableConfig(
+                "table_reader_version_increased",
+                s"s3a://${AWS.bucket}/delta-exchange-test/table_reader_version_increased",
+                true
+              )
             )
           )
         )

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -190,6 +190,11 @@ object TestResource {
                 true
               ),
               TableConfig(
+                "streaming_table_read_incompatible",
+                s"s3a://${AWS.bucket}/delta-exchange-test/streaming_table_read_incompatible",
+                true
+              ),
+              TableConfig(
                 "table_reader_version_increased",
                 s"s3a://${AWS.bucket}/delta-exchange-test/table_reader_version_increased",
                 true

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -238,13 +238,11 @@ private[spark] class DeltaSharingRestClient(
     val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
     val addFiles = ArrayBuffer[AddFileForCDF]()
     val removeFiles = ArrayBuffer[RemoveFile]()
-    val additionalProtocols = ArrayBuffer[Protocol]()
     val additionalMetadatas = ArrayBuffer[Metadata]()
     lines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).unwrap).foreach{
       case a: AddFileForCDF => addFiles.append(a)
       case r: RemoveFile => removeFiles.append(r)
       case m: Metadata => additionalMetadatas.append(m)
-      case p: Protocol => additionalProtocols.append(p)
       case f => throw new IllegalStateException(s"Unexpected File:${f}")
     }
     DeltaTableFiles(
@@ -253,7 +251,6 @@ private[spark] class DeltaSharingRestClient(
       metadata,
       addFiles = addFiles,
       removeFiles = removeFiles,
-      additionalProtocols = additionalProtocols,
       additionalMetadatas = additionalMetadatas
     )
   }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -231,9 +231,13 @@ private[spark] class DeltaSharingRestClient(
     val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
     val addFiles = ArrayBuffer[AddFileForCDF]()
     val removeFiles = ArrayBuffer[RemoveFile]()
+    val additionalProtocols = ArrayBuffer[Protocol]()
+    val additionalMetadatas = ArrayBuffer[Metadata]()
     lines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).unwrap).foreach{
       case a: AddFileForCDF => addFiles.append(a)
       case r: RemoveFile => removeFiles.append(r)
+      case m: Metadata => additionalMetadatas.append(m)
+      case p: Protocol => additionalProtocols.append(p)
       case f => throw new IllegalStateException(s"Unexpected File:${f}")
     }
     DeltaTableFiles(
@@ -241,7 +245,9 @@ private[spark] class DeltaSharingRestClient(
       protocol,
       metadata,
       addFiles = addFiles,
-      removeFiles = removeFiles
+      removeFiles = removeFiles,
+      additionalProtocols = additionalProtocols,
+      additionalMetadatas = additionalMetadatas
     )
   }
 

--- a/spark/src/main/scala/io/delta/sharing/spark/model.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/model.scala
@@ -103,9 +103,7 @@ private[sharing] sealed trait Action {
   def wrap: SingleAction
 }
 
-private[sharing] case class Protocol(
-    minReaderVersion: Int,
-    version: java.lang.Long = null) extends Action {
+private[sharing] case class Protocol(minReaderVersion: Int) extends Action {
   override def wrap: SingleAction = SingleAction(protocol = this)
 }
 

--- a/spark/src/main/scala/io/delta/sharing/spark/model.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/model.scala
@@ -49,7 +49,6 @@ private[sharing] case class DeltaTableFiles(
     addFiles: Seq[AddFileForCDF] = Nil,
     cdfFiles: Seq[AddCDCFile] = Nil,
     removeFiles: Seq[RemoveFile] = Nil,
-    additionalProtocols: Seq[Protocol] = Nil,
     additionalMetadatas: Seq[Metadata] = Nil)
 
 private[sharing] case class Share(name: String)

--- a/spark/src/main/scala/io/delta/sharing/spark/model.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/model.scala
@@ -48,7 +48,9 @@ private[sharing] case class DeltaTableFiles(
     files: Seq[AddFile] = Nil,
     addFiles: Seq[AddFileForCDF] = Nil,
     cdfFiles: Seq[AddCDCFile] = Nil,
-    removeFiles: Seq[RemoveFile] = Nil)
+    removeFiles: Seq[RemoveFile] = Nil,
+    additionalProtocols: Seq[Protocol] = Nil,
+    additionalMetadatas: Seq[Metadata] = Nil)
 
 private[sharing] case class Share(name: String)
 
@@ -92,7 +94,8 @@ private[sharing] case class Metadata(
     format: Format = Format(),
     schemaString: String = null,
     configuration: Map[String, String] = Map.empty,
-    partitionColumns: Seq[String] = Nil) extends Action {
+    partitionColumns: Seq[String] = Nil,
+    version: java.lang.Long = null) extends Action {
   override def wrap: SingleAction = SingleAction(metaData = this)
 }
 
@@ -101,7 +104,9 @@ private[sharing] sealed trait Action {
   def wrap: SingleAction
 }
 
-private[sharing] case class Protocol(minReaderVersion: Int) extends Action {
+private[sharing] case class Protocol(
+    minReaderVersion: Int,
+    version: java.lang.Long = null) extends Action {
   override def wrap: SingleAction = SingleAction(protocol = this)
 }
 

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -310,6 +310,23 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         )
       )
       assert(expectedRemoveFiles == tableFiles.removeFiles.toList)
+
+      assert(tableFiles.additionalProtocols.size == 0)
+      assert(tableFiles.additionalMetadatas.size == 2)
+      val v4Metadata = Metadata(
+        id = "16736144-3306-4577-807a-d3f899b77670",
+        format = Format(),
+        schemaString = """{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}},{"name":"age","type":"integer","nullable":true,"metadata":{}},{"name":"birthday","type":"date","nullable":true,"metadata":{}}]}""",
+        configuration = Map.empty,
+        partitionColumns = Nil,
+        version = 4)
+      assert(v4Metadata == tableFiles.additionalMetadatas(0))
+
+      val v5Metadata = v4Metadata.copy(
+        configuration = Map("enableChangeDataFeed" -> "true"),
+        version = 5
+      )
+      assert(v5Metadata == tableFiles.additionalMetadatas(1))
     } finally {
       client.close()
     }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -51,6 +51,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Table(name = "cdf_table_missing_log", schema = "default", share = "share8"),
         Table(name = "streaming_table_with_optimize", schema = "default", share = "share8"),
         Table(name = "streaming_table_metadata_protocol", schema = "default", share = "share8"),
+        Table(name = "streaming_table_read_incompatible", schema = "default", share = "share8"),
         Table(name = "table_reader_version_increased", schema = "default", share = "share8"),
         Table(name = "test_gzip", schema = "default", share = "share4"),
         Table(name = "table_wasb", schema = "default", share = "share_azure"),

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -45,12 +45,13 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Table(name = "table7", schema = "default", share = "share1"),
         Table(name = "table8", schema = "schema1", share = "share7"),
         Table(name = "table9", schema = "schema2", share = "share7"),
-        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),
-        Table(name = "cdf_table_with_partition", schema = "default", share = "share1"),
-        Table(name = "cdf_table_with_vacuum", schema = "default", share = "share1"),
-        Table(name = "cdf_table_missing_log", schema = "default", share = "share1"),
-        Table(name = "streaming_table_with_optimize", schema = "default", share = "share1"),
-        Table(name = "table_reader_version_increased", schema = "default", share = "share1"),
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
+        Table(name = "cdf_table_with_partition", schema = "default", share = "share8"),
+        Table(name = "cdf_table_with_vacuum", schema = "default", share = "share8"),
+        Table(name = "cdf_table_missing_log", schema = "default", share = "share8"),
+        Table(name = "streaming_table_with_optimize", schema = "default", share = "share8"),
+        Table(name = "streaming_table_metadata_protocol", schema = "default", share = "share8"),
+        Table(name = "table_reader_version_increased", schema = "default", share = "share8"),
         Table(name = "test_gzip", schema = "default", share = "share4"),
         Table(name = "table_wasb", schema = "default", share = "share_azure"),
         Table(name = "table_abfs", schema = "default", share = "share_azure"),
@@ -94,7 +95,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
     try {
       val tableMatadata =
-        client.getMetadata(Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"))
+        client.getMetadata(Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"))
       assert(Protocol(minReaderVersion = 1) == tableMatadata.protocol)
       val expectedMetadata = Metadata(
         id = "16736144-3306-4577-807a-d3f899b77670",
@@ -148,7 +149,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
     try {
       val tableFiles = client.getFiles(
-        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
         Nil,
         None,
         Some(1L),
@@ -211,7 +212,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       // Because with undecided timezone, the timestamp string can be mapped to different versions
       val errorMessage = intercept[UnexpectedHttpStatus] {
         client.getFiles(
-        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
         Nil,
         None,
         None,
@@ -245,7 +246,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
     try {
       val tableFiles = client.getFiles(
-        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"), 1L
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"), 1L
       )
       assert(tableFiles.version == 1)
       assert(tableFiles.addFiles.size == 4)
@@ -327,7 +328,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
 
       errorMessage = intercept[UnexpectedHttpStatus] {
         client.getFiles(
-          Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),
+          Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
           -1
         )
       }.getMessage
@@ -342,7 +343,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     try {
       val cdfOptions = Map("startingVersion" -> "0", "endingVersion" -> "3")
       val tableFiles = client.getCDFFiles(
-        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
         cdfOptions
       )
       assert(tableFiles.version == 0)
@@ -415,7 +416,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     try {
       val cdfOptions = Map("startingVersion" -> "0")
       val tableFiles = client.getCDFFiles(
-        Table(name = "cdf_table_with_vacuum", schema = "default", share = "share1"),
+        Table(name = "cdf_table_with_vacuum", schema = "default", share = "share8"),
         cdfOptions
       )
       assert(tableFiles.version == 0)
@@ -434,7 +435,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       val errorMessage = intercept[UnexpectedHttpStatus] {
         val cdfOptions = Map("startingVersion" -> "1")
         client.getCDFFiles(
-          Table(name = "cdf_table_missing_log", schema = "default", share = "share1"),
+          Table(name = "cdf_table_missing_log", schema = "default", share = "share8"),
           cdfOptions
         )
       }.getMessage
@@ -454,7 +455,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       val cdfOptions = Map("startingTimestamp" -> "2000-01-01 00:00:00")
       val errorMessage = intercept[UnexpectedHttpStatus] {
         val tableFiles = client.getCDFFiles(
-          Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),
+          Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
           cdfOptions
         )
       }.getMessage
@@ -473,7 +474,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       val cdfOptions = Map("startingVersion" -> "0", "endingTimestamp" -> "2100-01-01 00:00:00")
       val errorMessage = intercept[UnexpectedHttpStatus] {
         val tableFiles = client.getCDFFiles(
-          Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),
+          Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
           cdfOptions
         )
       }.getMessage

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -69,7 +69,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       assert(client.getTableVersion(Table(name = "table2", schema = "default", share = "share2")) == 2)
       assert(client.getTableVersion(Table(name = "table1", schema = "default", share = "share1")) == 2)
       assert(client.getTableVersion(Table(name = "table3", schema = "default", share = "share1")) == 4)
-      assert(client.getTableVersion(Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),
+      assert(client.getTableVersion(Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
         startingTimestamp = Some("2020-01-01 00:00:00")) == 0)
     } finally {
       client.close()
@@ -327,7 +327,6 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       )
       assert(expectedRemoveFiles == tableFiles.removeFiles.toList)
 
-      assert(tableFiles.additionalProtocols.size == 0)
       assert(tableFiles.additionalMetadatas.size == 2)
       val v4Metadata = Metadata(
         id = "16736144-3306-4577-807a-d3f899b77670",

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -37,7 +37,7 @@ class DeltaSharingSourceSuite extends QueryTest
   // VERSION 1: INSERT 3 rows, 3 add files
   // VERSION 2: REMOVE 1 row, 1 remove file
   // VERSION 3: UPDATE 1 row, 1 remove file and 1 add file
-  lazy val tablePath = testProfileFile.getCanonicalPath + "#share1.default.cdf_table_cdf_enabled"
+  lazy val tablePath = testProfileFile.getCanonicalPath + "#share8.default.cdf_table_cdf_enabled"
 
   lazy val deltaLog = RemoteDeltaLog(tablePath)
 

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -114,7 +114,7 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
   }
 
   integrationTest("cdf_table_cdf_enabled query without version") {
-    val tablePath = testProfileFile.getCanonicalPath + "#share1.default.cdf_table_cdf_enabled"
+    val tablePath = testProfileFile.getCanonicalPath + "#share8.default.cdf_table_cdf_enabled"
     val expected = Seq(
       Row("1", 1, sqlDate("2020-01-01")),
       Row("2", 2, sqlDate("2020-02-02"))
@@ -127,7 +127,7 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
   }
 
   integrationTest("cdf_table_cdf_enabled query with valid version") {
-    val tablePath = testProfileFile.getCanonicalPath + "#share1.default.cdf_table_cdf_enabled"
+    val tablePath = testProfileFile.getCanonicalPath + "#share8.default.cdf_table_cdf_enabled"
     val expected = Seq(
       Row("1", 1, sqlDate("2020-01-01")),
       Row("2", 2, sqlDate("2020-01-01")),
@@ -140,7 +140,7 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
   }
 
   integrationTest("cdf_table_cdf_enabled version exception") {
-    val tablePath = testProfileFile.getCanonicalPath + "#share1.default.cdf_table_cdf_enabled"
+    val tablePath = testProfileFile.getCanonicalPath + "#share8.default.cdf_table_cdf_enabled"
     val expected = Seq()
     val errorMessage = intercept[IllegalArgumentException] {
       checkAnswer(
@@ -150,7 +150,7 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
   }
 
   integrationTest("cdf_table_cdf_enabled timestamp exception") {
-    val tablePath = testProfileFile.getCanonicalPath + "#share1.default.cdf_table_cdf_enabled"
+    val tablePath = testProfileFile.getCanonicalPath + "#share8.default.cdf_table_cdf_enabled"
     val expected = Seq()
     var errorMessage = intercept[io.delta.sharing.spark.util.UnexpectedHttpStatus] {
       checkAnswer(
@@ -202,7 +202,7 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
   }
 
   integrationTest("table_changes: cdf_table_cdf_enabled") {
-    val tablePath = testProfileFile.getCanonicalPath + "#share1.default.cdf_table_cdf_enabled"
+    val tablePath = testProfileFile.getCanonicalPath + "#share8.default.cdf_table_cdf_enabled"
 
     val expected = Seq(
       Row("1", 1, sqlDate("2020-01-01"), 1L, 1651272635000L, "insert"),
@@ -233,7 +233,7 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
   }
 
   integrationTest("table_changes_empty: cdf_table_cdf_enabled") {
-    val tablePath = testProfileFile.getCanonicalPath + "#share1.default.cdf_table_cdf_enabled"
+    val tablePath = testProfileFile.getCanonicalPath + "#share8.default.cdf_table_cdf_enabled"
 
     val result = spark.read.format("deltaSharing")
       .option("readChangeFeed", "true")
@@ -242,7 +242,7 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
   }
 
   integrationTest("table_changes_with_timestamp: cdf_table_cdf_enabled") {
-    val tablePath = testProfileFile.getCanonicalPath + "#share1.default.cdf_table_cdf_enabled"
+    val tablePath = testProfileFile.getCanonicalPath + "#share8.default.cdf_table_cdf_enabled"
 
     // Use a start timestamp in the past, and expect an error.
     val result1 = intercept[IllegalStateException] {
@@ -265,7 +265,7 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
   }
 
   integrationTest("table_changes: cdf_table_with_vacuum") {
-    val tablePath = testProfileFile.getCanonicalPath + "#share1.default.cdf_table_with_vacuum"
+    val tablePath = testProfileFile.getCanonicalPath + "#share8.default.cdf_table_with_vacuum"
 
     val expected = Seq(
       Row(11, 2L, 1655410824000L, "update_preimage"),
@@ -282,7 +282,7 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
   }
 
   integrationTest("table_changes_exception: cdf_table_with_vacuum") {
-    val tablePath = testProfileFile.getCanonicalPath + "#share1.default.cdf_table_with_vacuum"
+    val tablePath = testProfileFile.getCanonicalPath + "#share8.default.cdf_table_with_vacuum"
 
     // parquet file is vacuumed, will see 404 error when requsting the presigned url
     val ex = intercept[org.apache.spark.SparkException] {
@@ -296,7 +296,7 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
   }
 
   integrationTest("table_changes_exception: cdf_table_missing_log") {
-    val tablePath = testProfileFile.getCanonicalPath + "#share1.default.cdf_table_missing_log"
+    val tablePath = testProfileFile.getCanonicalPath + "#share8.default.cdf_table_missing_log"
 
     // log file is missing
     val ex = intercept[io.delta.sharing.spark.util.UnexpectedHttpStatus] {


### PR DESCRIPTION
Return metadata for each table version, if seen in delta log, on queryTable with startingVersion.

Also updated the share config for integration test, added share8, so that when adding new tables later, we don't need to update the test for share1.