### PR TITLE
Add get table api

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,10 +28,10 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.2")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.6")
 
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.1"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.12"

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -251,7 +251,7 @@ class DataSharingRestClient:
         table: Table,
         starting_timestamp: Optional[str] = None,
     ) -> QueryTableVersionResponse:
-        query_str = f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}"
+        query_str = f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/version"
         if starting_timestamp is not None:
             query_str += f"?startingTimestamp={quote(starting_timestamp)}"
         with self._get_internal(

--- a/server/src/main/protobuf/protocol.proto
+++ b/server/src/main/protobuf/protocol.proto
@@ -84,6 +84,10 @@ message ListAllTablesResponse {
     optional string next_page_token = 2;
 }
 
+message GetTableResponse {
+    optional Table table = 1;
+}
+
 // Define a special class to generate the page token for pagination. It includes the information we
 // need to know where we should start to query, and check whether the page token comes from the
 // right result. For example, we would like to throw an error when the user uses a page token

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -239,8 +239,28 @@ class DeltaSharingService(serverConfig: ServerConfig) {
     ResponseHeaders.builder(200).set(DELTA_TABLE_VERSION_HEADER, version.toString)
   }
 
-  @Head("/shares/{share}/schemas/{schema}/tables/{table}")
   @Get("/shares/{share}/schemas/{schema}/tables/{table}")
+  @ProducesJson
+  def getTable(
+      @Param("share") share: String,
+      @Param("schema") schema: String,
+      @Param("table") table: String
+  ): GetTableResponse = processRequest {
+    sharedTableManager.getTable(share, schema, table)
+    GetTableResponse(
+      table = Some(
+        Table(
+          name = Some(table),
+          schema = Some(schema),
+          share = Some(share)
+        )
+      )
+    )
+  }
+
+  // TODO: deprecate HEAD request in favor of the GET request
+  @Head("/shares/{share}/schemas/{schema}/tables/{table}")
+  @Get("/shares/{share}/schemas/{schema}/tables/{table}/version")
   def getTableVersion(
     @Param("share") share: String,
     @Param("schema") schema: String,

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -295,6 +295,42 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(expected == tables)
   }
 
+  integrationTest("table1 - get - /shares/{share}/schemas/{schema}/tables/{table}") {
+    val response = readJson(requestPath("/shares/share1/schemas/default/tables/table1"))
+    val expected = GetTableResponse(
+      Some(Table().withName("table1").withSchema("default").withShare("share1"))
+    )
+    assert(expected == JsonFormat.fromJsonString[GetTableResponse](response))
+  }
+
+  integrationTest("getTable - get exceptions") {
+    // non-existent table
+    assertHttpError(
+      url = requestPath("/shares/share1/schemas/default/tables/does-not-exist"),
+      method = "GET",
+      data = None,
+      expectedErrorCode = 404,
+      expectedErrorMessage = "[Share/Schema/Table] 'share1/default/does-not-exist' does not exist, please contact your share provider for further information."
+    )
+
+    // non-existent schema
+    assertHttpError(
+      url = requestPath("/shares/share1/schemas/does-not-exist/tables/does-not-exist"),
+      method = "GET",
+      data = None,
+      expectedErrorCode = 404,
+      expectedErrorMessage = "[Share/Schema/Table] 'share1/does-not-exist/does-not-exist' does not exist, please contact your share provider for further information."
+    )
+
+    // non-existent share
+    assertHttpError(
+      url = requestPath("/shares/does-not-exist/schemas/does-not-exist/tables/does-not-exist"),
+      method = "GET",
+      data = None,
+      expectedErrorCode = 404,
+      expectedErrorMessage = "[Share/Schema/Table] 'does-not-exist/does-not-exist/does-not-exist' does not exist, please contact your share provider for further information."
+    )
+  }
 
   integrationTest("table1 - head - /shares/{share}/schemas/{schema}/tables/{table}") {
     // getTableVersion succeeds without parameters
@@ -326,9 +362,9 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(deltaTableVersion == "0")
   }
 
-  integrationTest("table1 - get - /shares/{share}/schemas/{schema}/tables/{table}") {
+  integrationTest("table1 - get - /shares/{share}/schemas/{schema}/tables/{table}/version") {
     // getTableVersion succeeds without parameters
-    var url = requestPath("/shares/share1/schemas/default/tables/table1")
+    var url = requestPath("/shares/share1/schemas/default/tables/table1/version")
     var connection = new URL(url).openConnection().asInstanceOf[HttpsURLConnection]
     connection.setRequestMethod("GET")
     connection.setRequestProperty("Authorization", s"Bearer ${TestResource.testAuthorizationToken}")
@@ -342,7 +378,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(deltaTableVersion == "2")
 
     // getTableVersion succeeds with parameters
-    url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled?startingTimestamp=2000-01-01%2000:00:00")
+    url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/version?startingTimestamp=2000-01-01%2000:00:00")
     connection = new URL(url).openConnection().asInstanceOf[HttpsURLConnection]
     connection.setRequestMethod("GET")
     connection.setRequestProperty("Authorization", s"Bearer ${TestResource.testAuthorizationToken}")
@@ -1435,10 +1471,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         output.close()
       }
     }
-    val e = intercept[IOException] {
-      connection.getInputStream()
-    }
-    assert(e.getMessage.contains(s"Server returned HTTP response code: $expectedErrorCode"))
+    val responseStatusCode = connection.getResponseCode()
+    assert(responseStatusCode == expectedErrorCode)
     // If the http method is HEAD, error message is not returned from the server.
     assert(method == "HEAD" || IOUtils.toString(connection.getErrorStream()).contains(expectedErrorMessage))
   }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -178,7 +178,7 @@ private[spark] class DeltaSharingRestClient(
     }
     val target =
       getTargetUrl(s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/" +
-        s"$encodedTableName$encodedParam")
+        s"$encodedTableName/version$encodedParam")
     val (version, _) = getResponse(new HttpGet(target))
     version.getOrElse {
       throw new IllegalStateException("Cannot find Delta-Table-Version in the header")

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -36,7 +36,7 @@ import io.delta.sharing.spark.util.UnexpectedHttpStatus
 // scalastyle:off maxLineLength
 class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
 
-  test("Check headers") {
+  integrationTest("Check headers") {
     val httpRequest = new HttpGet("random_url")
 
     val client = new DeltaSharingRestClient(testProfileProvider, forStreaming = false)


### PR DESCRIPTION
This PR:
- adds a get table api 
- changes the route for retrieving the version to /share/{share}/schema/{schema}/table/{table}/version due to conflicts with the get table api
- upgrades dependencies for use on M1 macbook pro*
- test/testQuietly to integrationTest to fix tests expecting an integration test

(*) the current version of the scalapb library does not use a version of protoc that has publicly available arm64 builds and fails the local development