### PR TITLE
Non-breaking change: return version and timestamp for queryTable with version

### DIFF
--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -300,12 +300,12 @@ class DataSharingRestClient:
             lines = values[1]
             protocol_json = json.loads(next(lines))
             metadata_json = json.loads(next(lines))
-            file_type = "add" if ((version is not None) or (timestamp is not None)) else "file"
+
             return ListFilesInTableResponse(
                 delta_table_version=int(headers.get("delta-table-version")),
                 protocol=Protocol.from_json(protocol_json["protocol"]),
                 metadata=Metadata.from_json(metadata_json["metaData"]),
-                add_files=[AddFile.from_json(json.loads(file)[file_type]) for file in lines],
+                add_files=[AddFile.from_json(json.loads(file)["file"]) for file in lines],
             )
 
     @retry_with_exponential_backoff

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -70,16 +70,6 @@ case class Protocol(minReaderVersion: Int) extends Action {
   override def wrap: SingleAction = SingleAction(protocol = this)
 }
 
-sealed abstract class AddFileBase(
-    url: String,
-    id: String,
-    @JsonInclude(JsonInclude.Include.ALWAYS)
-    partitionValues: Map[String, String],
-    size: Long,
-    @JsonRawValue
-    stats: String = null)
-    extends Action {}
-
 case class AddFile(
     url: String,
     id: String,
@@ -87,7 +77,9 @@ case class AddFile(
     partitionValues: Map[String, String],
     size: Long,
     @JsonRawValue
-    stats: String = null) extends AddFileBase(url, id, partitionValues, size, stats) {
+    stats: String = null,
+    timestamp: java.lang.Long = null,
+    version: java.lang.Long = null) extends Action {
 
   override def wrap: SingleAction = SingleAction(file = this)
 }
@@ -101,8 +93,7 @@ case class AddFileForCDF(
     version: Long,
     timestamp: Long,
     @JsonRawValue
-    stats: String = null)
-    extends AddFileBase(url, id, partitionValues, size, stats) {
+    stats: String = null) extends Action {
 
   override def wrap: SingleAction = SingleAction(add = this)
 }

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -260,22 +260,14 @@ class DeltaSharedTable(
         filteredFilters.map { addFile =>
           val cloudPath = absolutePath(deltaLog.dataPath, addFile.path)
           val signedUrl = fileSigner.sign(cloudPath)
-          val modelAddFile = if (isVersionQuery) {
-            model.AddFileForCDF(url = signedUrl,
-              id = Hashing.md5().hashString(addFile.path, UTF_8).toString,
-              partitionValues = addFile.partitionValues,
-              size = addFile.size,
-              stats = addFile.stats,
-              version = snapshot.version,
-              timestamp = ts.get
-            )
-          } else {
-            model.AddFile(url = signedUrl,
-              id = Hashing.md5().hashString(addFile.path, UTF_8).toString,
-              partitionValues = addFile.partitionValues,
-              size = addFile.size,
-              stats = addFile.stats)
-          }
+          val modelAddFile = model.AddFile(url = signedUrl,
+            id = Hashing.md5().hashString(addFile.path, UTF_8).toString,
+            partitionValues = addFile.partitionValues,
+            size = addFile.size,
+            stats = addFile.stats,
+            version = if (isVersionQuery) { snapshot.version } else null,
+            timestamp = if (isVersionQuery) { ts.get} else null
+          )
           modelAddFile.wrap
         }
       } else {

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -662,10 +662,10 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       partitionColumns = Nil).wrap
     assert(expectedMetadata == JsonUtils.fromJson[SingleAction](metadata))
     val files = lines.drop(2)
-    val actualFiles = files.map(f => JsonUtils.fromJson[SingleAction](f).add)
+    val actualFiles = files.map(f => JsonUtils.fromJson[SingleAction](f).file)
     assert(actualFiles.size == 3)
     val expectedFiles = Seq(
-      AddFileForCDF(
+      AddFile(
         url = actualFiles(0).url,
         id = "60d0cf57f3e4367db154aa2c36152a1f",
         partitionValues = Map.empty,
@@ -674,7 +674,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         version = 1,
         timestamp = 1651272635000L
       ),
-      AddFileForCDF(
+      AddFile(
         url = actualFiles(1).url,
         id = "d7ed708546dd70fdff9191b3e3d6448b",
         partitionValues = Map.empty,
@@ -683,7 +683,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         version = 1,
         timestamp = 1651272635000L
       ),
-      AddFileForCDF(
+      AddFile(
         url = actualFiles(2).url,
         id = "a6dc5694a4ebcc9a067b19c348526ad6",
         partitionValues = Map.empty,
@@ -825,10 +825,10 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       partitionColumns = Nil).wrap
     assert(expectedMetadata == JsonUtils.fromJson[SingleAction](metadata))
     val files = lines.drop(2)
-    val actualFiles = files.map(f => JsonUtils.fromJson[SingleAction](f).add)
+    val actualFiles = files.map(f => JsonUtils.fromJson[SingleAction](f).file)
     assert(actualFiles.size == 3)
     val expectedFiles = Seq(
-      AddFileForCDF(
+      AddFile(
         url = actualFiles(0).url,
         id = "60d0cf57f3e4367db154aa2c36152a1f",
         partitionValues = Map.empty,
@@ -837,7 +837,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         version = 1,
         timestamp = 1651272635000L
       ),
-      AddFileForCDF(
+      AddFile(
         url = actualFiles(1).url,
         id = "d7ed708546dd70fdff9191b3e3d6448b",
         partitionValues = Map.empty,
@@ -846,7 +846,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         version = 1,
         timestamp = 1651272635000L
       ),
-      AddFileForCDF(
+      AddFile(
         url = actualFiles(2).url,
         id = "a6dc5694a4ebcc9a067b19c348526ad6",
         partitionValues = Map.empty,

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -226,13 +226,8 @@ private[spark] class DeltaSharingRestClient(
     val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
     checkProtocol(protocol)
     val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
-    if (Seq(versionAsOf, timestampAsOf).filter(_.isDefined).isEmpty) {
-      val files = lines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).file)
-      DeltaTableFiles(version, protocol, metadata, files)
-    } else {
-      val addFiles = lines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).add)
-      DeltaTableFiles(version, protocol, metadata, addFiles = addFiles)
-    }
+    val files = lines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).file)
+    DeltaTableFiles(version, protocol, metadata, files)
   }
 
   override def getFiles(table: Table, startingVersion: Long): DeltaTableFiles = {

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -231,21 +231,21 @@ case class DeltaSharingSource(
       // include table changes from previous versions.
       val tableFiles = deltaLog.client.getFiles(deltaLog.table, Nil, None, Some(fromVersion), None)
 
-      val numFiles = tableFiles.addFiles.size
-      tableFiles.addFiles.sortWith(fileActionCompareFunc).zipWithIndex.foreach {
-        case (add, index) if (index > fromIndex) =>
+      val numFiles = tableFiles.files.size
+      tableFiles.files.sortWith(fileActionCompareFunc).zipWithIndex.foreach {
+        case (file, index) if (index > fromIndex) =>
           appendToSortedFetchedFiles(
             IndexedFile(
               fromVersion,
               index,
               AddFileForCDF(
-                add.url,
-                add.id,
-                add.partitionValues,
-                add.size,
+                file.url,
+                file.id,
+                file.partitionValues,
+                file.size,
                 fromVersion,
-                add.timestamp,
-                add.stats
+                -1,
+                file.stats
               ),
               isLast = (index + 1 == numFiles)))
       }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -189,37 +189,31 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Some(1L),
         None)
       assert(tableFiles.version == 1)
-      assert(tableFiles.addFiles.size == 3)
+      assert(tableFiles.files.size == 3)
       val expectedFiles = Seq(
-        AddFileForCDF(
-          url = tableFiles.addFiles(0).url,
+        AddFile(
+          url = tableFiles.files(0).url,
           id = "60d0cf57f3e4367db154aa2c36152a1f",
           partitionValues = Map.empty,
           size = 1030,
-          stats = """{"numRecords":1,"minValues":{"name":"1","age":1,"birthday":"2020-01-01"},"maxValues":{"name":"1","age":1,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
-          version = 1,
-          timestamp = 1651272635000L
+          stats = """{"numRecords":1,"minValues":{"name":"1","age":1,"birthday":"2020-01-01"},"maxValues":{"name":"1","age":1,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}"""
         ),
-        AddFileForCDF(
-          url = tableFiles.addFiles(1).url,
+        AddFile(
+          url = tableFiles.files(1).url,
           id = "d7ed708546dd70fdff9191b3e3d6448b",
           partitionValues = Map.empty,
           size = 1030,
-          stats = """{"numRecords":1,"minValues":{"name":"3","age":3,"birthday":"2020-01-01"},"maxValues":{"name":"3","age":3,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
-          version = 1,
-          timestamp = 1651272635000L
+          stats = """{"numRecords":1,"minValues":{"name":"3","age":3,"birthday":"2020-01-01"},"maxValues":{"name":"3","age":3,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}"""
         ),
-        AddFileForCDF(
-          url = tableFiles.addFiles(2).url,
+        AddFile(
+          url = tableFiles.files(2).url,
           id = "a6dc5694a4ebcc9a067b19c348526ad6",
           partitionValues = Map.empty,
           size = 1030,
-          stats = """{"numRecords":1,"minValues":{"name":"2","age":2,"birthday":"2020-01-01"},"maxValues":{"name":"2","age":2,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
-          version = 1,
-          timestamp = 1651272635000L
+          stats = """{"numRecords":1,"minValues":{"name":"2","age":2,"birthday":"2020-01-01"},"maxValues":{"name":"2","age":2,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}"""
         )
       )
-      assert(expectedFiles == tableFiles.addFiles.toList)
+      assert(expectedFiles == tableFiles.files.toList)
     } finally {
       client.close()
     }

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -145,7 +145,9 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
   }
 
   test("snapshot file index test with version") {
-    // The only diff in this test is: the RemoteSnapshot is with versionAsOf = Some(1)
+    // The only diff in this test with "snapshot file index test" is:
+    //  the RemoteSnapshot is with versionAsOf = Some(1), and is used in client.getFiles,
+    //  which will return version/timestamp for each file in TestDeltaSharingClient.getFiles.
     val spark = SparkSession.active
     val client = new TestDeltaSharingClient()
     val snapshot = new RemoteSnapshot(

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -62,25 +62,14 @@ class TestDeltaSharingClient(
     timestampAsOf: Option[String]): DeltaTableFiles = {
     limit.foreach(lim => TestDeltaSharingClient.limits = TestDeltaSharingClient.limits :+ lim)
 
-    if (versionAsOf.isDefined) {
-      val addFiles: Seq[AddFileForCDF] = Seq(
-        AddFileForCDF("f1.parquet", "f1", Map.empty, 0, 1, 1600000000L),
-        AddFileForCDF("f2.parquet", "f2", Map.empty, 0, 1, 1600000000L),
-        AddFileForCDF("f3.parquet", "f3", Map.empty, 0, 1, 1600000000L),
-        AddFileForCDF("f4.parquet", "f4", Map.empty, 0, 1, 1600000000L)
-      ).take(limit.getOrElse(4L).toInt)
+    val addFiles: Seq[AddFile] = Seq(
+      AddFile("f1.parquet", "f1", Map.empty, 0),
+      AddFile("f2.parquet", "f2", Map.empty, 0),
+      AddFile("f3.parquet", "f3", Map.empty, 0),
+      AddFile("f4.parquet", "f4", Map.empty, 0)
+    ).take(limit.getOrElse(4L).toInt)
 
-      DeltaTableFiles(0, Protocol(0), metadata, addFiles = addFiles)
-    } else {
-      val addFiles: Seq[AddFile] = Seq(
-        AddFile("f1.parquet", "f1", Map.empty, 0),
-        AddFile("f2.parquet", "f2", Map.empty, 0),
-        AddFile("f3.parquet", "f3", Map.empty, 0),
-        AddFile("f4.parquet", "f4", Map.empty, 0)
-      ).take(limit.getOrElse(4L).toInt)
-
-      DeltaTableFiles(0, Protocol(0), metadata, addFiles)
-    }
+    DeltaTableFiles(0, Protocol(0), metadata, addFiles)
   }
 
   override def getFiles(table: Table, startingVersion: Long): DeltaTableFiles = {


### PR DESCRIPTION
Non-breaking change: return version and timestamp for queryTable with version: We are extending `AddFile` instead of switching to `AddFileForCDF`, so the line in the response still has key 'file' instead of 'add'. 

Verified that this is non-breaking to reserve the client change in another PR, so the integration test verified that old client works with new server response.