### PR TITLE
Spark connector changes to consume size from metadata.

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2271,6 +2271,8 @@ format | [Format](#format) Object | Specification of the encoding for the files 
 schemaString | String | Schema of the table. This is a serialized JSON string which can be deserialized to a [Schema](#schema-object) Object. | Required
 partitionColumns | Array<String> | An array containing the names of columns by which the data should be partitioned. When a table doesn’t have partition columns, this will be an **empty** array. | Required
 configuration | Map[String, String] | A map containing configuration options for the table
+size | Long | The size of the table in bytes. | Optional 
+numFiles | Long | The number of files in the table. | Optional
 
 Example (for illustration purposes; each JSON object must be a single line in the response):
 
@@ -2287,7 +2289,9 @@ Example (for illustration purposes; each JSON object must be a single line in th
     "id": "f8d5c169-3d01-4ca3-ad9e-7dc3355aedb2",
     "configuration": {
       "enableChangeDataFeed": "true"
-    }
+    },
+    "size": 123456,
+    "numFiles": 5
   }
 }
 ```

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -208,13 +208,25 @@ class RemoteSnapshot(
 
   def getTablePath: Path = tablePath
 
-  lazy val sizeInBytes = {
+  // This function is invoked during spark's query planning phase.
+  //
+  // The delta sharing server may not return the table size in its metadata if:
+  //   - We are talking to an older version of the server.
+  //   - The table does not contain this information in its metadata.
+  // We perform a full scan in that case.
+  lazy val sizeInBytes: Long = {
     val implicits = spark.implicits
     import implicits._
-    val tableFiles = client.getFiles(table, Nil, None, versionAsOf, timestampAsOf)
-    checkProtocolNotChange(tableFiles.protocol)
-    checkSchemaNotChange(tableFiles.metadata)
-    tableFiles.files.map(_.size).sum
+
+    if (metadata.size != null) {
+      metadata.size
+    } else {
+      log.warn("Getting table size from a full file scan for table: " + table)
+      val tableFiles = client.getFiles(table, Nil, None, versionAsOf, timestampAsOf)
+      checkProtocolNotChange(tableFiles.protocol)
+      checkSchemaNotChange(tableFiles.metadata)
+      tableFiles.files.map(_.size).sum
+    }
   }
 
   private def getTableMetadata: (Metadata, Protocol, Long) = {

--- a/spark/src/main/scala/io/delta/sharing/spark/model.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/model.scala
@@ -96,7 +96,9 @@ private[sharing] case class Metadata(
     schemaString: String = null,
     configuration: Map[String, String] = Map.empty,
     partitionColumns: Seq[String] = Nil,
-    version: java.lang.Long = null) extends Action {
+    version: java.lang.Long = null,
+    size: java.lang.Long = null,
+    numFiles: java.lang.Long = null) extends Action {
   override def wrap: SingleAction = SingleAction(metaData = this)
 }
 

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -88,6 +88,8 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     val spark = SparkSession.active
     val client = new TestDeltaSharingClient()
     val snapshot = new RemoteSnapshot(new Path("test"), client, Table("fe", "fi", "fo"))
+    assert(snapshot.sizeInBytes == 100)
+    assert(snapshot.metadata.numFiles == 2)
 
     // Create an index without limits.
     val fileIndex = {
@@ -158,6 +160,8 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
       Table("fe", "fi", "fo"),
       versionAsOf = Some(1)
     )
+    assert(snapshot.sizeInBytes == 100)
+    assert(snapshot.metadata.numFiles == 2)
 
     // Create an index without limits.
     val fileIndex = {
@@ -229,6 +233,8 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
       // This is not parsed, just a place holder.
       timestampAsOf = Some("2022-01-01 00:00:00.0")
     )
+    assert(snapshot.sizeInBytes == 100)
+    assert(snapshot.metadata.numFiles == 2)
 
     // Create an index without limits.
     val fileIndex = {

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -42,7 +42,8 @@ class TestDeltaSharingClient(
       |{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",
       |\"fields\":[{\"name\":\"col1\",\"type\":\"integer\",\"nullable\":true,
       |\"metadata\":{}},{\"name\":\"col2\",\"type\":\"string\",\"nullable\":true,
-      |\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1603723967515}}"""
+      |\"metadata\":{}}]}","partitionColumns":[],"configuration":{},
+      |"size": 100,"numFiles": 2,"createdTime":1603723967515}}"""
       .stripMargin.replaceAll("\n", "")
   private val metadata = JsonUtils.fromJson[SingleAction](metadataString).metaData
 


### PR DESCRIPTION
In this change, delta sharing will try to get the table size from table metadata if it is available.
If not available, it will fall back to computing the size from full parquet scan.
The existing code always computes the size from parquet scan, making it a performance bottleneck.

Tested the following combinations:

New server, new connector -> avoids extra queryTable call
New server, old connector -> works (backwards compatibility)
Old server, new connector -> works (backwards compatibility)
