### PR TITLE
Support more flexible format for timestamp options in spark 

### DIFF
--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -400,9 +400,9 @@ def test_load_as_pandas_success(
         pytest.param(
             "share8.default.cdf_table_cdf_enabled",
             None,
-            "2000-01-01 00:00:00",
+            "2000-01-01T00:00:00Z",
             "Please use a timestamp greater",
-            id="timestap too early ",
+            id="timestamp too early ",
         ),
     ],
 )
@@ -488,7 +488,7 @@ def test_load_as_pandas_exception(
             "share8.default.cdf_table_cdf_enabled",
             None,
             None,
-            "2000-01-01 00:00:00",
+            "2000-01-01T00:00:00Z",
             None,
             "Please use a timestamp greater",
             pd.DataFrame({"not_used": []}),
@@ -499,7 +499,7 @@ def test_load_as_pandas_exception(
             0,
             None,
             None,
-            "2100-01-01 00:00:00",
+            "2100-01-01T00:00:00Z",
             "Please use a timestamp less",
             pd.DataFrame({"not_used": []}),
             id="cdf_table_cdf_enabled table changes with ending_timestamp",
@@ -617,7 +617,7 @@ def test_parse_url():
         pytest.param(
             "share8.default.cdf_table_cdf_enabled",
             None,
-            "2000-01-01 00:00:00",
+            "2000-01-01T00:00:00Z",
             "Please use a timestamp greater",
             [],
             "not-used-schema-str",
@@ -626,7 +626,7 @@ def test_parse_url():
         pytest.param(
             "share8.default.cdf_table_cdf_enabled",
             1,
-            "2000-01-01 00:00:00",
+            "2000-01-01T00:00:00Z",
             "Please either provide",
             [],
             "not-used-schema-str",
@@ -648,7 +648,7 @@ def test_load_as_spark(
         spark = SparkSession.builder \
             .appName("delta-sharing-test") \
             .master("local[*]") \
-            .config("spark.jars.packages", "io.delta:delta-sharing-spark_2.12:0.6.0-SNAPSHOT") \
+            .config("spark.jars.packages", "io.delta:delta-sharing-spark_2.12:1.0.0-SNAPSHOT") \
             .config("spark.delta.sharing.network.sslTrustAll", "true") \
             .getOrCreate()
 
@@ -698,7 +698,7 @@ def test_load_as_spark(
             "share8.default.cdf_table_cdf_enabled",
             None,
             None,
-            "2000-01-01 00:00:00",
+            "2000-01-01T00:00:00Z",
             None,
             "Please use a timestamp greater",
             [],
@@ -710,7 +710,7 @@ def test_load_as_spark(
             0,
             None,
             None,
-            "2100-01-01 00:00:00",
+            "2100-01-01T00:00:00Z",
             "Please use a timestamp less than",
             [],
             "unused-schema-str",
@@ -746,7 +746,7 @@ def test_load_table_changes_as_spark(
         spark = SparkSession.builder \
             .appName("delta-sharing-test") \
             .master("local[*]") \
-            .config("spark.jars.packages", "io.delta:delta-sharing-spark_2.12:0.6.0-SNAPSHOT") \
+            .config("spark.jars.packages", "io.delta:delta-sharing-spark_2.12:1.0.0-SNAPSHOT") \
             .config("spark.delta.sharing.network.sslTrustAll", "true") \
             .getOrCreate()
 

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -230,7 +230,7 @@ def test_query_existed_table_version(rest_client: DataSharingRestClient):
 def test_query_table_version_with_timestamp(rest_client: DataSharingRestClient):
     response = rest_client.query_table_version(
         Table(name="cdf_table_cdf_enabled", share="share8", schema="default"),
-        starting_timestamp="2020-01-01 00:00:00.0"
+        starting_timestamp="2020-01-01T00:00:00-08:00"
     )
     assert isinstance(response.delta_table_version, int)
     assert response.delta_table_version == 0
@@ -241,7 +241,7 @@ def test_query_table_version_with_timestamp_exception(rest_client: DataSharingRe
     try:
         rest_client.query_table_version(
             Table(name="table1", share="share1", schema="default"),
-            starting_timestamp="2020-01-1 00:00:00.0"
+            starting_timestamp="2020-01-1T00:00:00-08:00"
         )
     except Exception as e:
         assert isinstance(e, HTTPError)
@@ -520,16 +520,17 @@ def test_list_files_in_table_timestamp(
     # Use a random string, and look for an appropriate error.
     # This will ensure that the timestamp is pass to server.
     try:
-        rest_client.list_files_in_table(cdf_table, timestamp="random")
+        rest_client.list_files_in_table(cdf_table, timestamp="randomTimestamp")
         assert False
     except Exception as e:
         assert isinstance(e, HTTPError)
-        assert "Invalid timestamp: Timestamp format must be" in (str(e))
+        assert "Invalid timestamp:" in (str(e))
+        assert "randomTimestamp" in (str(e))
 
     # Use a really old start time, and look for an appropriate error.
     # This will ensure that the timestamp is parsed correctly.
     try:
-        rest_client.list_files_in_table(cdf_table, timestamp="2000-01-01 00:00:00")
+        rest_client.list_files_in_table(cdf_table, timestamp="2000-01-01T00:00:00Z")
         assert False
     except Exception as e:
         assert isinstance(e, HTTPError)
@@ -537,7 +538,7 @@ def test_list_files_in_table_timestamp(
 
     # Use an end time far away, and look for an appropriate error.
     try:
-        rest_client.list_files_in_table(cdf_table, timestamp="9000-01-01 00:00:00")
+        rest_client.list_files_in_table(cdf_table, timestamp="9000-01-01T00:00:00Z")
         assert False
     except Exception as e:
         assert isinstance(e, HTTPError)
@@ -698,7 +699,7 @@ def test_list_table_changes_with_timestamp(
     try:
         rest_client.list_table_changes(
             cdf_table,
-            CdfOptions(starting_timestamp="2000-05-03 00:00:00")
+            CdfOptions(starting_timestamp="2000-05-03T00:00:00-08:00")
         )
         assert False
     except Exception as e:
@@ -709,7 +710,7 @@ def test_list_table_changes_with_timestamp(
     try:
         rest_client.list_table_changes(
             cdf_table,
-            CdfOptions(starting_version=0, ending_timestamp="2100-05-03 00:00:00")
+            CdfOptions(starting_version=0, ending_timestamp="2100-05-03T00:00:00Z")
         )
         assert False
     except Exception as e:

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharingHistoryManager.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharingHistoryManager.scala
@@ -18,6 +18,9 @@
 package io.delta.standalone.internal
 
 import java.sql.Timestamp
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 import io.delta.standalone.internal.actions.CommitMarker
 import io.delta.standalone.internal.util.FileNames
@@ -59,9 +62,10 @@ object DeltaSharingHistoryManager {
   // Convert timestamp string to Timestamp
   private[internal] def getTimestamp(paramName: String, timeStampStr: String): Timestamp = {
     try {
-      Timestamp.valueOf(timeStampStr)
+      new Timestamp(OffsetDateTime.parse(
+        timeStampStr, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant.toEpochMilli)
     } catch {
-      case e: IllegalArgumentException =>
+      case e: java.time.format.DateTimeParseException =>
         throw DeltaCDFErrors.invalidTimestamp(paramName, e.getMessage)
     }
   }

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -430,7 +430,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       method = "GET",
       data = None,
       expectedErrorCode = 400,
-      expectedErrorMessage = "The provided timestamp (9999-01-01 00:00:00.0) is after the latest version available"
+      expectedErrorMessage = "The provided timestamp ("
     )
   }
 
@@ -804,7 +804,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       method = "POST",
       data = Some("""{"timestamp": "2000-01-01T00:00:00-08:00"}"""),
       expectedErrorCode = 400,
-      expectedErrorMessage = "The provided timestamp (2000-01-01 00:00:00.0) is before the earliest version"
+      expectedErrorMessage = "The provided timestamp "
     )
 
     // timestamp after the latest version
@@ -813,7 +813,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       method = "POST",
       data = Some("""{"timestamp": "9999-01-01T00:00:00-08:00"}"""),
       expectedErrorCode = 400,
-      expectedErrorMessage = "The provided timestamp (9999-01-01 00:00:00.0) is after the latest version available"
+      expectedErrorMessage = "The provided timestamp "
     )
 
     // can only query table data since version 1
@@ -1561,7 +1561,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       method = "GET",
       data = None,
       expectedErrorCode = 400,
-      expectedErrorMessage = "The provided timestamp (2000-01-01 00:00:00.0) is before the earliest version available"
+      expectedErrorMessage = "The provided timestamp ("
     )
 
     assertHttpError(
@@ -1569,7 +1569,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       method = "GET",
       data = None,
       expectedErrorCode = 400,
-      expectedErrorMessage = "The provided timestamp (9999-01-01 00:00:00.0) is after the latest version available"
+      expectedErrorMessage = "The provided timestamp ("
     )
 
     assertHttpError(

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
@@ -28,6 +28,11 @@ object DeltaSharingErrors {
     new IllegalStateException(s"sourceVersion($version) is invalid.")
   }
 
+  def timestampInvalid(str: String): Throwable = {
+    new IllegalArgumentException(s"The provided timestamp ($str) cannot be converted to a valid " +
+      s"timestamp.")
+  }
+
   def cannotFindSourceVersionException(json: String): Throwable = {
     new IllegalStateException(s"Cannot find 'sourceVersion' in $json")
   }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
@@ -86,6 +86,10 @@ trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
 
   def isTimeTravel: Boolean = versionAsOf.isDefined || timestampAsOf.isDefined
 
+  // Parse the input timestamp string and TimestampType, and generate a formatted timestamp string
+  // in the ISO8601 format, in the UTC timezone, such as 2022-01-01T00:00:00Z.
+  // The input string is quite flexible, examples of accepted format: "2022", "2022-01-01",
+  // "2022-01-01 00:00:00" "2022-01-01T00:00:00-08:00", etc.
   private def getFormattedTimestamp(str: String): String = {
     val castResult = Cast(
     Literal(str), TimestampType, Option(SQLConf.get.sessionLocalTimeZone)).eval()

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
@@ -88,8 +88,8 @@ trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
 
   // Parse the input timestamp string and TimestampType, and generate a formatted timestamp string
   // in the ISO8601 format, in the UTC timezone, such as 2022-01-01T00:00:00Z.
-  // The input string is quite flexible, examples of accepted format: "2022", "2022-01-01",
-  // "2022-01-01 00:00:00" "2022-01-01T00:00:00-08:00", etc.
+  // The input string is quite flexible, and can be in any timezone, examples of accepted format:
+  // "2022", "2022-01-01", "2022-01-01 00:00:00" "2022-01-01T00:00:00-08:00", etc.
   private def getFormattedTimestamp(str: String): String = {
     val castResult = Cast(
     Literal(str), TimestampType, Option(SQLConf.get.sessionLocalTimeZone)).eval()

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
@@ -23,7 +23,10 @@ import scala.util.Try
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.network.util.{ByteUnit, JavaUtils}
-import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.catalyst.expressions.{Cast, Literal}
+import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.TimestampType
 
 trait DeltaSharingOptionParser {
   protected def options: CaseInsensitiveMap[String]
@@ -68,7 +71,7 @@ trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
       }
   }
 
-  val startingTimestamp = options.get(STARTING_TIMESTAMP_OPTION)
+  val startingTimestamp = options.get(STARTING_TIMESTAMP_OPTION).map(getFormattedTimestamp(_))
 
   val cdfOptions: Map[String, String] = prepareCdfOptions()
 
@@ -79,14 +82,27 @@ trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
     }
   }
 
-  val timestampAsOf = options.get(TIME_TRAVEL_TIMESTAMP)
+  val timestampAsOf = options.get(TIME_TRAVEL_TIMESTAMP).map(getFormattedTimestamp(_))
 
   def isTimeTravel: Boolean = versionAsOf.isDefined || timestampAsOf.isDefined
+
+  private def getFormattedTimestamp(str: String): String = {
+    val castResult = Cast(
+    Literal(str), TimestampType, Option(SQLConf.get.sessionLocalTimeZone)).eval()
+    if (castResult == null) {
+      throw DeltaSharingErrors.timestampInvalid(str)
+    }
+    DateTimeUtils.toJavaTimestamp(castResult.asInstanceOf[java.lang.Long]).toInstant.toString
+  }
 
   private def prepareCdfOptions(): Map[String, String] = {
     if (readChangeFeed) {
       validCdfOptions.filter(option => options.contains(option._1)).map(option =>
-        option._1 -> options.get(option._1).get
+        if ((option._1 == CDF_START_TIMESTAMP) || (option._1 == CDF_END_TIMESTAMP)) {
+          option._1 -> getFormattedTimestamp(options.get(option._1).get)
+        } else {
+          option._1 -> options.get(option._1).get
+        }
       )
     } else {
      Map.empty[String, String]

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingOptionsSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingOptionsSuite.scala
@@ -61,24 +61,22 @@ class DeltaSharingOptionsSuite extends SparkFunSuite {
       "ignoreChanges" -> "false",
       "ignoreDeletes" -> "false",
       "readChangeData" -> "true",
-      "startingTimestamp" -> "2020",
-      "timestampAsOf" -> "2021"
+      "timestampAsOf" -> "2021-01-01T00:00:00-01:00"
     ))
     assert(options.maxBytesPerTrigger == Some(12288))
     assert(!options.ignoreChanges)
     assert(!options.ignoreDeletes)
     assert(options.readChangeFeed)
-    assert(options.startingTimestamp == Some("2020"))
-    assert(options.timestampAsOf == Some("2021"))
+    assert(options.timestampAsOf == Some("2021-01-01T01:00:00Z"))
 
     // Non parsed options remain in the CaseInsensitiveMap
     options = new DeltaSharingOptions(Map(
       "notReservedOption" -> "random",
       "endingVersion" -> "2",
-      "endingTimestamp" -> "2020"
+      "endingTimestamp" -> "2020-01-01"
     ))
     assert(options.options.get(DeltaSharingOptions.CDF_END_VERSION) == Some("2"))
-    assert(options.options.get(DeltaSharingOptions.CDF_END_TIMESTAMP) == Some("2020"))
+    assert(options.options.get(DeltaSharingOptions.CDF_END_TIMESTAMP) == Some("2020-01-01"))
     assert(options.options.get("notreservedoption") == Some("random"))
   }
 
@@ -86,93 +84,125 @@ class DeltaSharingOptionsSuite extends SparkFunSuite {
     var options = new DeltaSharingOptions(Map(
       "readChangeFeed" -> "true",
       "startingVersion" -> "15",
-      "endingTimestamp" -> "2022"
+      "endingTimestamp" -> "2022-01-01T00:00:00-02:00"
     ))
     assert(options.cdfOptions.size == 3)
     assert(options.cdfOptions.get(DeltaSharingOptions.CDF_READ_OPTION) == Some("true"))
     assert(options.cdfOptions.get(DeltaSharingOptions.CDF_START_VERSION) == Some("15"))
-    assert(options.cdfOptions.get(DeltaSharingOptions.CDF_END_TIMESTAMP) == Some("2022"))
+    assert(options.cdfOptions.get(DeltaSharingOptions.CDF_END_TIMESTAMP) ==
+      Some("2022-01-01T02:00:00Z"))
 
     options = new DeltaSharingOptions(Map(
       "readChangeData" -> "true",
-      "startingTimestamp" -> "2022",
+      "startingTimestamp" -> "2022-01-01T00:00:00-03:00",
       "endingVersion" -> "16"
     ))
     assert(options.cdfOptions.size == 3)
     assert(options.cdfOptions.get(DeltaSharingOptions.CDF_READ_OPTION_LEGACY) == Some("true"))
-    assert(options.cdfOptions.get(DeltaSharingOptions.CDF_START_TIMESTAMP) == Some("2022"))
+    assert(options.cdfOptions.get(DeltaSharingOptions.CDF_START_TIMESTAMP)
+      == Some("2022-01-01T03:00:00Z"))
     assert(options.cdfOptions.get(DeltaSharingOptions.CDF_END_VERSION) == Some("16"))
 
     // startingTimestamp won't be considered as cdf options if readChangeFeed is not set
     options = new DeltaSharingOptions(Map(
-      "startingTimestamp" -> "2022",
+      "startingTimestamp" -> "2022-01-01T00:00:00Z",
       "endingVersion" -> "16"
     ))
     assert(options.cdfOptions.isEmpty)
   }
 
+  test("timestamp formatted correctly") {
+    // various input string of timestamp is supported
+    var options = new DeltaSharingOptions(Map(
+      "readChangeData" -> "true",
+      "startingTimestamp" -> "2022",
+      "endingTimestamp" -> "2022-01",
+      "timestampAsOf" -> "2022-01-01 00:00"
+    ))
+    // only checking the existence, because it's not sure in which timezone the test is executed.
+    assert(options.timestampAsOf.isDefined)
+    assert(options.cdfOptions.get(DeltaSharingOptions.CDF_START_TIMESTAMP).isDefined)
+    assert(options.cdfOptions.get(DeltaSharingOptions.CDF_END_TIMESTAMP).isDefined)
+
+    options = new DeltaSharingOptions(Map(
+      "readChangeData" -> "true",
+      "startingTimestamp" -> "2022-01-01T00:00:00",
+      "endingTimestamp" -> "2022-01-01 00:00:00Z",
+      "timestampAsOf" -> "2022-01-01 00:00:00+01:00"
+    ))
+    // only checking the existence, because it's not sure in which timezone the test is executed.
+    assert(options.timestampAsOf.isDefined)
+    assert(options.cdfOptions.get(DeltaSharingOptions.CDF_START_TIMESTAMP).isDefined)
+    assert(options.cdfOptions.get(DeltaSharingOptions.CDF_END_TIMESTAMP).isDefined)
+  }
+
+  test("timestamp format exceptions") {
+    var errorMessage = intercept[IllegalArgumentException] {
+      new DeltaSharingOptions(Map("timestampAsOf" -> "202"))
+    }.getMessage
+    assert(errorMessage.contains("The provided timestamp (202) cannot be converted to a valid " +
+      "timestamp."))
+
+    errorMessage = intercept[IllegalArgumentException] {
+      new DeltaSharingOptions(Map("timestampAsOf" -> "a"))
+    }.getMessage
+    assert(errorMessage.contains("The provided timestamp (a) cannot be converted to a valid " +
+      "timestamp."))
+  }
+
   test("exceptions") {
     // Boolean required
     var errorMessage = intercept[IllegalArgumentException] {
-      val options = new DeltaSharingOptions(
-        Map("ignoreChanges" -> "1"))
+      new DeltaSharingOptions(Map("ignoreChanges" -> "1"))
     }.getMessage
     assert(errorMessage.contains(
       "Invalid value '1' for option 'ignoreChanges', must be 'true' or 'false'"))
 
     errorMessage = intercept[IllegalArgumentException] {
-      val options = new DeltaSharingOptions(
-        Map("ignoreDeletes" -> "1"))
+      new DeltaSharingOptions(Map("ignoreDeletes" -> "1"))
     }.getMessage
     assert(errorMessage.contains(
       "Invalid value '1' for option 'ignoreDeletes', must be 'true' or 'false'"))
 
     errorMessage = intercept[IllegalArgumentException] {
-      val options = new DeltaSharingOptions(
-        Map("readChangeFeed" -> "1"))
+      new DeltaSharingOptions(Map("readChangeFeed" -> "1"))
     }.getMessage
     assert(errorMessage.contains(
       "Invalid value '1' for option 'readChangeFeed', must be 'true' or 'false'"))
 
     errorMessage = intercept[IllegalArgumentException] {
-      val options = new DeltaSharingOptions(
-        Map("readChangeData" -> "1"))
+      new DeltaSharingOptions(Map("readChangeData" -> "1"))
     }.getMessage
     assert(errorMessage.contains(
       "Invalid value '1' for option 'readChangeData', must be 'true' or 'false'"))
 
     // Integer or bytes
     errorMessage = intercept[IllegalArgumentException] {
-      val options = new DeltaSharingOptions(
-        Map("versionAsOf" -> "x3"))
+      new DeltaSharingOptions(Map("versionAsOf" -> "x3"))
     }.getMessage
     assert(errorMessage.contains("Invalid value 'x3' for option 'versionAsOf', must be an integer" +
       " greater than or equal to zero"))
 
     errorMessage = intercept[IllegalArgumentException] {
-      val options = new DeltaSharingOptions(
-        Map("maxFilesPerTrigger" -> "-1"))
+      new DeltaSharingOptions(Map("maxFilesPerTrigger" -> "-1"))
     }.getMessage
     assert(errorMessage.contains(
       "Invalid value '-1' for option 'maxFilesPerTrigger', must be a positive integer"))
 
     errorMessage = intercept[IllegalArgumentException] {
-      val options = new DeltaSharingOptions(
-        Map("maxBytesPerTrigger" -> "2mg"))
+      new DeltaSharingOptions(Map("maxBytesPerTrigger" -> "2mg"))
     }.getMessage
     assert(errorMessage.contains("Invalid value '2mg' for option 'maxBytesPerTrigger', must be " +
       "a size configuration such as '10g'"))
 
     // only one of options can be set
     errorMessage = intercept[IllegalArgumentException] {
-      val options = new DeltaSharingOptions(
-        Map("startingVersion" -> "1", "startingTimestamp" -> "2020"))
+      new DeltaSharingOptions(Map("startingVersion" -> "1", "startingTimestamp" -> "2020"))
     }.getMessage
     assert(errorMessage.contains("Please either provide 'startingVersion' or 'startingTimestamp'"))
 
     errorMessage = intercept[IllegalArgumentException] {
-      val options = new DeltaSharingOptions(
-        Map("versionAsOf" -> "1", "timestampAsOf" -> "2020"))
+      new DeltaSharingOptions(Map("versionAsOf" -> "1", "timestampAsOf" -> "2020"))
     }.getMessage
     assert(errorMessage.contains("Please either provide 'versionAsOf' or 'timestampAsOf'"))
   }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -92,7 +92,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       assert(client.getTableVersion(Table(name = "table1", schema = "default", share = "share1")) == 2)
       assert(client.getTableVersion(Table(name = "table3", schema = "default", share = "share1")) == 4)
       assert(client.getTableVersion(Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
-        startingTimestamp = Some("2020-01-01 00:00:00")) == 0)
+        startingTimestamp = Some("2020-01-01T00:00:00Z")) == 0)
     } finally {
       client.close()
     }
@@ -103,7 +103,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     try {
       val errorMessage = intercept[UnexpectedHttpStatus] {
         client.getTableVersion(Table(name = "table1", schema = "default", share = "share1"),
-          startingTimestamp = Some("2020-01-01 00:00:00"))
+          startingTimestamp = Some("2020-01-01T00:00:00Z"))
       }.getMessage
       assert(errorMessage.contains("400 Bad Request"))
       assert(errorMessage.contains("Reading table by version or timestamp is not supported"))
@@ -260,7 +260,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
           Nil,
           None,
           None,
-          Some("2000-01-01 00:00:00"))
+          Some("2000-01-01T00:00:00Z"))
       }.getMessage
       assert(errorMessage.contains("The provided timestamp"))
     } finally {
@@ -582,7 +582,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       // This is to test that timestamp is correctly passed to the server and parsed.
       // The error message is expected as we are using a timestamp much smaller than the earliest
       // version of the table.
-      val cdfOptions = Map("startingTimestamp" -> "2000-01-01 00:00:00")
+      val cdfOptions = Map("startingTimestamp" -> "2000-01-01T00:00:00Z")
       val errorMessage = intercept[UnexpectedHttpStatus] {
         val tableFiles = client.getCDFFiles(
           Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
@@ -602,7 +602,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       // This is to test that timestamp is correctly passed to the server and parsed.
       // The error message is expected as we are using a timestamp much larger than the latest
       // version of the table.
-      val cdfOptions = Map("startingVersion" -> "0", "endingTimestamp" -> "2100-01-01 00:00:00")
+      val cdfOptions = Map("startingVersion" -> "0", "endingTimestamp" -> "2100-01-01T00:00:00Z")
       val errorMessage = intercept[UnexpectedHttpStatus] {
         val tableFiles = client.getCDFFiles(
           Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceCDFSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceCDFSuite.scala
@@ -415,7 +415,7 @@ class DeltaSharingSourceCDFSuite extends QueryTest
         .load(cdfTablePath).writeStream.format("console").start()
       query.processAllAvailable()
     }.getMessage
-    assert(message.contains("The provided timestamp (9999-01-01 00:00:00.0) is after"))
+    assert(message.contains("The provided timestamp ("))
 
     // startingTimestamp corresponds to version 0, < starting version 1 on partitionTablePath.
     message = intercept[StreamingQueryException] {
@@ -425,7 +425,8 @@ class DeltaSharingSourceCDFSuite extends QueryTest
         .load(partitionTablePath).writeStream.format("console").start()
       query.processAllAvailable()
     }.getMessage
-    assert(message.contains("The provided timestamp(2022-01-01 00:00:00) corresponds to 0"))
+    assert(message.contains("The provided timestamp"))
+    assert(message.contains("corresponds to 0"))
     // startingVersion > latest version
   }
 

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -523,17 +523,17 @@ class DeltaSharingSourceSuite extends QueryTest
       }
     }
 
-    var message = intercept[StreamingQueryException] {
+    var message = intercept[IllegalArgumentException] {
       val query = spark.readStream.format("deltaSharing").option("path", tablePath)
         .option("startingTimestamp", "")
         .load().writeStream.format("console").start()
       query.processAllAvailable()
     }.getMessage
-    assert(message.contains("Invalid startingTimestamp:"))
+    assert(message.contains("The provided timestamp () cannot be converted to a valid timestamp"))
 
     message = intercept[IllegalArgumentException] {
       val query = spark.readStream.format("deltaSharing").option("path", tablePath)
-        .option("startingTimestamp", "")
+        .option("startingTimestamp", "2022-01-01")
         .option("startingVersion", "1")
         .load().writeStream.format("console").start()
     }.getMessage
@@ -545,7 +545,7 @@ class DeltaSharingSourceSuite extends QueryTest
         .load().writeStream.format("console").start()
       query.processAllAvailable()
     }.getMessage
-    assert(message.contains("The provided timestamp (9999-01-01 00:00:00.0) is after"))
+    assert(message.contains("The provided timestamp ("))
   }
 
   integrationTest("startingTimestamp - succeeds") {

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -184,7 +184,8 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
         expected
       )
     }.getMessage
-    assert(errorMessage.contains("The provided timestamp (2000-01-01 00:00:00.0) is before"))
+    assert(errorMessage.contains("The provided timestamp ("))
+    assert(errorMessage.contains("The provided timestamp ("))
 
     errorMessage = intercept[IllegalArgumentException] {
       checkAnswer(


### PR DESCRIPTION
Client side:
Support more flexible format for timestamp options in spark, to be similar with delta.

Server side:
Support ISO_OFFSET_DATE_TIME format for all timestamp related parameters: startingTimestamp, timestampAsOf, cdf.startingTimestamp, cdf.endingTimestamp.