### PR TITLE
Support more flexible format for timestamp options in spark in v0.5"

### DIFF
--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -432,7 +432,7 @@ def test_load(
             "share1.default.cdf_table_cdf_enabled",
             None,
             None,
-            "2000-01-01 00:00:00",
+            "2000-01-01T00:00:00Z",
             None,
             "Please use a timestamp greater",
             pd.DataFrame({"not_used": []}),
@@ -443,7 +443,7 @@ def test_load(
             0,
             None,
             None,
-            "2100-01-01 00:00:00",
+            "2100-01-01T00:00:00Z",
             "Please use a timestamp less",
             pd.DataFrame({"not_used": []}),
             id="cdf_table_cdf_enabled table changes with ending_timestamp",
@@ -561,7 +561,7 @@ def test_load_as_spark(
         spark = SparkSession.builder \
             .appName("delta-sharing-test") \
             .master("local[*]") \
-            .config("spark.jars.packages", "io.delta:delta-sharing-spark_2.12:0.5.0-SNAPSHOT") \
+            .config("spark.jars.packages", "io.delta:delta-sharing-spark_2.12:0.5.3-SNAPSHOT") \
             .config("spark.delta.sharing.network.sslTrustAll", "true") \
             .getOrCreate()
 
@@ -611,7 +611,7 @@ def test_load_as_spark(
             "share1.default.cdf_table_cdf_enabled",
             None,
             None,
-            "2000-01-01 00:00:00",
+            "2000-01-01T00:00:00Z",
             None,
             "Please use a timestamp greater",
             [],
@@ -623,7 +623,7 @@ def test_load_as_spark(
             0,
             None,
             None,
-            "2100-01-01 00:00:00",
+            "2100-01-01T00:00:00Z",
             "Please use a timestamp less than",
             [],
             "unused-schema-str",
@@ -666,7 +666,7 @@ def test_load_table_changes_as_spark(
         spark = SparkSession.builder \
             .appName("delta-sharing-test") \
             .master("local[*]") \
-            .config("spark.jars.packages", "io.delta:delta-sharing-spark_2.12:0.5.0-SNAPSHOT") \
+            .config("spark.jars.packages", "io.delta:delta-sharing-spark_2.12:0.5.3-SNAPSHOT") \
             .config("spark.delta.sharing.network.sslTrustAll", "true") \
             .getOrCreate()
 

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -573,7 +573,7 @@ def test_list_table_changes_with_timestamp(
     try:
         rest_client.list_table_changes(
             cdf_table,
-            CdfOptions(starting_timestamp="2000-05-03 00:00:00")
+            CdfOptions(starting_timestamp="2000-05-03T00:00:00Z")
         )
         assert False
     except Exception as e:
@@ -584,7 +584,7 @@ def test_list_table_changes_with_timestamp(
     try:
         rest_client.list_table_changes(
             cdf_table,
-            CdfOptions(starting_version=0, ending_timestamp="2100-05-03 00:00:00")
+            CdfOptions(starting_version=0, ending_timestamp="2100-05-03T00:00:00Z")
         )
         assert False
     except Exception as e:

--- a/python/dev/pytest
+++ b/python/dev/pytest
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-PYTHON_EXECUTABLE="${PYTHON_EXECUTABLE:-python}"
+PYTHON_EXECUTABLE="${PYTHON_EXECUTABLE:-python3}"
 
 set -o pipefail
 set -e

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharingCDCReader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharingCDCReader.scala
@@ -18,6 +18,9 @@
 package io.delta.standalone.internal
 
 import java.sql.Timestamp
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 import io.delta.standalone.DeltaLog
 import io.delta.standalone.internal.actions.{
@@ -82,9 +85,10 @@ class DeltaSharingCDCReader(val deltaLog: DeltaLogImpl, val conf: Configuration)
   // Convert timestamp string in cdfOptions to Timestamp
   private def getTimestamp(paramName: String, timeStampStr: String): Timestamp = {
     try {
-      Timestamp.valueOf(timeStampStr)
+      new Timestamp(OffsetDateTime.parse(
+        timeStampStr, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant.toEpochMilli)
     } catch {
-      case e: IllegalArgumentException =>
+      case e: java.time.format.DateTimeParseException =>
         throw DeltaCDFErrors.invalidTimestamp(paramName, e.getMessage)
     }
   }

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -643,9 +643,9 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
 
   integrationTest("cdf_table_cdf_enabled_changes: timestamp works") {
     // 1651272616000, PST: 2022-04-29 15:50:16.0
-    val startStr = URLEncoder.encode(new Timestamp(1651272616000L).toString)
+    val startStr = new Timestamp(1651272616000L).toInstant.toString
     // 1651272660000, PST: 2022-04-29 15:51:00.0
-    val endStr = URLEncoder.encode(new Timestamp(1651272660000L).toString)
+    val endStr = new Timestamp(1651272660000L).toInstant.toString
 
     val response = readNDJson(requestPath(s"/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingTimestamp=${startStr}&endingTimestamp=${endStr}"), Some("GET"), None, None)
     val lines = response.split("\n")
@@ -874,7 +874,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     )
 
     assertHttpError(
-      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=1&startingTimestamp=2022-02-02%2000:00:00"),
+      url = requestPath("/shares/share1/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=1&startingTimestamp=2022-02-02T00:00:00Z"),
       method = "GET",
       data = None,
       expectedErrorCode = 400,

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -307,7 +307,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       // This is to test that timestamp is correctly passed to the server and parsed.
       // The error message is expected as we are using a timestamp much larger than the latest
       // version of the table.
-      val cdfOptions = Map("startingTimestamp" -> "2000-01-01 00:00:00")
+      val cdfOptions = Map("startingTimestamp" -> "2000-01-01T00:00:00Z")
       val errorMessage = intercept[UnexpectedHttpStatus] {
         val tableFiles = client.getCDFFiles(
           Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),
@@ -326,7 +326,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       // This is to test that timestamp is correctly passed to the server and parsed.
       // The error message is expected as we are using a timestamp much larger than the latest
       // version of the table.
-      val cdfOptions = Map("startingVersion" -> "0", "endingTimestamp" -> "2100-01-01 00:00:00")
+      val cdfOptions = Map("startingVersion" -> "0", "endingTimestamp" -> "2100-01-01T00:00:00Z")
       val errorMessage = intercept[UnexpectedHttpStatus] {
         val tableFiles = client.getCDFFiles(
           Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share1"),

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -221,7 +221,7 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
     val result1 = intercept[IllegalStateException] {
       val df = spark.read.format("deltaSharing")
         .option("readChangeFeed", "true")
-        .option("startingTimestamp", "2000-01-01 00:00:00").load(tablePath)
+        .option("startingTimestamp", "2000-01-01").load(tablePath)
       checkAnswer(df, Nil)
     }
     assert (result1.getMessage.contains("Please use a timestamp greater"))
@@ -231,7 +231,7 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
       val df = spark.read.format("deltaSharing")
         .option("readChangeFeed", "true")
         .option("startingVersion", 0)
-        .option("endingTimestamp", "2100-01-01 00:00:00").load(tablePath)
+        .option("endingTimestamp", "2100-01-01").load(tablePath)
       checkAnswer(df, Nil)
     }
     assert (result2.getMessage.contains("Please use a timestamp less"))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.1"
+version in ThisBuild := "0.5.3-SNAPSHOT"


### PR DESCRIPTION
Client side:
Support more flexible format for startingTimestamp/endingTimestamp options in spark, to be similar with delta.

Server side:
Support ISO_OFFSET_DATE_TIME format for all timestamp related parameters: cdf.startingTimestamp, cdf.endingTimestamp.