### PR TITLE
PROTOCOL changes in release 0.6.2

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1174,12 +1174,15 @@ Example:
 
 This is the API for clients to get a table version without any other extra information. The server usually can implement this API effectively. If a client caches information about a shared table locally, it can store the table version and use this cheap API to quickly check whether their cache is stale and they should re-fetch the data.
 
+Note: We are migrating this method from HEAD to GET, and with a `/version` suffix. Please use the new API as we'll be deprecating the support of HEAD API soon. 
+
 HTTP Request | Value
 -|-
-Method | `HEAD`
+Method | `GET`
 Header | `Authorization: Bearer {token}`
-URL | `{prefix}/shares/{share}/schemas/{schema}/tables/{table}`
+URL | `{prefix}/shares/{share}/schemas/{schema}/tables/{table}/version`
 URL Parameters | **{share}**: The share name to query. It's case-insensitive.<br>**{schema}**: The schema name to query. It's case-insensitive.<br>**{table}**: The table name to query. It's case-insensitive.
+Query Parameters | **startingTimestamp** (type: String, optional): The startingTimestamp of the query, the server needs to return a table version at or after the provided timestamp, can be earlier that the timestamp of table version 0.
 
 <details open>
 <summary><b>200: The table version was successfully returned.</b></summary>
@@ -1368,7 +1371,7 @@ URL Parameters | **{share}**: The share name to query. It's case-insensitive.<br
 
 Example:
 
-`HEAD {prefix}/shares/vaccine_share/schemas/acme_vaccine_data/tables/vaccine_patients`
+`GET {prefix}/shares/vaccine_share/schemas/acme_vaccine_data/tables/vaccine_patients/version?startingTimestamp=2022-12-01%2000:00:00`
 
 ```
 HTTP/2 200 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1371,7 +1371,7 @@ Query Parameters | **startingTimestamp** (type: String, optional): The startingT
 
 Example:
 
-`GET {prefix}/shares/vaccine_share/schemas/acme_vaccine_data/tables/vaccine_patients/version
+`GET {prefix}/shares/vaccine_share/schemas/acme_vaccine_data/tables/vaccine_patients/version`
 
 ```
 HTTP/2 200 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1971,29 +1971,46 @@ The change data feed represents row-level changes between versions of a Delta ta
 </tr>
 <tr>
 <td>Method</td>
-<td>`GET`</td>
+<td>
+ 
+`GET`
+ 
+</td>
 </tr>
 <tr>
 <td>Header</td>
-<td>`Authorization: Bearer {token}`</td>
+<td>
+
+`Authorization: Bearer {token}`
+
+</td>
 </tr>
 <tr>
 <td>URL</td>
-<td>`{prefix}/shares/{share}/schemas/{schema}/tables/{table}/changes`</td>
+<td>
+
+`{prefix}/shares/{share}/schemas/{schema}/tables/{table}/changes`
+
+</td>
 </tr>
 <tr>
 <td>URL Parameters</td>
-<td>**{share}**: The share name to query. It's case-insensitive.<br>
+<td>
+
+**{share}**: The share name to query. It's case-insensitive.<br>
 **{schema}**: The schema name to query. It's case-insensitive.<br>
-**{table}**: The table name to query. It's case-insensitive.</td>
+**{table}**: The table name to query. It's case-insensitive.
+</td>
 </tr>
 <tr>
 <td>Query Parameters</td>
-<td>**startingVersion** (type: Int64, optional): The starting version of the query, inclusive. <br>
+<td>
+
+ **startingVersion** (type: Int64, optional): The starting version of the query, inclusive. <br>
  **startingTimestamp** (type: String, optional): The starting timestamp of the query, will be converted to a version created greater or equal to this timestamp. <br>
  **endingVersion** (type: Int64, optional): The ending version of the query, inclusive. <br>
  **endingTimestamp** (type: String, optional): The ending timestamp of the query, will be converted to a version created earlier or equal to this timestamp. <br>
- **includeHistoricalMetadata**(type: Boolean, optional): If set to true, return the historical metadata if seen in the delta log. This is for the streaming client to check if the table schema is still read compatible.</td>
+ **includeHistoricalMetadata** (type: Boolean, optional): If set to true, return the historical metadata if seen in the delta log. This is for the streaming client to check if the table schema is still read compatible.</td>
 </tr>
 </table>
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1174,18 +1174,56 @@ Example:
 
 This is the API for clients to get a table version without any other extra information. The server usually can implement this API effectively. If a client caches information about a shared table locally, it can store the table version and use this cheap API to quickly check whether their cache is stale and they should re-fetch the data.
 
-Note: This method is migrating from HEAD to GET, and with a `/version` suffix. Please use the new API as the support of HEAD API will be deprecated on the server side 07/01/2023. 
+Note: This method is migrating from HEAD to GET, and with a `/version` suffix. Please use the new API as we encourage that the HEAD API be deprecated by 07/01/2023. 
 
-HTTP Request | Value
--|-
-Method | `GET`
-Header | `Authorization: Bearer {token}`
-URL | `{prefix}/shares/{share}/schemas/{schema}/tables/{table}/version`
-URL Parameters | **{share}**: The share name to query. It's case-insensitive.<br>**{schema}**: The schema name to query. It's case-insensitive.<br>**{table}**: The table name to query. It's case-insensitive.
-Query Parameters | **startingTimestamp** (type: String, optional): The startingTimestamp of the query, a string in the [Timestamp Format](#timestamp-format), the server needs to return a table version at or after the provided timestamp, can be earlier than the timestamp of table version 0.
+<table>
+<tr>
+<th>HTTP Request</th>
+<th colspan="2">Value</th>
+</tr>
+<tr>
+<td>Method</td>
+<td>GET</td>
+<td>HEAD (deprecated)</td>
+</tr>
+<tr>
+<td>HEADER</td>
+<td colspan="2">
+
+`Authorization: Bearer {token}`</td>
+</tr>
+<tr>
+<td>URL</td>
+<td>
+
+`{prefix}/shares/{share}/schemas/{schema}/tables/{table}/version`
+</td>
+<td>
+
+`{prefix}/shares/{share}/schemas/{schema}/tables/{table}`
+</td>
+</tr>
+<tr>
+<td>URL parameters</td>
+<td colspan="2">
+
+**{share}**: The share name to query. It's case-insensitive.<br>**{schema}**: The schema name to query. It's case-insensitive.<br>**{table}**: The table name to query. It's case-insensitive.
+</td>
+</tr>
+<tr>
+<td>Query parameters</td>
+<td>
+
+**startingTimestamp** (type: String, optional): The startingTimestamp of the query, a string in the [Timestamp Format](#timestamp-format), the server needs to return the earliest table version at or after the provided timestamp, can be earlier than the timestamp of table version 0.
+</td>
+<td>N/A</td>
+</tr>
+</table>
 
 <details open>
 <summary><b>200: The table version was successfully returned.</b></summary>
+
+
 
 <table>
 <tr>
@@ -1703,9 +1741,10 @@ A sequence of JSON strings delimited by newline. Each line is a JSON object defi
 The response contains multiple lines:
 - The first line is [a JSON wrapper object](#json-wrapper-object-in-each-line) containing the table [Protocol](#protocol) object.
 - The second line is [a JSON wrapper object](#json-wrapper-object-in-each-line) containing the table [Metadata](#metadata) object.
-- The rest of the lines are [JSON wrapper objects](#json-wrapper-object-in-each-line) for 
-  - either [data change files](#data-change-files) with possible historical [Metadata](#metadata) (when startingVersion is set).
-  - or [files](#file) in the table (otherwise).
+- The rest of the lines are [JSON wrapper objects](#json-wrapper-object-in-each-line) for [data change files](#data-change-files), [Metadata](#metadata), or [files](#file).  
+  - The lines are [data change files](#data-change-files) with possible historical [Metadata](#metadata) (when startingVersion is set).
+  - The lines are [files](#file) in the table (otherwise).
+  - The ordering of the lines doesn't matter.
 
 </td>
 </tr>
@@ -2044,7 +2083,8 @@ The response contains multiple lines:
 - The first line is [a JSON wrapper object](#json-wrapper-object-in-each-line) containing the table [Protocol](#protocol) object.
 - The second line is [a JSON wrapper object](#json-wrapper-object-in-each-line) containing the table [Metadata](#metadata) object.
 - The rest of the lines are [JSON wrapper objects](#json-wrapper-object-in-each-line) for [Data Change Files](#data-change-files) of the change data feed.
-- Historical [Metadata](#metadata) will be returned if includeHistoricalMetadata is set to true.
+  - Historical [Metadata](#metadata) will be returned if includeHistoricalMetadata is set to true.
+  - The ordering of the lines doesn't matter.
 
 </td>
 </tr>

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -21,7 +21,7 @@
     - [Protocol](#protocol)
     - [Metadata](#metadata)
     - [File](#file)
-    - [CDF Files](#cdf-files)
+    - [Data Change Files](#data-change-files)
     - [Format](#format)
     - [Schema Object](#schema-object)
       - [Struct Type](#struct-type)
@@ -1651,7 +1651,7 @@ This is the API for clients to read data from a table.
 </td>
 </tr>
 <tr>
-<td>Body</td>
+<td>Body (an example)</td>
 <td>
 
 ```json
@@ -1703,7 +1703,9 @@ A sequence of JSON strings delimited by newline. Each line is a JSON object defi
 The response contains multiple lines:
 - The first line is [a JSON wrapper object](#json-wrapper-object-in-each-line) containing the table [Protocol](#protocol) object.
 - The second line is [a JSON wrapper object](#json-wrapper-object-in-each-line) containing the table [Metadata](#metadata) object.
-- The rest of the lines are [JSON wrapper objects](#json-wrapper-object-in-each-line) for [files](#file) in the table.
+- The rest of the lines are [JSON wrapper objects](#json-wrapper-object-in-each-line) for 
+  - either [data change files](#data-change-files) with possible historical [Metadata](#metadata) (when startingVersion is set).
+  - or [files](#file) in the table (otherwise).
 
 </td>
 </tr>
@@ -1879,7 +1881,11 @@ The request body should be a JSON string containing the following two optional f
 - **limitHint** (type: Int32, optional): an optional limit number. It’s a hint from the client to tell the server how many rows in the table the client plans to read. The server can use this hint to return only some files by using the file stats. For example, when running `SELECT * FROM table LIMIT 1000`, the client can set `limitHint` to `1000`.
   - Applying `limitHint` is **BEST EFFORT**. The server may return files containing more rows than the client requests.
 
-- **version** (type: Int64, optional): an optional version number. If set, will return files as of the specified version of the table. This is only supported on tables with change data feed (cdf) enabled. 
+- **version** (type: Int64, optional): an optional version number. If set, will return files as of the specified version of the table. This is only supported on tables with history sharing enabled.
+
+- **timestamp** (type: String, optional): an optional timestamp string. If set, will return files as of the table version corresponding to the specified timestamp. This is only supported on tables with history sharing enabled.
+
+- **startingVersion** (type: Int64, optional): an optional version number. If set, will return all data change files since startingVersion, including historical metadata if seen in the delta log.
 
 When `predicateHints` and `limitHint` are both present, the server should apply `predicateHints` first then `limitHint`. As these two parameters are hints rather than enforcement, the client must always apply `predicateHints` and `limitHint` on the response returned by the server if it wishes to filter and limit the returned data. An empty JSON object (`{}`) should be provided when these two parameters are missing.
 
@@ -1958,7 +1964,38 @@ The change data feed represents row-level changes between versions of a Delta ta
 - _commit_version (type: Long): The table version containing the change.
 - _commit_timestamp (type: String): The timestap associated when the commit of the change was created, in the format "yyyy-mm-dd hh:mm:ss".
 
-
+<table>
+<tr>
+<th>HTTP Request</th>
+<th>Value</th>
+</tr>
+<tr>
+<td>Method</td>
+<td>`GET`</td>
+</tr>
+<tr>
+<td>Header</td>
+<td>`Authorization: Bearer {token}`</td>
+</tr>
+<tr>
+<td>URL</td>
+<td>`{prefix}/shares/{share}/schemas/{schema}/tables/{table}/changes`</td>
+</tr>
+<tr>
+<td>URL Parameters</td>
+<td>**{share}**: The share name to query. It's case-insensitive.<br>
+**{schema}**: The schema name to query. It's case-insensitive.<br>
+**{table}**: The table name to query. It's case-insensitive.</td>
+</tr>
+<tr>
+<td>Query Parameters</td>
+<td>**startingVersion** (type: Int64, optional): The starting version of the query, inclusive. <br>
+ **startingTimestamp** (type: String, optional): The starting timestamp of the query, will be converted to a version created greater or equal to this timestamp. <br>
+ **endingVersion** (type: Int64, optional): The ending version of the query, inclusive. <br>
+ **endingTimestamp** (type: String, optional): The ending timestamp of the query, will be converted to a version created earlier or equal to this timestamp. <br>
+ **includeHistoricalMetadata**(type: Boolean, optional): If set to true, return the historical metadata if seen in the delta log. This is for the streaming client to check if the table schema is still read compatible.</td>
+</tr>
+</table>
 HTTP Request | Value
 -|-
 Method | `GET`
@@ -1996,7 +2033,8 @@ A sequence of JSON strings delimited by newline. Each line is a JSON object defi
 The response contains multiple lines:
 - The first line is [a JSON wrapper object](#json-wrapper-object-in-each-line) containing the table [Protocol](#protocol) object.
 - The second line is [a JSON wrapper object](#json-wrapper-object-in-each-line) containing the table [Metadata](#metadata) object.
-- The rest of the lines are [JSON wrapper objects](#json-wrapper-object-in-each-line) for [CDF files](#cdf-files) of the change data feed.
+- The rest of the lines are [JSON wrapper objects](#json-wrapper-object-in-each-line) for [Data Change Files](#data-change-files) of the change data feed.
+- Historical [Metadata](#metadata) will be returned if includeHistoricalMetadata is set to true.
 
 </td>
 </tr>
@@ -2274,6 +2312,7 @@ format | [Format](#format) Object | Specification of the encoding for the files 
 schemaString | String | Schema of the table. This is a serialized JSON string which can be deserialized to a [Schema](#schema-object) Object. | Required
 partitionColumns | Array<String> | An array containing the names of columns by which the data should be partitioned. When a table doesn’t have partition columns, this will be an **empty** array. | Required
 configuration | Map[String, String] | A map containing configuration options for the table
+version | Long | The table version the metadata corresponds to. | Optional
 size | Long | The size of the table in bytes. | Optional 
 numFiles | Long | The number of files in the table. | Optional
 
@@ -2308,6 +2347,8 @@ id | String | A unique string for the file in a table. The same file is guarante
 partitionValues | Map<String, String> | A map from partition column to value for this file. See [Partition Value Serialization](#partition-value-serialization) for how to parse the partition values. When the table doesn’t have partition columns, this will be an **empty** map. | Required
 size | Long | The size of this file in bytes. | Required
 stats | String | Contains statistics (e.g., count, min/max values for columns) about the data in this file. This field may be missing. A file may or may not have stats. This is a serialized JSON string which can be deserialized to a [Statistics Struct](#per-file-statistics). A client can decide whether to use stats or drop it. | Optional
+version | Long | The table version of the file, returned when querying a version snapshot of a table. | Optional
+timestamp | Long | The unix timestamp corresponding to the table version of the file, in milliseconds. Returned when querying a version snapshot of a table | Optional
 
 Example (for illustration purposes; each JSON object must be a single line in the response):
 
@@ -2325,7 +2366,7 @@ Example (for illustration purposes; each JSON object must be a single line in th
 }
 ```
 
-### CDF Files
+### Data Change Files
 
 #### Add File
 Field Name | Data Type | Description | Optional/Required

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1174,7 +1174,7 @@ Example:
 
 This is the API for clients to get a table version without any other extra information. The server usually can implement this API effectively. If a client caches information about a shared table locally, it can store the table version and use this cheap API to quickly check whether their cache is stale and they should re-fetch the data.
 
-Note: We are migrating this method from HEAD to GET, and with a `/version` suffix. Please use the new API as we'll be deprecating the support of HEAD API soon. 
+Note: We are migrating this method from HEAD to GET, and with a `/version` suffix. Please use the new API as we'll deprecate the support of HEAD API soon. 
 
 HTTP Request | Value
 -|-
@@ -1371,7 +1371,7 @@ Query Parameters | **startingTimestamp** (type: String, optional): The startingT
 
 Example:
 
-`GET {prefix}/shares/vaccine_share/schemas/acme_vaccine_data/tables/vaccine_patients/version?startingTimestamp=2022-12-01%2000:00:00`
+`GET {prefix}/shares/vaccine_share/schemas/acme_vaccine_data/tables/vaccine_patients/version
 
 ```
 HTTP/2 200 
@@ -1996,13 +1996,6 @@ The change data feed represents row-level changes between versions of a Delta ta
  **includeHistoricalMetadata**(type: Boolean, optional): If set to true, return the historical metadata if seen in the delta log. This is for the streaming client to check if the table schema is still read compatible.</td>
 </tr>
 </table>
-HTTP Request | Value
--|-
-Method | `GET`
-Header | `Authorization: Bearer {token}`
-URL | `{prefix}/shares/{share}/schemas/{schema}/tables/{table}/changes`
-URL Parameters | **{share}**: The share name to query. It's case-insensitive.<br>**{schema}**: The schema name to query. It's case-insensitive.<br>**{table}**: The table name to query. It's case-insensitive.
-Query Parameters | **startingVersion** (type: Int64, optional): The starting version of the query, inclusive. <br> **startingTimestamp** (type: String, optional): The starting timestamp of the query, will be converted to a version created greater or equal to this timestamp. <br> **endingVersion** (type: Int64, optional): The ending version of the query, inclusive. <br> **endingTimestamp** (type: String, optional): The ending timestamp of the query, will be converted to a version created earlier or equal to this timestamp.
 
 <details open>
 <summary><b>200: The change data feed was successfully returned.</b></summary>
@@ -2312,9 +2305,9 @@ format | [Format](#format) Object | Specification of the encoding for the files 
 schemaString | String | Schema of the table. This is a serialized JSON string which can be deserialized to a [Schema](#schema-object) Object. | Required
 partitionColumns | Array<String> | An array containing the names of columns by which the data should be partitioned. When a table doesn’t have partition columns, this will be an **empty** array. | Required
 configuration | Map[String, String] | A map containing configuration options for the table
-version | Long | The table version the metadata corresponds to. | Optional
-size | Long | The size of the table in bytes. | Optional 
-numFiles | Long | The number of files in the table. | Optional
+version | Long | The table version the metadata corresponds to, returned when querying table data with a version or timestamp parameter, or cdf query with includeHistoricalMetadata set to true. | Optional
+size | Long | The size of the table in bytes, will be returned if available in the delta log. | Optional 
+numFiles | Long | The number of files in the table, will be returned if available in the delta log. | Optional
 
 Example (for illustration purposes; each JSON object must be a single line in the response):
 
@@ -2347,8 +2340,8 @@ id | String | A unique string for the file in a table. The same file is guarante
 partitionValues | Map<String, String> | A map from partition column to value for this file. See [Partition Value Serialization](#partition-value-serialization) for how to parse the partition values. When the table doesn’t have partition columns, this will be an **empty** map. | Required
 size | Long | The size of this file in bytes. | Required
 stats | String | Contains statistics (e.g., count, min/max values for columns) about the data in this file. This field may be missing. A file may or may not have stats. This is a serialized JSON string which can be deserialized to a [Statistics Struct](#per-file-statistics). A client can decide whether to use stats or drop it. | Optional
-version | Long | The table version of the file, returned when querying a version snapshot of a table. | Optional
-timestamp | Long | The unix timestamp corresponding to the table version of the file, in milliseconds. Returned when querying a version snapshot of a table | Optional
+version | Long | The table version of the file, returned when querying a table data with a version or timestamp parameter. | Optional
+timestamp | Long | The unix timestamp corresponding to the table version of the file, in milliseconds, returned when querying a table data with a version or timestamp parameter. | Optional
 
 Example (for illustration purposes; each JSON object must be a single line in the response):
 


### PR DESCRIPTION
PROTOCOL changes in release 0.6.0:

- Query Table Version: 
  - change from HEAD to GET.
  - with a `/version` suffix.
  - Support parameter `startingTimestamp`.
- Read Data from a Table
  - Support parameter `timestamp`.
  - Support parameter `startingVersion`.
  - The response can be data change files and include historical metadata for query with `startingVersion`. 
- Read Change Data Feed from a Table:
  - Support parameter `includeHistoricalMetadata`
  - The response will include historical metadata if `includeHistoricalMetadata` is set to true.
- Metadata now contains 3 optional fields: version/size/numFiles. version will be returned when querying table data with a version or timestamp parameter, or cdf query with includeHistoricalMetadata set to true, size/numFiles will be returned when available in the delta log.
- File now contains 2 optional fields: version/timestamp, which will be returned when querying table with a version or timestamp parameter.