### PR TITLE
Add load_as methods for pyarrow dataset and table

### DIFF
--- a/examples/python/quickstart_pyarrow.py
+++ b/examples/python/quickstart_pyarrow.py
@@ -1,0 +1,81 @@
+#
+# Copyright (2021) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+
+import delta_sharing
+
+# Point to the profile file. It can be a file on the local file system or a file on a remote storage.
+profile_file = os.path.dirname(__file__) + "/../open-datasets.share"
+
+# Create a SharingClient.
+client = delta_sharing.SharingClient(profile_file)
+
+# List all shared tables.
+print("########### All Available Tables #############")
+print(client.list_all_tables())
+
+# Create a url to access a shared table.
+# A table path is the profile file path following with `#` and the fully qualified name of a table (`<share-name>.<schema-name>.<table-name>`).
+table_url = profile_file + "#delta_sharing.default.owid-covid-data"
+
+# As PyArrow Dataset.
+
+# Create a lazy reference for delta sharing table as a PyArrow Dataset.
+print(
+    "########### Create a lazy reference for delta_sharing.default.owid-covid-data as a PyArrow Dataset #############")
+data = delta_sharing.load_as_pyarrow_dataset(table_url)
+print(data.schema)
+
+# Create a lazy reference for delta sharing table as a PyArrow Dataset with additional pyarrow options.
+print(
+    "########### Create a lazy reference for delta_sharing.default.owid-covid-data as a PyArrow Dataset with additional options #############")
+delta_sharing.load_as_pyarrow_dataset(table_url, pyarrow_ds_options={"partitioning": "hive"})
+
+# As PyArrow Table.
+
+# Fetch 10 rows from a delta sharing table as a PyArrow Table. This can be used to read sample data from a table that cannot fit in the memory.
+print("########### Loading 10 rows from delta_sharing.default.owid-covid-data as a PyArrow Table #############")
+data = delta_sharing.load_as_pyarrow_table(table_url, limit=10)
+
+# Print the sample.
+print("########### Show the number of fetched rows #############")
+print(data.num_rows)
+
+# Load full table as a PyArrow Table. This can be used to process tables that can fit in the memory.
+print("########### Loading all data from delta_sharing.default.owid-covid-data as a PyArrow Table #############")
+data = delta_sharing.load_as_pyarrow_table(table_url)
+print(data.num_rows)
+
+# Load full table as a PyArrow Table with additional pyarrow options.
+print(
+    "########### Loading all data from delta_sharing.default.owid-covid-data as a PyArrow Table with additional pyarrow options #############")
+import pyarrow.dataset as ds
+
+data = delta_sharing.load_as_pyarrow_table(
+    table_url,
+    pyarrow_ds_options={"exclude_invalid_files": False},
+    pyarrow_tbl_options={
+        "columns": ["date", "location", "total_cases"],
+        "filter": ds.field("date") == "2020-02-24"
+    }
+)
+print(data)
+
+# Convert PyArrow Table to Pandas DataFrame.
+print("########### Converting delta_sharing.default.owid-covid-data PyArrow Table to a Pandas DataFrame #############")
+pdf = data.to_pandas()
+print(pdf)

--- a/python/delta_sharing/__init__.py
+++ b/python/delta_sharing/__init__.py
@@ -14,7 +14,13 @@
 # limitations under the License.
 #
 
-from delta_sharing.delta_sharing import SharingClient, load_as_pandas, load_as_spark
+from delta_sharing.delta_sharing import (
+    SharingClient,
+    load_as_pandas,
+    load_as_spark,
+    load_as_pyarrow_dataset,
+    load_as_pyarrow_table,
+)
 from delta_sharing.delta_sharing import load_table_changes_as_pandas, load_table_changes_as_spark
 from delta_sharing.protocol import Share, Schema, Table
 from delta_sharing.version import __version__
@@ -27,6 +33,8 @@ __all__ = [
     "Table",
     "load_as_pandas",
     "load_as_spark",
+    "load_as_pyarrow_dataset",
+    "load_as_pyarrow_table",
     "load_table_changes_as_pandas",
     "load_table_changes_as_spark",
     "__version__",

--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ -15,11 +15,14 @@
 #
 from decimal import Decimal
 from typing import Any, Callable, Dict
-from pyarrow.dataset import Dataset as PyArrowDataset
-from pyarrow.dataset import dataset
-from pyarrow import Table as PyArrowTable
+
 import numpy as np
 import pandas as pd
+import pyarrow as pa
+from pyarrow import Schema as PyArrowSchema
+from pyarrow import Table as PyArrowTable
+from pyarrow.dataset import Dataset as PyArrowDataset
+from pyarrow.dataset import dataset
 
 
 def _get_dummy_column(schema_type):
@@ -59,18 +62,154 @@ def _get_dummy_column(schema_type):
     raise ValueError(f"Could not parse datatype: {schema_type}")
 
 
-def get_empty_pyarrow_table(schema_json: dict) -> PyArrowTable:
-    # TODO: Manually create a pyarrow Schema instead of a relying pandas
-    pdf = get_empty_pandas_table(schema_json)
-    table = PyArrowTable.from_pandas(pdf)
+def _to_pyarrow_schema(schema_value: dict) -> PyArrowSchema:
+    """
+    Converts delta table schema to a valid PyArrow Schema with
+    field metadata and nullability preserved.
+    This implementation closely follows PySpark and supports columns
+    with complex data types like `struct`, `map` and `array`.
 
-    return table
+    :param schema_value: Representation of delta table schema as a dict
+    :return: pyarrow.Schema
+    """
+    assert schema_value is not None and schema_value["type"] == "struct", "Invalid schema found."
+
+    def _to_arrow_type(f_type) -> pa.DataType:
+        is_nested = isinstance(f_type, dict)
+
+        if not is_nested:
+            f_type = f_type.lower()
+
+        if not is_nested and f_type == "boolean":
+            return pa.bool_()
+
+        elif not is_nested and f_type == "byte":
+            return pa.int8()
+
+        elif not is_nested and f_type == "short":
+            return pa.int16()
+
+        elif not is_nested and f_type == "integer":
+            return pa.int32()
+
+        elif not is_nested and f_type == "long":
+            return pa.int64()
+
+        elif not is_nested and f_type == "float":
+            return pa.float32()
+
+        elif not is_nested and f_type == "double":
+            return pa.float64()
+
+        elif not is_nested and f_type.startswith("decimal"):
+            try:
+                import re
+
+                decimal_pattern = re.compile(r"(\([^\)]+\))")
+                res = [
+                    int(v.strip())
+                    for v in decimal_pattern.findall(f_type)[0].lstrip("(").rstrip(")").split(",")
+                ]
+                precision = res[0]
+                scale = res[1]
+            except:
+                precision = 10
+                scale = 0
+            return pa.decimal128(precision, scale)
+
+        elif not is_nested and f_type == "string":
+            return pa.string()
+
+        elif not is_nested and f_type == "binary":
+            return pa.binary()
+
+        elif not is_nested and f_type == "date":
+            return pa.date32()
+
+        elif not is_nested and f_type == "timestamp":
+            return pa.timestamp("us")
+
+        elif not is_nested and f_type in ["void", "null"]:
+            return pa.null()
+
+        elif is_nested and f_type["type"] == "array":
+            element_type = f_type["elementType"]
+            if isinstance(element_type, str) and element_type == "timestamp":
+                raise TypeError(
+                    f"Could not parse map field types: array<timestamp> to PyArrow type."
+                )
+            elif isinstance(element_type, dict) and element_type["type"] == "struct":
+                if any(
+                    isinstance(struct_field["type"], dict)
+                    and struct_field["type"]["type"] == "struct"
+                    for struct_field in element_type["fields"]
+                ):
+                    raise TypeError("Nested StructType cannot be converted to PyArrow type.")
+            return pa.list_(_to_arrow_type(element_type))
+
+        elif is_nested and f_type["type"] == "map":
+            key_type = f_type["keyType"]
+            value_type = f_type["valueType"]
+            if (isinstance(key_type, str) and key_type == "timestamp") or (
+                isinstance(value_type, str) and value_type == "timestamp"
+            ):
+                raise TypeError(
+                    f"Could not parse map field with timestamp key or value types to PyArrow type."
+                )
+            elif (isinstance(key_type, dict) and key_type["type"] == "struct") or (
+                isinstance(value_type, dict) and value_type["type"] == "struct"
+            ):
+                raise TypeError(
+                    f"Could not parse map field with struct key or value types to PyArrow type."
+                )
+            return pa.map_(_to_arrow_type(key_type), _to_arrow_type(value_type))
+
+        elif is_nested and f_type["type"] == "struct":
+            if any(
+                isinstance(struct_field["type"], dict) and struct_field["type"]["type"] == "struct"
+                for struct_field in f_type["fields"]
+            ):
+                raise TypeError("Nested StructType cannot be converted to PyArrow type.")
+            struct_fields = [
+                pa.field(
+                    struct_field["name"],
+                    _to_arrow_type(struct_field["type"]),
+                    nullable=(str(struct_field["nullable"]).lower() == "true"),
+                    metadata=struct_field["metadata"],
+                )
+                for struct_field in f_type["fields"]
+            ]
+            return pa.struct(struct_fields)
+        else:
+            raise TypeError(f"Could not parse type: {f_type} to PyArrow type.")
+
+    fields = []
+    for field in schema_value["fields"]:
+        field_name = str(field["name"])
+        field_type = field["type"]
+        field_nullable = str(field["nullable"]).lower() == "true"
+        field_metadata = field["metadata"]
+
+        fields.append(
+            pa.field(
+                field_name,
+                _to_arrow_type(field_type),
+                nullable=field_nullable,
+                metadata=field_metadata,
+            )
+        )
+
+    return pa.schema(fields)
+
+
+def get_empty_pyarrow_table(schema_json: dict) -> PyArrowTable:
+    schema = _to_pyarrow_schema(schema_json)
+    return schema.empty_table()
 
 
 def get_empty_pyarrow_dataset(schema_json: dict) -> PyArrowDataset:
-    table = get_empty_pyarrow_table(schema_json)
-
-    return dataset(table)
+    schema = _to_pyarrow_schema(schema_json)
+    return dataset([], schema=schema)
 
 
 def get_empty_pandas_table(schema_json: dict) -> pd.DataFrame:

--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ -15,7 +15,9 @@
 #
 from decimal import Decimal
 from typing import Any, Callable, Dict
-
+from pyarrow.dataset import Dataset as PyArrowDataset
+from pyarrow.dataset import dataset
+from pyarrow import Table as PyArrowTable
 import numpy as np
 import pandas as pd
 
@@ -57,7 +59,21 @@ def _get_dummy_column(schema_type):
     raise ValueError(f"Could not parse datatype: {schema_type}")
 
 
-def get_empty_table(schema_json: dict) -> pd.DataFrame:
+def get_empty_pyarrow_table(schema_json: dict) -> PyArrowTable:
+    # TODO: Manually create a pyarrow Schema instead of a relying pandas
+    pdf = get_empty_pandas_table(schema_json)
+    table = PyArrowTable.from_pandas(pdf)
+
+    return table
+
+
+def get_empty_pyarrow_dataset(schema_json: dict) -> PyArrowDataset:
+    table = get_empty_pyarrow_table(schema_json)
+
+    return dataset(table)
+
+
+def get_empty_pandas_table(schema_json: dict) -> pd.DataFrame:
     """
     For empty tables, we use dummy columns from `_get_dummy_column` and then
     drop all rows to generate a table with the correct column names and

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 from itertools import chain
-from typing import BinaryIO, List, Optional, Sequence, TextIO, Tuple, Union, Any
+from typing import BinaryIO, List, Optional, Sequence, TextIO, Tuple, Union, Any, Mapping
 from pathlib import Path
 
 import pandas as pd
@@ -125,8 +125,8 @@ def load_as_pyarrow_table(
     limit: Optional[int] = None,
     version: Optional[int] = None,
     timestamp: Optional[str] = None,
-    pyarrow_ds_options: Optional[dict[str, Any]] = None,
-    pyarrow_tbl_options: Optional[dict[str, Any]] = None,
+    pyarrow_ds_options: Optional[Mapping[str, Any]] = None,
+    pyarrow_tbl_options: Optional[Mapping[str, Any]] = None,
 ) -> PyArrowTable:
     """
     Load the shared table using the given url as a Pyarrow Table.
@@ -169,7 +169,7 @@ def load_as_pyarrow_dataset(
     url: str,
     version: Optional[int] = None,
     timestamp: Optional[str] = None,
-    pyarrow_ds_options: Optional[dict[str, Any]] = None,
+    pyarrow_ds_options: Optional[Mapping[str, Any]] = None,
 ) -> PyArrowDataset:
     """
     Load the shared table using the given url as a Pyarrow Dataset.

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -156,7 +156,7 @@ def load_as_pyarrow_table(
     ds = load_as_pyarrow_dataset(
         url=url, version=version, timestamp=timestamp, pyarrow_ds_options=pyarrow_ds_options
     )
-    pa_table = (
+    pa_table: PyArrowTable = (
         ds.head(limit, **pyarrow_tbl_options)
         if limit is not None
         else ds.to_table(**pyarrow_tbl_options)
@@ -192,12 +192,14 @@ def load_as_pyarrow_dataset(
     profile_json, share, schema, table = _parse_url(url)
     profile = DeltaSharingProfile.read_from_file(profile_json)
 
-    return DeltaSharingReader(
+    ds: PyArrowDataset = DeltaSharingReader(
         table=Table(name=table, share=share, schema=schema),
         rest_client=DataSharingRestClient(profile),
         version=version,
         timestamp=timestamp,
     ).to_pyarrow_dataset(pyarrow_ds_options=pyarrow_ds_options)
+
+    return ds
 
 
 def load_table_changes_as_spark(

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -21,7 +21,6 @@ import fsspec
 import pandas as pd
 from pyarrow.dataset import dataset
 from pyarrow.dataset import Dataset as PyArrowDataset
-from pyarrow import Table as PyArrowTable
 
 from delta_sharing.converter import to_converters, get_empty_pandas_table, get_empty_pyarrow_dataset
 from delta_sharing.protocol import AddCdcFile, CdfOptions, FileAction, Table

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, Callable, Dict, Optional, Sequence
+from typing import Any, Callable, Dict, Optional, Sequence, Mapping
 from urllib.parse import urlparse
 from json import loads
 
@@ -73,7 +73,7 @@ class DeltaSharingReader:
         )
 
     def to_pyarrow_dataset(
-        self, pyarrow_ds_options: Optional[dict[str, Any]] = None
+        self, pyarrow_ds_options: Optional[Mapping[str, Any]] = None
     ) -> PyArrowDataset:
         if pyarrow_ds_options is None:
             pyarrow_ds_options = {}

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -154,12 +154,12 @@ class DeltaSharingReader:
 
             for file_url in file_urls:
                 ds = DeltaSharingReader._to_pyarrow_dataset(file_url, pyarrow_ds_options)
-                tbl: PyArrowTable = ds.head(left)
+                tbl: PyArrowTable = ds.head(left, **pyarrow_tbl_options)
                 pa_tables.append(tbl)
                 left -= tbl.num_rows
                 assert (
                     left >= 0
-                ), f"Too many rows returned from dataset. Required: {left}, returned: {tbl.num_rows}"
+                ), f"Too many rows returned. Required: {left}, returned: {tbl.num_rows}"
                 if left == 0:
                     break
 

--- a/python/delta_sharing/tests/test_converter.py
+++ b/python/delta_sharing/tests/test_converter.py
@@ -119,8 +119,8 @@ def test_pyarrow_schema_map():
         _to_pyarrow_schema(base_schema_dict_tmp)
 
     assert (
-            str(exp_info1.value)
-            == "Could not parse map field with timestamp key or value types to PyArrow type."
+        str(exp_info1.value)
+        == "Could not parse map field with timestamp key or value types to PyArrow type."
     )
 
     with pytest.raises(TypeError) as exp_info2:
@@ -148,8 +148,8 @@ def test_pyarrow_schema_map():
         _to_pyarrow_schema(base_schema_dict_tmp)
 
     assert (
-            str(exp_info2.value)
-            == "Could not parse map field with struct key or value types to PyArrow type."
+        str(exp_info2.value)
+        == "Could not parse map field with struct key or value types to PyArrow type."
     )
 
 
@@ -299,7 +299,7 @@ def test_pyarrow_schema_array():
         _to_pyarrow_schema(base_schema_dict_tmp)
 
     assert (
-            str(exp_info2.value) == "Could not parse map field types: array<timestamp> to PyArrow type."
+        str(exp_info2.value) == "Could not parse map field types: array<timestamp> to PyArrow type."
     )
 
     with pytest.raises(TypeError) as exp_info3:

--- a/python/delta_sharing/tests/test_converter.py
+++ b/python/delta_sharing/tests/test_converter.py
@@ -22,7 +22,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from delta_sharing.converter import to_converter, get_empty_table
+from delta_sharing.converter import to_converter, get_empty_pandas_table
 
 
 def test_to_converter_boolean():
@@ -81,7 +81,7 @@ def test_get_empty_table():
         '],"type":"struct"}'
     )
     schema_json = loads(schema_string)
-    pdf = get_empty_table(schema_json)
+    pdf = get_empty_pandas_table(schema_json)
     assert pdf.empty
     assert pdf.columns.values.size == 2
     assert pdf.columns.values[0] == "a"

--- a/python/delta_sharing/tests/test_converter.py
+++ b/python/delta_sharing/tests/test_converter.py
@@ -20,9 +20,10 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 
-from delta_sharing.converter import to_converter, get_empty_pandas_table
+from delta_sharing.converter import to_converter, get_empty_pandas_table, _to_pyarrow_schema
 
 
 def test_to_converter_boolean():
@@ -86,3 +87,264 @@ def test_get_empty_table():
     assert pdf.columns.values.size == 2
     assert pdf.columns.values[0] == "a"
     assert pdf.columns.values[1] == "b"
+
+
+def test_pyarrow_schema_map():
+    base_schema_dict = {"type": "struct", "fields": []}
+
+    simple_map_col = {
+        "name": "simple_map",
+        "type": {"type": "map", "keyType": "string", "valueType": "string"},
+        "nullable": True,
+        "metadata": {},
+    }
+
+    base_schema_dict["fields"] = [simple_map_col]
+    base_w_map_schema = _to_pyarrow_schema(base_schema_dict)
+
+    assert base_w_map_schema.field("simple_map").nullable
+    assert base_w_map_schema.field("simple_map").type == pa.map_(pa.string(), pa.string())
+
+    with pytest.raises(TypeError) as exp_info1:
+        timestamp_map_col = {
+            "name": "timestamp_map_col",
+            "type": {"type": "map", "keyType": "timestamp", "valueType": "string"},
+            "nullable": False,
+            "metadata": {},
+        }
+
+        base_schema_dict_tmp = base_schema_dict.copy()
+        base_schema_dict_tmp["fields"] = [timestamp_map_col]
+
+        _to_pyarrow_schema(base_schema_dict_tmp)
+
+    assert (
+            str(exp_info1.value)
+            == "Could not parse map field with timestamp key or value types to PyArrow type."
+    )
+
+    with pytest.raises(TypeError) as exp_info2:
+        struct_map_col = {
+            "name": "struct_map_col",
+            "type": {
+                "type": "map",
+                "keyType": "string",
+                "valueType": {
+                    "type": "struct",
+                    "fields": [
+                        {"name": "firstname", "type": "string", "nullable": True, "metadata": {}},
+                        {"name": "middlename", "type": "string", "nullable": False, "metadata": {}},
+                        {"name": "lastname", "type": "string", "nullable": True, "metadata": {}},
+                    ],
+                },
+            },
+            "nullable": False,
+            "metadata": {},
+        }
+
+        base_schema_dict_tmp = base_schema_dict.copy()
+        base_schema_dict_tmp["fields"] = [struct_map_col]
+
+        _to_pyarrow_schema(base_schema_dict_tmp)
+
+    assert (
+            str(exp_info2.value)
+            == "Could not parse map field with struct key or value types to PyArrow type."
+    )
+
+
+def test_pyarrow_schema_struct():
+    base_schema_dict = {"type": "struct", "fields": []}
+
+    simple_struct_col = {
+        "name": "simple_struct",
+        "type": {
+            "type": "struct",
+            "fields": [
+                {"name": "firstname", "type": "string", "nullable": True, "metadata": {}},
+                {"name": "middlename", "type": "string", "nullable": False, "metadata": {}},
+                {"name": "lastname", "type": "string", "nullable": True, "metadata": {}},
+            ],
+        },
+        "nullable": False,
+        "metadata": {},
+    }
+
+    base_schema_dict["fields"] = [simple_struct_col]
+    base_w_st_schema = _to_pyarrow_schema(base_schema_dict)
+
+    assert not base_w_st_schema.field("simple_struct").nullable
+    assert base_w_st_schema.field("simple_struct").type == pa.struct(
+        [
+            pa.field("firstname", pa.string(), nullable=True),
+            pa.field("middlename", pa.string(), nullable=False),
+            pa.field("lastname", pa.string(), nullable=True),
+        ]
+    )
+
+    with pytest.raises(TypeError) as exp_info1:
+        complex_struct_col = {
+            "name": "complex_struct",
+            "type": {
+                "type": "struct",
+                "fields": [
+                    {
+                        "test": "test",
+                        "type": {
+                            "type": "struct",
+                            "fields": [
+                                {
+                                    "test": "nested_struct_field",
+                                    "type": "string",
+                                    "nullable": True,
+                                    "metadata": {},
+                                }
+                            ],
+                        },
+                        "nullable": True,
+                        "metadata": {},
+                    }
+                ],
+            },
+            "nullable": False,
+            "metadata": {},
+        }
+
+        base_schema_dict_tmp = base_schema_dict.copy()
+        base_schema_dict_tmp["fields"] = [complex_struct_col]
+
+        _to_pyarrow_schema(base_schema_dict_tmp)
+
+    assert str(exp_info1.value) == "Nested StructType cannot be converted to PyArrow type."
+
+
+def test_pyarrow_schema_array():
+    base_schema_dict = {"type": "struct", "fields": []}
+
+    simple_arr_col = {
+        "name": "simple_arr",
+        "type": {"type": "array", "elementType": "string", "containsNull": True},
+        "nullable": True,
+        "metadata": {},
+    }
+
+    complex_arr_col_1 = {
+        "name": "complex_arr",
+        "type": {
+            "type": "array",
+            "elementType": {
+                "type": "struct",
+                "fields": [
+                    {"name": "middlename", "type": "string", "nullable": False, "metadata": {}},
+                ],
+            },
+            "containsNull": True,
+        },
+        "nullable": False,
+        "metadata": {},
+    }
+
+    base_schema_dict["fields"].extend([simple_arr_col, complex_arr_col_1])
+
+    base_w_arr_schema = _to_pyarrow_schema(base_schema_dict)
+
+    assert base_w_arr_schema.field("simple_arr").nullable
+    assert base_w_arr_schema.field("simple_arr").type == pa.list_(pa.string())
+
+    assert not base_w_arr_schema.field("complex_arr").nullable
+    assert base_w_arr_schema.field("complex_arr").type == pa.list_(
+        pa.struct([pa.field("middlename", pa.string(), nullable=False)])
+    )
+
+    with pytest.raises(TypeError) as exp_info1:
+        complex_arr_col_2 = {
+            "name": "complex_arr",
+            "type": {
+                "type": "array",
+                "elementType": {
+                    "type": "struct",
+                    "fields": [
+                        {
+                            "name": "middlename",
+                            "type": {"type": "struct", "fields": []},
+                            "nullable": False,
+                            "metadata": {},
+                        },
+                    ],
+                },
+                "containsNull": True,
+            },
+            "nullable": False,
+            "metadata": {},
+        }
+
+        base_schema_dict_tmp = base_schema_dict.copy()
+        base_schema_dict_tmp["fields"] = [complex_arr_col_2]
+
+        _to_pyarrow_schema(base_schema_dict_tmp)
+
+    assert str(exp_info1.value) == "Nested StructType cannot be converted to PyArrow type."
+
+    with pytest.raises(TypeError) as exp_info2:
+        complex_arr_col_2 = {
+            "name": "complex_arr",
+            "type": {"type": "array", "elementType": "timestamp", "containsNull": True},
+            "nullable": False,
+            "metadata": {},
+        }
+
+        base_schema_dict_tmp = base_schema_dict.copy()
+        base_schema_dict_tmp["fields"] = [complex_arr_col_2]
+
+        _to_pyarrow_schema(base_schema_dict_tmp)
+
+    assert (
+            str(exp_info2.value) == "Could not parse map field types: array<timestamp> to PyArrow type."
+    )
+
+    with pytest.raises(TypeError) as exp_info3:
+        base_schema_dict_tmp = base_schema_dict.copy()
+        base_schema_dict_tmp["fields"] = [
+            {"name": "test", "type": "xyz", "nullable": False, "metadata": {}}
+        ]
+        _to_pyarrow_schema(base_schema_dict_tmp)
+
+    assert str(exp_info3.value) == "Could not parse type: xyz to PyArrow type."
+
+
+def test_pyarrow_schema_base():
+    base_schema_dict = {
+        "type": "struct",
+        "fields": [
+            {"name": "age", "type": "integer", "nullable": False, "metadata": {"foo": "bar"}},
+            {"name": "gender", "type": "string", "nullable": True, "metadata": {}},
+            {"name": "is_active", "type": "boolean", "nullable": False, "metadata": {}},
+            {"name": "date_of_birth", "type": "date", "nullable": True, "metadata": {}},
+            {"name": "salary", "type": "double", "nullable": True, "metadata": {}},
+            {"name": "salary_band", "type": "decimal(38,0)", "nullable": True, "metadata": {}},
+            {"name": "created_timestamp", "type": "timestamp", "nullable": False, "metadata": {}},
+            {"name": "test", "type": "void", "nullable": True, "metadata": {}},
+        ],
+    }
+
+    base_schema = _to_pyarrow_schema(base_schema_dict)
+
+    # Metadata tests
+    assert not base_schema.field("age").metadata == {"foo": "bar"}
+
+    # Nullability tests
+    assert base_schema.field("gender").nullable
+    assert not base_schema.field("age").nullable
+    assert not base_schema.field("created_timestamp").nullable
+    assert base_schema.field("date_of_birth").nullable
+    assert not base_schema.field("is_active").nullable
+
+    # Type conversion tests
+    assert base_schema.field("gender").type == pa.string()
+    assert base_schema.field("age").type == pa.int32()
+    assert base_schema.field("salary").type == pa.float64()
+    assert base_schema.field("salary_band").type == pa.decimal128(38, 0)
+    assert base_schema.field("is_active").type == pa.bool_()
+    assert base_schema.field("date_of_birth").type == pa.date32()
+    assert base_schema.field("created_timestamp").type == pa.timestamp("us")
+    assert pa.null() in base_schema.types

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Dependencies. When you update don't forget to update setup.py.
 pandas
-pyarrow>=4.0.0
-fsspec>=0.7.4
+pyarrow
+fsspec
 requests
 aiohttp
 yarl>=1.6.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -43,8 +43,8 @@ setup(
     python_requires='>=3.7',
     install_requires=[
         'pandas',
-        'pyarrow>=4.0.0',
-        'fsspec>=0.7.4',
+        'pyarrow',
+        'fsspec',
         'requests',
         'aiohttp',
         'dataclasses;python_version<"3.7"',


### PR DESCRIPTION
Adds separate implementations for `load_as_pyarrow_table` and `load_as_pyarrow_dataset` that allows users to read delta sharing tables as pyarrow table and dataset respectively.

- [x] Add basic implementation
- [x] Fix lint
- [x] Refactor common code
- [x] Verify performance with and without limit
- [x] Add tests - converter
- [x] Add tests - reader
- [ ] Add tests - delta_sharing
- [x] Add examples
- [ ] Fix review comments


closes https://github.com/delta-io/delta-sharing/issues/238