### PR TITLE
Spark connector changes to consume size from metadata in v0.5

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2267,6 +2267,8 @@ format | [Format](#format) Object | Specification of the encoding for the files 
 schemaString | String | Schema of the table. This is a serialized JSON string which can be deserialized to a [Schema](#schema-object) Object. | Required
 partitionColumns | Array<String> | An array containing the names of columns by which the data should be partitioned. When a table doesn’t have partition columns, this will be an **empty** array. | Required
 configuration | Map[String, String] | A map containing configuration options for the table
+size | Long | The size of the table in bytes. | Optional
+numFiles | Long | The number of files in the table. | Optional
 
 Example (for illustration purposes; each JSON object must be a single line in the response):
 
@@ -2283,7 +2285,9 @@ Example (for illustration purposes; each JSON object must be a single line in th
     "id": "f8d5c169-3d01-4ca3-ad9e-7dc3355aedb2",
     "configuration": {
       "enableChangeDataFeed": "true"
-    }
+    },
+    "size": 123456,
+    "numFiles": 5
   }
 }
 ```

--- a/spark/src/main/scala/io/delta/sharing/spark/model.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/model.scala
@@ -92,7 +92,9 @@ private[sharing] case class Metadata(
     format: Format = Format(),
     schemaString: String = null,
     configuration: Map[String, String] = Map.empty,
-    partitionColumns: Seq[String] = Nil) extends Action {
+    partitionColumns: Seq[String] = Nil,
+    size: java.lang.Long = null,
+    numFiles: java.lang.Long = null) extends Action {
   override def wrap: SingleAction = SingleAction(metaData = this)
 }
 

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -88,6 +88,8 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     val spark = SparkSession.active
     val client = new TestDeltaSharingClient()
     val snapshot = new RemoteSnapshot(new Path("test"), client, Table("fe", "fi", "fo"))
+    assert(snapshot.sizeInBytes == 100)
+    assert(snapshot.metadata.numFiles == 2)
 
     // Create an index without limits.
     val fileIndex = {
@@ -153,6 +155,8 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     val remoteDeltaLog = new RemoteDeltaLog(table, path, client)
     val snapshot = new RemoteSnapshot(path, client, table)
     val params = RemoteDeltaFileIndexParams(spark, snapshot, client.getProfileProvider)
+    assert(snapshot.sizeInBytes == 100)
+    assert(snapshot.metadata.numFiles == 2)
 
     val deltaTableFiles = client.getCDFFiles(table, Map.empty)
 

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -41,7 +41,8 @@ class TestDeltaSharingClient(
       |{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",
       |\"fields\":[{\"name\":\"col1\",\"type\":\"integer\",\"nullable\":true,
       |\"metadata\":{}},{\"name\":\"col2\",\"type\":\"string\",\"nullable\":true,
-      |\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1603723967515}}"""
+      |\"metadata\":{}}]}","partitionColumns":[],"configuration":{},
+      |"size": 100,"numFiles": 2,"createdTime":1603723967515}}"""
       .stripMargin.replaceAll("\n", "")
   private val metadata = JsonUtils.fromJson[SingleAction](metadataString).metaData
 


### PR DESCRIPTION
In this change, delta sharing will try to get the table size from table metadata if it is available.
If not available, it will fall back to computing the size from full parquet scan.
The existing code always computes the size from parquet scan, making it a performance bottleneck.

Tested the following combinations:

New server, new connector -> avoids extra queryTable call