### PR TITLE
Fix typo of start_version in load_table_changes_as_spark in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If the table supports history sharing(`tableConfig.cdfEnabled=true` in the OSS D
 delta_sharing.load_table_changes_as_pandas(table_url, starting_version=0, ending_version=5)
 
 # If the code is running with PySpark, you can load table changes as Spark DataFrame.
-delta_sharing.load_table_changes_as_spark(table_url, starting__version=0, ending_version=5)
+delta_sharing.load_table_changes_as_spark(table_url, starting_version=0, ending_version=5)
 ```
   
 

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -677,8 +677,8 @@ def test_load_as_spark(
     [
         pytest.param(
             "share8.default.cdf_table_cdf_enabled",
-            0,
-            3,
+            1,
+            1,
             None,
             None,
             None,

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -677,8 +677,8 @@ def test_load_as_spark(
     [
         pytest.param(
             "share8.default.cdf_table_cdf_enabled",
-            1,
-            1,
+            0,
+            3,
             None,
             None,
             None,


### PR DESCRIPTION
Fix typo of start_version in load_table_changes_as_spark in README 