### PR TITLE
Plug in op conversion and generate json predicates.

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -53,7 +53,8 @@ private[sharing] trait DeltaSharingClient {
     predicates: Seq[String],
     limit: Option[Long],
     versionAsOf: Option[Long],
-    timestampAsOf: Option[String]): DeltaTableFiles
+    timestampAsOf: Option[String],
+    jsonPredicates: Option[String]): DeltaTableFiles
 
   def getFiles(table: Table, startingVersion: Long): DeltaTableFiles
 
@@ -76,7 +77,8 @@ private[sharing] case class QueryTableRequest(
   limitHint: Option[Long],
   version: Option[Long],
   timestamp: Option[String],
-  startingVersion: Option[Long]
+  startingVersion: Option[Long],
+  jsonPredicates: Option[String] = None
 )
 
 private[sharing] case class ListSharesResponse(
@@ -221,14 +223,17 @@ private[spark] class DeltaSharingRestClient(
       predicates: Seq[String],
       limit: Option[Long],
       versionAsOf: Option[Long],
-      timestampAsOf: Option[String]): DeltaTableFiles = {
+      timestampAsOf: Option[String],
+      jsonPredicates: Option[String]): DeltaTableFiles = {
     val encodedShareName = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchemaName = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTableName = URLEncoder.encode(table.name, "UTF-8")
     val target = getTargetUrl(
       s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query")
     val (version, lines) = getNDJson(
-      target, QueryTableRequest(predicates, limit, versionAsOf, timestampAsOf, None))
+      target,
+      QueryTableRequest(predicates, limit, versionAsOf, timestampAsOf, None, jsonPredicates)
+    )
     require(versionAsOf.isEmpty || versionAsOf.get == version)
     val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
     checkProtocol(protocol)

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -78,7 +78,7 @@ private[sharing] case class QueryTableRequest(
   version: Option[Long],
   timestamp: Option[String],
   startingVersion: Option[Long],
-  jsonPredicates: Option[String] = None
+  jsonPredicates: Option[String]
 )
 
 private[sharing] case class ListSharesResponse(
@@ -249,7 +249,7 @@ private[spark] class DeltaSharingRestClient(
     val target = getTargetUrl(
       s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query")
     val (version, lines) = getNDJson(
-      target, QueryTableRequest(Nil, None, None, None, Some(startingVersion)))
+      target, QueryTableRequest(Nil, None, None, None, Some(startingVersion), None))
     val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
     checkProtocol(protocol)
     val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -237,10 +237,12 @@ case class DeltaSharingSource(
     if (isStartingVersion) {
       // If isStartingVersion is true, it means to fetch the snapshot at the fromVersion, which may
       // include table changes from previous versions.
-      val tableFiles = deltaLog.client.getFiles(deltaLog.table, Nil, None, Some(fromVersion), None)
+      val tableFiles = deltaLog.client.getFiles(
+        deltaLog.table, Nil, None, Some(fromVersion), None, None
+      )
       latestRefreshFunc = () => {
         deltaLog.client.getFiles(
-          deltaLog.table, Nil, None, Some(fromVersion), None
+          deltaLog.table, Nil, None, Some(fromVersion), None, None
         ).files.map { f =>
           f.id -> f.url
         }.toMap

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -17,9 +17,12 @@
 package io.delta.sharing.spark
 
 import java.lang.ref.WeakReference
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Base64
 
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.delta.sharing.CachedTableManager
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Column, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
@@ -27,6 +30,7 @@ import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Cast, Expressi
 import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, HadoopFsRelation, PartitionDirectory}
 import org.apache.spark.sql.types.{DataType, StructType}
 
+import io.delta.sharing.spark.filters.{BaseOp, OpConverter}
 import io.delta.sharing.spark.model.{
   AddCDCFile,
   AddFile,
@@ -35,6 +39,7 @@ import io.delta.sharing.spark.model.{
   FileAction,
   RemoveFile
 }
+import io.delta.sharing.spark.util.JsonUtils
 
 private[sharing] case class RemoteDeltaFileIndexParams(
     val spark: SparkSession,
@@ -45,7 +50,7 @@ private[sharing] case class RemoteDeltaFileIndexParams(
 
 // A base class for all file indices for remote delta log.
 private[sharing] abstract class RemoteDeltaFileIndexBase(
-    val params: RemoteDeltaFileIndexParams) extends FileIndex {
+    val params: RemoteDeltaFileIndexParams) extends FileIndex with Logging {
   override def refresh(): Unit = {}
 
   override def sizeInBytes: Long = params.snapshotAtAnalysis.sizeInBytes
@@ -101,6 +106,26 @@ private[sharing] abstract class RemoteDeltaFileIndexBase(
       partitionFilters)
     new Column(rewrittenFilters.reduceLeftOption(And).getOrElse(Literal(true)))
   }
+
+  // Converts the specified SQL expressions to a json predicate.
+  //
+  // If the conversion fails, returns a None, which will imply that we will
+  // not perform json predicate based filtering.
+  protected def convertToJsonPredicate(partitionFilters: Seq[Expression]) : Option[String] = {
+    try {
+      val op = OpConverter.convert(partitionFilters)
+      if (op.isDefined) {
+        val op_json = JsonUtils.toJson[BaseOp](op.get)
+        Some(new String(Base64.getUrlEncoder.encode(op_json.getBytes), UTF_8))
+      } else {
+        None
+      }
+    } catch {
+      case e: Exception =>
+        log.error("Error while converting partition filters: " + e)
+        None
+    }
+  }
 }
 
 // The index for processing files in a delta snapshot.
@@ -109,7 +134,7 @@ private[sharing] case class RemoteDeltaSnapshotFileIndex(
     limitHint: Option[Long]) extends RemoteDeltaFileIndexBase(params) {
 
   override def inputFiles: Array[String] = {
-    params.snapshotAtAnalysis.filesForScan(Nil, None, this)
+    params.snapshotAtAnalysis.filesForScan(Nil, None, None, this)
       .map(f => toDeltaSharingPath(f).toString)
       .toArray
   }
@@ -120,6 +145,7 @@ private[sharing] case class RemoteDeltaSnapshotFileIndex(
     makePartitionDirectories(params.snapshotAtAnalysis.filesForScan(
       partitionFilters ++ dataFilters,
       limitHint,
+      convertToJsonPredicate(partitionFilters),
       this
     ))
   }

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -115,8 +115,8 @@ private[sharing] abstract class RemoteDeltaFileIndexBase(
     try {
       val op = OpConverter.convert(partitionFilters)
       if (op.isDefined) {
-        val op_json = JsonUtils.toJson[BaseOp](op.get)
-        Some(new String(Base64.getUrlEncoder.encode(op_json.getBytes), UTF_8))
+        val opJson = JsonUtils.toJson[BaseOp](op.get)
+        Some(new String(Base64.getUrlEncoder.encode(opJson.getBytes), UTF_8))
       } else {
         None
       }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -151,7 +151,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
     try {
       val tableFiles =
-        client.getFiles(Table(name = "table2", schema = "default", share = "share2"), Nil, None, None, None)
+        client.getFiles(Table(name = "table2", schema = "default", share = "share2"), Nil, None, None, None, None)
       assert(tableFiles.version == 2)
       assert(Protocol(minReaderVersion = 1) == tableFiles.protocol)
       val expectedMetadata = Metadata(
@@ -191,6 +191,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Nil,
         None,
         Some(1L),
+        None,
         None)
       assert(tableFiles.version == 1)
       assert(tableFiles.files.size == 3)
@@ -238,6 +239,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
           Nil,
           None,
           Some(1L),
+          None,
           None
         )
       }.getMessage
@@ -260,7 +262,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
           Nil,
           None,
           None,
-          Some("2000-01-01T00:00:00Z"))
+          Some("2000-01-01T00:00:00Z"),
+          None)
       }.getMessage
       assert(errorMessage.contains("The provided timestamp"))
     } finally {
@@ -277,7 +280,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
           Nil,
           None,
           None,
-          Some("abc")
+          Some("abc"),
+          None
         )
       }.getMessage
       assert(errorMessage.contains("Reading table by version or timestamp is not supported because change data feed is not enabled on table: share1.default.table1"))

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -94,24 +94,24 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
       SqlLiteral(23, IntegerType)
     )
     // The client should get a base64 encoded json as jsonPredicate.
-    val expected_json =
+    val expectedJson =
       """{"op":"equal",
          |"children":[
          |  {"op":"column","name":"id","valueType":"int"},
          |  {"op":"literal","value":"23","valueType":"int"}]
          |}""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")
-    val encoded_json = new String(Base64.getUrlEncoder.encode(expected_json.getBytes), UTF_8)
+    val encodedJson = new String(Base64.getUrlEncoder.encode(expectedJson.getBytes), UTF_8)
 
     val remoteDeltaLog = new RemoteDeltaLog(Table("fe", "fi", "fo"), new Path("test"), client)
     fileIndex.listFiles(Seq(sqlEq), Seq.empty)
     assert(TestDeltaSharingClient.limits === Seq(2L))
     assert(TestDeltaSharingClient.jsonPredicates.size === 1)
-    val received_json = TestDeltaSharingClient.jsonPredicates(0)
-    assert(received_json == encoded_json)
+    val receivedJson = TestDeltaSharingClient.jsonPredicates(0)
+    assert(receivedJson == encodedJson)
 
     // Also test that we can decode the json correctly.
-    val decoded_json = new String(Base64.getUrlDecoder.decode(received_json), UTF_8)
-    assert(decoded_json == expected_json)
+    val decodedJson = new String(Base64.getUrlDecoder.decode(receivedJson), UTF_8)
+    assert(decodedJson == expectedJson)
   }
 
   test("snapshot file index test") {

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -29,16 +29,12 @@ import org.apache.spark.sql.catalyst.expressions.{
   EqualTo => SqlEqualTo,
   Literal => SqlLiteral
 }
-import org.apache.spark.sql.types.{
-  IntegerType => SqlIntegerType
-}
-import io.delta.sharing.spark.util.JsonUtils
-
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructField, StructType}
 
 import io.delta.sharing.spark.filters.{BaseOp, OpConverter}
 import io.delta.sharing.spark.model.Table
+import io.delta.sharing.spark.util.JsonUtils
 
 class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
 
@@ -94,8 +90,8 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
 
     // We will send a simple equal op as a SQL expression tree.
     val sqlEq = SqlEqualTo(
-      SqlAttributeReference("id", SqlIntegerType)(),
-      SqlLiteral(23, SqlIntegerType)
+      SqlAttributeReference("id", IntegerType)(),
+      SqlLiteral(23, IntegerType)
     )
     // The client should get a base64 encoded json as jsonPredicate.
     val expected_json =
@@ -110,7 +106,7 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     fileIndex.listFiles(Seq(sqlEq), Seq.empty)
     assert(TestDeltaSharingClient.limits === Seq(2L))
     assert(TestDeltaSharingClient.jsonPredicates.size === 1)
-    val received_json = TestDeltaSharingClient.jsonPredicates(0) 
+    val received_json = TestDeltaSharingClient.jsonPredicates(0)
     assert(received_json == encoded_json)
 
     // Also test that we can decode the json correctly.

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -60,8 +60,12 @@ class TestDeltaSharingClient(
     predicates: Seq[String],
     limit: Option[Long],
     versionAsOf: Option[Long],
-    timestampAsOf: Option[String]): DeltaTableFiles = {
+    timestampAsOf: Option[String],
+    jsonPredicates: Option[String]): DeltaTableFiles = {
     limit.foreach(lim => TestDeltaSharingClient.limits = TestDeltaSharingClient.limits :+ lim)
+    jsonPredicates.foreach(p => {
+      TestDeltaSharingClient.jsonPredicates = TestDeltaSharingClient.jsonPredicates :+ p
+    })
 
     val addFiles: Seq[AddFile] = if (versionAsOf.isDefined || timestampAsOf.isDefined) {
        Seq(
@@ -114,6 +118,7 @@ class TestDeltaSharingClient(
 
   def clear(): Unit = {
     TestDeltaSharingClient.limits = Nil
+    TestDeltaSharingClient.jsonPredicates = Nil
   }
 }
 
@@ -125,4 +130,5 @@ class TestDeltaSharingProfileProvider extends DeltaSharingProfileProvider {
 
 object TestDeltaSharingClient {
   var limits = Seq.empty[Long]
+  var jsonPredicates = Seq.empty[String]
 }


### PR DESCRIPTION
This PR plugs in json predicate tree generation from the spark provided SQL expression trees, and sends the json predicates to the server via delta sharing client.

I will send the protocol.md changes in a followup PR.