### PR TITLE
Add UUIDs as Table IDs on the reference server

### DIFF
--- a/server/src/main/protobuf/protocol.proto
+++ b/server/src/main/protobuf/protocol.proto
@@ -40,6 +40,7 @@ message Table {
     optional string name = 1;
     optional string schema = 2;
     optional string share = 3;
+    optional string id = 4;
 }
 
 message QueryTableRequest {

--- a/server/src/main/scala/io/delta/sharing/server/SharedTableManager.scala
+++ b/server/src/main/scala/io/delta/sharing/server/SharedTableManager.scala
@@ -138,8 +138,14 @@ class SharedTableManager(serverConfig: ServerConfig) {
     val schemaConfig = getSchema(getShareInternal(share), schema)
     getPage(nextPageToken, Some(share), Some(schema), maxResults, schemaConfig.getTables.size) {
       (start, end) =>
-        schemaConfig.getTables.asScala.map { tableConfig =>
-          Table().withName(tableConfig.getName).withSchema(schema).withShare(share)
+        schemaConfig.getTables.asScala.map {
+          tableConfig =>
+            Table(
+              name = Some(tableConfig.getName),
+              schema = Some(schema),
+              share = Some(share),
+              id = Some(tableConfig.getId)
+            )
         }.slice(start, end)
     }
   }
@@ -158,7 +164,8 @@ class SharedTableManager(serverConfig: ServerConfig) {
               Table(
                 name = Some(table.getName),
                 schema = Some(schema.name),
-                share = Some(share)
+                share = Some(share),
+                id = Some(table.getId)
               )
           }
         }.slice(start, end)

--- a/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
+++ b/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
@@ -218,11 +218,12 @@ case class SchemaConfig(
 case class TableConfig(
     @BeanProperty var name: String,
     @BeanProperty var location: String,
+    @BeanProperty var id: String = "",
     @BeanProperty var cdfEnabled: Boolean = false,
     @BeanProperty var startVersion: Long = 0) extends ConfigItem {
 
   def this() {
-    this(null, null)
+    this(null, null, null)
   }
 
   override def checkConfig(): Unit = {

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -268,9 +268,25 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   integrationTest("/shares/{share}/schemas/{schema}/tables") {
     val response = readJson(requestPath("/shares/share1/schemas/default/tables"))
     val expected = ListTablesResponse(
-      Table().withName("table1").withSchema("default").withShare("share1") ::
-        Table().withName("table3").withSchema("default").withShare("share1") ::
-        Table().withName("table7").withSchema("default").withShare("share1") :: Nil)
+      Table(
+        name = Some("table1"),
+        schema = Some("default"),
+        share = Some("share1"),
+        id = Some("00000000-0000-0000-0000-000000000001")
+      )::
+        Table(
+          name = Some("table3"),
+          schema = Some("default"),
+          share = Some("share1"),
+          id = Some("00000000-0000-0000-0000-000000000003")
+        )::
+        Table(
+          name = Some("table7"),
+          schema = Some("default"),
+          share = Some("share1"),
+          id = Some("00000000-0000-0000-0000-000000000007")
+        )::Nil
+    )
     assert(expected == JsonFormat.fromJsonString[ListTablesResponse](response))
   }
 
@@ -283,17 +299,43 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       tables ++= response.items
     }
     val expected =
-      Table().withName("table1").withSchema("default").withShare("share1") ::
-        Table().withName("table3").withSchema("default").withShare("share1") ::
-        Table().withName("table7").withSchema("default").withShare("share1") :: Nil
+      Table(
+        name = Some("table1"),
+        schema = Some("default"),
+        share = Some("share1"),
+        id = Some("00000000-0000-0000-0000-000000000001")
+      )::
+        Table(
+          name = Some("table3"),
+          schema = Some("default"),
+          share = Some("share1"),
+          id = Some("00000000-0000-0000-0000-000000000003")
+        )::
+        Table(
+          name = Some("table7"),
+          schema = Some("default"),
+          share = Some("share1"),
+          id = Some("00000000-0000-0000-0000-000000000007")
+        )::Nil
     assert(expected == tables)
   }
 
   integrationTest("/shares/{share}/all-tables") {
     val response = readJson(requestPath("/shares/share7/all-tables"))
     val expected = ListAllTablesResponse(
-      Table().withName("table8").withSchema("schema1").withShare("share7") ::
-        Table().withName("table9").withSchema("schema2").withShare("share7") :: Nil)
+      Table(
+        name = Some("table8"),
+        schema = Some("schema1"),
+        share = Some("share7"),
+        id = Some("00000000-0000-0000-0000-000000000008")
+      )::
+        Table(
+          name = Some("table9"),
+          schema = Some("schema2"),
+          share = Some("share7"),
+          id = Some("00000000-0000-0000-0000-000000000009")
+        )::Nil
+    )
     assert(expected == JsonFormat.fromJsonString[ListAllTablesResponse](response))
   }
 
@@ -306,8 +348,18 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       tables ++= response.items
     }
     val expected =
-      Table().withName("table8").withSchema("schema1").withShare("share7") ::
-        Table().withName("table9").withSchema("schema2").withShare("share7") :: Nil
+      Table(
+        name = Some("table8"),
+        schema = Some("schema1"),
+        share = Some("share7"),
+        id = Some("00000000-0000-0000-0000-000000000008")
+      )::
+        Table(
+          name = Some("table9"),
+          schema = Some("schema2"),
+          share = Some("share7"),
+          id = Some("00000000-0000-0000-0000-000000000009")
+        )::Nil
     assert(expected == tables)
   }
 

--- a/server/src/test/scala/io/delta/sharing/server/SharedTableManagerSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/SharedTableManagerSuite.scala
@@ -118,9 +118,9 @@ class SharedTableManagerSuite extends FunSuite {
           SchemaConfig(
             "schema1",
             Arrays.asList(
-              TableConfig("table1", "location1"),
-              TableConfig("table2", "location1"),
-              TableConfig("table3", "location2")
+              TableConfig("table1", "location1", "00000000-0000-0000-0000-000000000001"),
+              TableConfig("table2", "location1", "00000000-0000-0000-0000-000000000002"),
+              TableConfig("table3", "location2", "00000000-0000-0000-0000-000000000003")
             )
           )
         )
@@ -129,9 +129,24 @@ class SharedTableManagerSuite extends FunSuite {
     val sharedTableManager = new SharedTableManager(serverConfig)
     val (tables, _) = sharedTableManager.listTables("share1", "schema1")
     assert(tables == Seq(
-      Table().withName("table1").withSchema("schema1").withShare("share1"),
-      Table().withName("table2").withSchema("schema1").withShare("share1"),
-      Table().withName("table3").withSchema("schema1").withShare("share1")
+      Table(
+        name = Some("table1"),
+        schema = Some("schema1"),
+        share = Some("share1"),
+        id = Some("00000000-0000-0000-0000-000000000001")
+      ),
+      Table(
+        name = Some("table2"),
+        schema = Some("schema1"),
+        share = Some("share1"),
+        id = Some("00000000-0000-0000-0000-000000000002")
+      ),
+      Table(
+        name = Some("table3"),
+        schema = Some("schema1"),
+        share = Some("share1"),
+        id = Some("00000000-0000-0000-0000-000000000003")
+      )
     ))
 
     assert(intercept[DeltaSharingNoSuchElementException] {
@@ -151,14 +166,14 @@ class SharedTableManagerSuite extends FunSuite {
           SchemaConfig(
             "schema1",
             Arrays.asList(
-              TableConfig("table1", "location1"),
-              TableConfig("table2", "location1")
+              TableConfig("table1", "location1", "00000000-0000-0000-0000-000000000001"),
+              TableConfig("table2", "location1", "00000000-0000-0000-0000-000000000002")
             )
           ),
           SchemaConfig(
             "schema2",
             Arrays.asList(
-              TableConfig("table3", "location1")
+              TableConfig("table3", "location1", "00000000-0000-0000-0000-000000000003")
             )
           )
         )
@@ -167,9 +182,24 @@ class SharedTableManagerSuite extends FunSuite {
     val sharedTableManager = new SharedTableManager(serverConfig)
     val (tables, _) = sharedTableManager.listAllTables("share1")
     assert(tables == Seq(
-      Table().withName("table1").withSchema("schema1").withShare("share1"),
-      Table().withName("table2").withSchema("schema1").withShare("share1"),
-      Table().withName("table3").withSchema("schema2").withShare("share1")
+      Table(
+        name = Some("table1"),
+        schema = Some("schema1"),
+        share = Some("share1"),
+        id = Some("00000000-0000-0000-0000-000000000001")
+      ),
+      Table(
+        name = Some("table2"),
+        schema = Some("schema1"),
+        share = Some("share1"),
+        id = Some("00000000-0000-0000-0000-000000000002")
+      ),
+      Table(
+        name = Some("table3"),
+        schema = Some("schema2"),
+        share = Some("share1"),
+        id = Some("00000000-0000-0000-0000-000000000003")
+      )
     ))
 
     assert(intercept[DeltaSharingNoSuchElementException] {
@@ -186,8 +216,13 @@ class SharedTableManagerSuite extends FunSuite {
           SchemaConfig(
             "schema1",
             Arrays.asList(
-              TableConfig("table1", "location1"),
-              TableConfig("table0", "location0", true)
+              TableConfig("table1", "location1", "00000000-0000-0000-0000-000000000001"),
+              TableConfig(
+                "table0",
+                "location0",
+                "00000000-0000-0000-0000-000000000000",
+                cdfEnabled = true
+              )
             )
           )
         )
@@ -195,10 +230,17 @@ class SharedTableManagerSuite extends FunSuite {
     )
     val sharedTableManager = new SharedTableManager(serverConfig)
     var table = sharedTableManager.getTable("share1", "schema1", "table1")
-    assert(table == TableConfig("table1", "location1"))
+    assert(table == TableConfig("table1", "location1", "00000000-0000-0000-0000-000000000001"))
 
     table = sharedTableManager.getTable("share1", "schema1", "table0")
-    assert(table == TableConfig("table0", "location0", true))
+    assert(table ==
+      TableConfig(
+        "table0",
+        "location0",
+        "00000000-0000-0000-0000-000000000000",
+        cdfEnabled = true
+      )
+    )
 
     assert(intercept[DeltaSharingNoSuchElementException] {
       sharedTableManager.getTable("share2", "schema1", "table1")

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -70,7 +70,7 @@ object TestResource {
               TableConfig(
                 "table1",
                 s"s3a://${AWS.bucket}/delta-exchange-test/table1",
-                "00000000-0000-0000-0000-000000000000"
+                "00000000-0000-0000-0000-000000000001"
               ),
               TableConfig(
                 "table3",

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -67,9 +67,21 @@ object TestResource {
           SchemaConfig(
             "default",
             java.util.Arrays.asList(
-              TableConfig("table1", s"s3a://${AWS.bucket}/delta-exchange-test/table1"),
-              TableConfig("table3", s"s3a://${AWS.bucket}/delta-exchange-test/table3"),
-              TableConfig("table7", s"s3a://${AWS.bucket}/delta-exchange-test/table7")
+              TableConfig(
+                "table1",
+                s"s3a://${AWS.bucket}/delta-exchange-test/table1",
+                "00000000-0000-0000-0000-000000000000"
+              ),
+              TableConfig(
+                "table3",
+                s"s3a://${AWS.bucket}/delta-exchange-test/table3",
+                "00000000-0000-0000-0000-000000000003"
+              ),
+              TableConfig(
+                "table7",
+                s"s3a://${AWS.bucket}/delta-exchange-test/table7",
+                "00000000-0000-0000-0000-000000000007"
+              )
             )
           )
         )
@@ -77,7 +89,11 @@ object TestResource {
       ShareConfig("share2",
         java.util.Arrays.asList(
           SchemaConfig("default", java.util.Arrays.asList(
-            TableConfig("table2", s"s3a://${AWS.bucket}/delta-exchange-test/table2")
+            TableConfig(
+              "table2",
+              s"s3a://${AWS.bucket}/delta-exchange-test/table2",
+              "00000000-0000-0000-0000-000000000002"
+            )
           )
           )
         )),
@@ -86,8 +102,16 @@ object TestResource {
           SchemaConfig(
             "default",
             java.util.Arrays.asList(
-              TableConfig("table4", s"s3a://${AWS.bucket}/delta-exchange-test/table4"),
-              TableConfig("table5", s"s3a://${AWS.bucket}/delta-exchange-test/table5")
+              TableConfig(
+                "table4",
+                s"s3a://${AWS.bucket}/delta-exchange-test/table4",
+                "00000000-0000-0000-0000-000000000004"
+              ),
+              TableConfig(
+                "table5",
+                s"s3a://${AWS.bucket}/delta-exchange-test/table5",
+                "00000000-0000-0000-0000-000000000005"
+              )
             )
           )
         )
@@ -98,7 +122,11 @@ object TestResource {
             "default",
             java.util.Arrays.asList(
               // table made with spark.sql.parquet.compression.codec=gzip
-              TableConfig("test_gzip", s"s3a://${AWS.bucket}/compress-test/table1")
+              TableConfig(
+                "test_gzip",
+                s"s3a://${AWS.bucket}/compress-test/table1",
+                "00000000-0000-0000-0000-000000000099"
+              )
             )
           )
         )
@@ -119,13 +147,21 @@ object TestResource {
           SchemaConfig(
             "schema1",
             java.util.Arrays.asList(
-              TableConfig("table8", s"s3a://${AWS.bucket}/delta-exchange-test/table8")
+              TableConfig(
+                "table8",
+                s"s3a://${AWS.bucket}/delta-exchange-test/table8",
+                "00000000-0000-0000-0000-000000000008"
+              )
             )
           ),
           SchemaConfig(
             "schema2",
             java.util.Arrays.asList(
-              TableConfig("table9", s"s3a://${AWS.bucket}/delta-exchange-test/table9")
+              TableConfig(
+                "table9",
+                s"s3a://${AWS.bucket}/delta-exchange-test/table9",
+                "00000000-0000-0000-0000-000000000009"
+              )
             )
           )
         )
@@ -136,8 +172,16 @@ object TestResource {
           SchemaConfig(
             "default",
             java.util.Arrays.asList(
-              TableConfig("table_wasb", s"wasbs://${Azure.container}@${Azure.accountName}.blob.core.windows.net/delta-sharing-test/table1"),
-              TableConfig("table_abfs", s"abfss://${Azure.container}@${Azure.accountName}.dfs.core.windows.net/delta-sharing-test/table1")
+              TableConfig(
+                "table_wasb",
+                s"wasbs://${Azure.container}@${Azure.accountName}.blob.core.windows.net/delta-sharing-test/table1",
+                "00000000-0000-0000-0000-000000000098"
+              ),
+              TableConfig(
+                "table_abfs",
+                s"abfss://${Azure.container}@${Azure.accountName}.dfs.core.windows.net/delta-sharing-test/table1",
+                "00000000-0000-0000-0000-000000000097"
+              )
             )
           )
         )
@@ -148,7 +192,11 @@ object TestResource {
           SchemaConfig(
             "default",
             java.util.Arrays.asList(
-              TableConfig("table_gcs", s"gs://${GCP.bucket}/delta-sharing-test/table1")
+              TableConfig(
+                "table_gcs",
+                s"gs://${GCP.bucket}/delta-sharing-test/table1",
+                "00000000-0000-0000-0000-000000000096"
+              )
             )
           )
         )
@@ -161,73 +209,87 @@ object TestResource {
               TableConfig(
                 "cdf_table_cdf_enabled",
                 s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_cdf_enabled",
-                true
+                "00000000-0000-0000-0000-000000000095",
+                cdfEnabled = true
               ),
               TableConfig(
                 "cdf_table_with_partition",
                 s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_with_partition",
-                true,
-                1
+                "00000000-0000-0000-0000-000000000094",
+                cdfEnabled = true,
+                startVersion = 1
               ),
               TableConfig(
                 "cdf_table_with_vacuum",
                 s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_with_vacuum",
-                true
+                "00000000-0000-0000-0000-000000000093",
+                cdfEnabled = true
               ),
               TableConfig(
                 "cdf_table_missing_log",
                 s"s3a://${AWS.bucket}/delta-exchange-test/cdf_table_missing_log",
-                true
+                "00000000-0000-0000-0000-000000000092",
+                cdfEnabled = true
               ),
               TableConfig(
                 "streaming_table_with_optimize",
                 s"s3a://${AWS.bucket}/delta-exchange-test/streaming_table_with_optimize",
-                true
+                "00000000-0000-0000-0000-000000000091",
+                cdfEnabled = true
               ),
               TableConfig(
                 "streaming_table_metadata_protocol",
                 s"s3a://${AWS.bucket}/delta-exchange-test/streaming_table_metadata_protocol",
-                true
+                "00000000-0000-0000-0000-000000000090",
+                cdfEnabled = true
               ),
               TableConfig(
                 "streaming_notnull_to_null",
                 s"s3a://${AWS.bucket}/delta-exchange-test/streaming_notnull_to_null",
-                true
+                "00000000-0000-0000-0000-000000000089",
+                cdfEnabled = true
               ),
               TableConfig(
                 "streaming_null_to_notnull",
                 s"s3a://${AWS.bucket}/delta-exchange-test/streaming_null_to_notnull",
-                true
+                "00000000-0000-0000-0000-000000000088",
+                cdfEnabled = true
               ),
               TableConfig(
                 "streaming_cdf_null_to_notnull",
                 s"s3a://${AWS.bucket}/delta-exchange-test/streaming_cdf_null_to_notnull",
-                true
+                "00000000-0000-0000-0000-000000000087",
+                cdfEnabled = true
               ),
               TableConfig(
                 "streaming_cdf_table",
                 s"s3a://${AWS.bucket}/delta-exchange-test/streaming_cdf_table",
-                true
+                "00000000-0000-0000-0000-000000000086",
+                cdfEnabled = true
               ),
               TableConfig(
                 "table_reader_version_increased",
                 s"s3a://${AWS.bucket}/delta-exchange-test/table_reader_version_increased",
-                true
+                "00000000-0000-0000-0000-000000000085",
+                cdfEnabled = true
               ),
               TableConfig(
                 "table_with_no_metadata",
                 s"s3a://${AWS.bucket}/delta-exchange-test/table_with_no_metadata",
-                true
+                "00000000-0000-0000-0000-000000000084",
+                cdfEnabled = true
               ),
               TableConfig(
                 "table_data_loss_with_checkpoint",
                 s"s3a://${AWS.bucket}/delta-exchange-test/table_data_loss_with_checkpoint",
-                true
+                "00000000-0000-0000-0000-000000000083",
+                cdfEnabled = true
               ),
               TableConfig(
                 "table_data_loss_no_checkpoint",
                 s"s3a://${AWS.bucket}/delta-exchange-test/table_data_loss_no_checkpoint",
-                true
+                "00000000-0000-0000-0000-000000000082",
+                cdfEnabled = true
               )
             )
           )

--- a/server/src/test/scala/io/delta/sharing/server/config/ServerConfigSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/config/ServerConfigSuite.scala
@@ -53,10 +53,16 @@ class ServerConfigSuite extends FunSuite {
       val sharesInTemplate = Arrays.asList(
         ShareConfig("share1", Arrays.asList(
           SchemaConfig("schema1", Arrays.asList(
-            TableConfig("table1", "s3a://<bucket-name>/<the-table-path>"),
+            TableConfig(
+              "table1",
+              "s3a://<bucket-name>/<the-table-path>",
+              id = "00000000-0000-0000-0000-000000000000"
+            ),
             TableConfig(
               "table2",
-              "wasbs://<container-name>@<account-name}.blob.core.windows.net/<the-table-path>")
+              "wasbs://<container-name>@<account-name}.blob.core.windows.net/<the-table-path>",
+              id = "00000000-0000-0000-0000-000000000001"
+            )
           ))
         )),
         ShareConfig("share2", Arrays.asList(
@@ -64,14 +70,18 @@ class ServerConfigSuite extends FunSuite {
             TableConfig(
               "table3",
               "abfss://<container-name>@<account-name}.dfs.core.windows.net/<the-table-path>",
-              true)
+              id = "00000000-0000-0000-0000-000000000002",
+              cdfEnabled = true
+            )
           ))
         )),
         ShareConfig("share3", Arrays.asList(
           SchemaConfig("schema3", Arrays.asList(
             TableConfig(
               "table4",
-              "gs://<bucket-name>/<the-table-path>")
+              "gs://<bucket-name>/<the-table-path>",
+              id = "00000000-0000-0000-0000-000000000003"
+            )
           ))
         ))
       )

--- a/server/src/universal/conf/delta-sharing-server.yaml.template
+++ b/server/src/universal/conf/delta-sharing-server.yaml.template
@@ -9,9 +9,11 @@ shares:
     - name: "table1"
       # S3. See https://github.com/delta-io/delta-sharing#s3 for how to config the credentials
       location: "s3a://<bucket-name>/<the-table-path>"
+      id: "00000000-0000-0000-0000-000000000000"
     - name: "table2"
       # Azure Blob Storage. See https://github.com/delta-io/delta-sharing#azure-blob-storage for how to config the credentials
       location: "wasbs://<container-name>@<account-name}.blob.core.windows.net/<the-table-path>"
+      id: "00000000-0000-0000-0000-000000000001"
 - name: "share2"
   schemas:
   - name: "schema2"
@@ -20,6 +22,7 @@ shares:
       # Azure Data Lake Storage Gen2. See https://github.com/delta-io/delta-sharing#azure-data-lake-storage-gen2 for how to config the credentials
       location: "abfss://<container-name>@<account-name}.dfs.core.windows.net/<the-table-path>"
       cdfEnabled: true
+      id: "00000000-0000-0000-0000-000000000002"
 - name: "share3"
   schemas:
   - name: "schema3"
@@ -27,6 +30,7 @@ shares:
     - name: "table4"
       # Google Cloud Storage (GCS). See https://github.com/delta-io/delta-sharing#google-cloud-storage for how to config the credentials
       location: "gs://<bucket-name>/<the-table-path>"
+      id: "00000000-0000-0000-0000-000000000003"
 # Set the host name that the server will use
 host: "localhost"
 # Set the port that the server will listen on. Note: using ports below 1024 


### PR DESCRIPTION
The protocol currently says the table ID is optional however in lots of client implementations it requires table IDs to be in place. This change returns table IDs on all the tables hosted by the reference server.