### PR TITLE
Add support for expressing sharing profile using a JSON

### DIFF
--- a/python/delta_sharing/__init__.py
+++ b/python/delta_sharing/__init__.py
@@ -16,11 +16,12 @@
 
 from delta_sharing.delta_sharing import SharingClient, load_as_pandas, load_as_spark
 from delta_sharing.delta_sharing import load_table_changes_as_pandas, load_table_changes_as_spark
-from delta_sharing.protocol import Share, Schema, Table
+from delta_sharing.protocol import DeltaSharingProfile, Share, Schema, Table
 from delta_sharing.version import __version__
 
 
 __all__ = [
+    "DeltaSharingProfile",
     "SharingClient",
     "Share",
     "Schema",

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -210,8 +210,8 @@ class SharingClient:
     A Delta Sharing client to query shares/schemas/tables from a Delta Sharing Server.
     """
 
-    def __init__(self,
-                 profile: Union[str, bytes, bytearray, BinaryIO, TextIO, Path, DeltaSharingProfile]):
+    def __init__(self, profile: Union[str, bytes, bytearray,
+                                      BinaryIO, TextIO, Path, DeltaSharingProfile]):
         if _is_valid_json(profile):
             profile = DeltaSharingProfile.from_json(profile)
         elif not isinstance(profile, DeltaSharingProfile):

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -210,7 +210,8 @@ class SharingClient:
     A Delta Sharing client to query shares/schemas/tables from a Delta Sharing Server.
     """
 
-    def __init__(self, profile: Union[str, bytes, bytearray, BinaryIO, TextIO, Path, DeltaSharingProfile]):
+    def __init__(self,
+                 profile: Union[str, bytes, bytearray, BinaryIO, TextIO, Path, DeltaSharingProfile]):
         if _is_valid_json(profile):
             profile = DeltaSharingProfile.from_json(profile)
         elif not isinstance(profile, DeltaSharingProfile):

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -83,7 +83,10 @@ def load_as_pandas(
     :return: A pandas DataFrame representing the shared table.
     """
     profile_json, share, schema, table = _parse_url(url)
-    profile = DeltaSharingProfile.read_from_file(profile_json)
+    if _is_valid_json(profile_json):
+        profile = DeltaSharingProfile.from_json(profile_json)
+    else:
+        profile = DeltaSharingProfile.read_from_file(profile_json)
     return DeltaSharingReader(
         table=Table(name=table, share=share, schema=schema),
         rest_client=DataSharingRestClient(profile),
@@ -193,7 +196,10 @@ def load_table_changes_as_pandas(
     :return: A pandas DataFrame representing the shared table.
     """
     profile_json, share, schema, table = _parse_url(url)
-    profile = DeltaSharingProfile.read_from_file(profile_json)
+    if _is_valid_json(profile_json):
+        profile = DeltaSharingProfile.from_json(profile_json)
+    else:
+        profile = DeltaSharingProfile.read_from_file(profile_json)
     return DeltaSharingReader(
         table=Table(name=table, share=share, schema=schema),
         rest_client=DataSharingRestClient(profile),

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import json
 from itertools import chain
 from typing import BinaryIO, List, Optional, Sequence, TextIO, Tuple, Union
 from pathlib import Path
@@ -51,6 +52,18 @@ def _parse_url(url: str) -> Tuple[str, str, str, str]:
     return (profile, share, schema, table)
 
 
+def _is_valid_json(json_str):
+    """Helper function that tests if a sharing profile is a valid JSON string
+    :json_str: a JSON string containing the profile version, sharing server endpoint, bearer token
+    :return: whether or not the json_str is a valid JSON string
+    """
+    try:
+        json.loads(json_str)
+    except ValueError:
+        return False
+    return True
+
+
 def load_as_pandas(
     url: str,
     limit: Optional[int] = None,
@@ -65,6 +78,8 @@ def load_as_pandas(
       Use this optional parameter to explore the shared table without loading the entire table to
       the memory.
     :param version: an optional non-negative int. Load the snapshot of table at version
+    :param timestamp: an optional string. Load the snapshot of table at version corresponding
+      to the timestamp.
     :return: A pandas DataFrame representing the shared table.
     """
     profile_json, share, schema, table = _parse_url(url)
@@ -195,8 +210,10 @@ class SharingClient:
     A Delta Sharing client to query shares/schemas/tables from a Delta Sharing Server.
     """
 
-    def __init__(self, profile: Union[str, BinaryIO, TextIO, Path, DeltaSharingProfile]):
-        if not isinstance(profile, DeltaSharingProfile):
+    def __init__(self, profile: Union[str, bytes, bytearray, BinaryIO, TextIO, Path, DeltaSharingProfile]):
+        if _is_valid_json(profile):
+            profile = DeltaSharingProfile.from_json(profile)
+        elif not isinstance(profile, DeltaSharingProfile):
             profile = DeltaSharingProfile.read_from_file(profile)
         self._profile = profile
         self._rest_client = DataSharingRestClient(profile)

--- a/python/delta_sharing/protocol.py
+++ b/python/delta_sharing/protocol.py
@@ -40,7 +40,7 @@ class DeltaSharingProfile:
             )
 
     @staticmethod
-    def read_from_file(profile: Union[str, IO, Path]) -> "DeltaSharingProfile":
+    def read_from_file(profile: Union[str, bytes, bytearray, IO, Path]) -> "DeltaSharingProfile":
         if isinstance(profile, str):
             infile = fsspec.open(profile).open()
         elif isinstance(profile, Path):

--- a/spark/src/main/scala/io/delta/sharing/spark/util/JsonUtils.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/util/JsonUtils.scala
@@ -37,4 +37,13 @@ private[sharing] object JsonUtils {
   def fromJson[T: Manifest](json: String): T = {
     mapper.readValue[T](json)
   }
+
+  def isValidJson(jsonStr: String): Boolean = {
+    try {
+      this.fromJson[T](json)
+      true
+    } catch {
+      case e: Exception => false
+    }
+  }
 }


### PR DESCRIPTION
Fixes [#277].

This commit adds support for specifying a sharing profile as a JSON string, bytes, or byte array to the Python connector. In particular, this commit adds the following:

- Adds a static function `_is_valid_json()` to the `delta_sharing` module that determines if the profile is a JSON string
- Adds a conditional check to the DeltaSharingClient constructor to determine if the profile should be `read_from_file()` or `from_json`
- Exposes the `DeltaSharingProfile` class, so that the sharing profile can be expressed using a `DeltaSharingProfile` object