### PR TITLE
Increase delta sharing network timeout.

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingFileSystem.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingFileSystem.scala
@@ -44,7 +44,7 @@ private[sharing] class DeltaSharingFileSystem extends FileSystem {
   }
 
   lazy private val timeoutInSeconds = {
-    val timeoutStr = getConf.get("spark.delta.sharing.network.timeout", "120s")
+    val timeoutStr = getConf.get("spark.delta.sharing.network.timeout", "320s")
     val timeoutInSeconds = JavaUtils.timeStringAs(timeoutStr, TimeUnit.SECONDS)
     if (timeoutInSeconds < 0) {
       throw new IllegalArgumentException(

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -157,7 +157,7 @@ private[sharing] object RemoteDeltaLog {
         "spark.delta.sharing.network.numRetries must not be negative")
     }
     val timeoutInSeconds = {
-      val timeoutStr = sqlConf.getConfString("spark.delta.sharing.network.timeout", "120s")
+      val timeoutStr = sqlConf.getConfString("spark.delta.sharing.network.timeout", "320s")
       val timeoutInSeconds = JavaUtils.timeStringAs(timeoutStr, TimeUnit.SECONDS)
       if (timeoutInSeconds < 0) {
         throw new IllegalArgumentException(


### PR DESCRIPTION
This PR increases the default network timeout for the spark client.
This allows it to scale to larger tables that may require more time for metadata operations such as presigning urls.