### PR TITLE
Added skipChangeCommits support for Delta Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Once the provider shares a table with history, the recipient can perform a strea
 val tablePath = "<profile-file-path>#<share-name>.<schema-name>.<table-name>"
 val df = spark.readStream.format("deltaSharing")
   .option("startingVersion", "1")
-  .option("ignoreChanges", "true")
+  .option("skipChangeCommits", "true")
   .load(tablePath)
 ```
 

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
@@ -63,7 +63,7 @@ object DeltaSharingErrors {
   def deltaSharingSourceIgnoreChangesError(version: Long): Throwable = {
     new UnsupportedOperationException("Detected a data update in the source table at version " +
       s"$version. This is currently not supported. If you'd like to ignore updates, set the " +
-      s"option 'ignoreChanges' to 'true'. If you would like the data update to be reflected, " +
+      s"option 'skipChangeCommits' to 'true'. If you would like the data update to be reflected, " +
       s"please restart the query from latest snapshot with a fresh checkpoint directory.")
   }
 

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
@@ -60,6 +60,9 @@ trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
 
   val ignoreDeletes = options.get(IGNORE_DELETES_OPTION).exists(toBoolean(_, IGNORE_DELETES_OPTION))
 
+  val skipChangeCommits = options.get(SKIP_CHANGE_COMMITS_OPTION)
+    .exists(toBoolean(_, SKIP_CHANGE_COMMITS_OPTION))
+
   val readChangeFeed = options.get(CDF_READ_OPTION).exists(toBoolean(_, CDF_READ_OPTION)) ||
     options.get(CDF_READ_OPTION_LEGACY).exists(toBoolean(_, CDF_READ_OPTION_LEGACY))
 
@@ -154,6 +157,7 @@ object DeltaSharingOptions extends Logging {
   val MAX_BYTES_PER_TRIGGER_OPTION = "maxBytesPerTrigger"
   val IGNORE_CHANGES_OPTION = "ignoreChanges"
   val IGNORE_DELETES_OPTION = "ignoreDeletes"
+  val SKIP_CHANGE_COMMITS_OPTION = "skipChangeCommits"
 
   val STARTING_VERSION_OPTION = "startingVersion"
   val STARTING_TIMESTAMP_OPTION = "startingTimestamp"


### PR DESCRIPTION
### Description
We have added a `skipChangeCommits` flag for Structured Streaming with Delta source ([Here](https://github.com/delta-io/delta/pull/1616) is the PR for Delta). This PR aims to bring parity to Delta Sharing as a streaming source. Below is the description of `skipChangeCommits` flag and how it differs from existing `ignoreChanges` flag:

Added `skipChangeCommits` flag to entirely skip commits that contain `removeFiles` in Delta Sharing source for structured streaming. The purpose for this change is to replace the current `ignoreChanges` flag that could result in data duplication issues when using Delta Sharing as a structured streaming source with DELETE/UPDATE/MERGE INTO operations (e.g. GDPR)

Behavior for existing `ignoreChanges` flag:
- When there's `removeFile` detected in a commit, the `removeFile` would be ignored. And if `addFile` exists as well, the `addFile` would be processed by structured streaming.

Behavior for new `skipChangeCommits` flag:
- When there's `removeFile` detected in a commit, both `removeFile` and `addFile` (if exists) would be ignored by structured streaming to prevent duplication in the sink.

We will deprecate the `ignoreChanges` flag once `skipChangeCommits` is available.

### Testing
Added new tests under `DeltaSharingSourceSuite`, also verified that existing tests were running well.
```
[info] Run completed in 2 minutes, 20 seconds.
[info] Total number of tests run: 25
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 25, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```