### PR TITLE
Correct refreshing logic of pre-signed urls for delta sharing streaming

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -149,6 +149,10 @@ case class DeltaSharingSource(
   // a variable to be used by the CachedTableManager to refresh the presigned urls if the query
   // runs for a long time.
   private var latestRefreshFunc = () => { Map.empty[String, String] }
+  // The latest timestamp in millisecond, records the time of the last rpc sent to the server to
+  // fetch the pre-signed urls.
+  // This is used to track whether the pre-signed urls stored in sortedFetchedFiles are going to
+  // expire and need a refresh.
   private var lastQueryTableTimestamp: Long = -1
 
   // Check the latest table version from the delta sharing server through the client.getTableVersion

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -321,8 +321,7 @@ case class DeltaSharingSource(
         deltaLog.table, Map(DeltaSharingOptions.CDF_START_VERSION -> fromVersion.toString), true)
       DeltaSharingCDFReader.getIdToUrl(d.addFiles, d.cdfFiles, d.removeFiles)
     }
-
-
+    
     (Seq(tableFiles.metadata) ++ tableFiles.additionalMetadatas).foreach { m =>
       val schemaToCheck = DeltaTableUtils.addCdcSchema(DeltaTableUtils.toSchema(m.schemaString))
       if (!SchemaUtils.isReadCompatible(schemaToCheck, schema)) {

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -321,7 +321,7 @@ case class DeltaSharingSource(
         deltaLog.table, Map(DeltaSharingOptions.CDF_START_VERSION -> fromVersion.toString), true)
       DeltaSharingCDFReader.getIdToUrl(d.addFiles, d.cdfFiles, d.removeFiles)
     }
-    
+
     (Seq(tableFiles.metadata) ++ tableFiles.additionalMetadatas).foreach { m =>
       val schemaToCheck = DeltaTableUtils.addCdcSchema(DeltaTableUtils.toSchema(m.schemaString))
       if (!SchemaUtils.isReadCompatible(schemaToCheck, schema)) {

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
@@ -72,7 +72,8 @@ object DeltaSharingCDFReader {
       schema: StructType,
       isStreaming: Boolean,
       refresher: () => Map[String, String],
-      lastQueryTableTimestamp: Long): DataFrame = {
+      lastQueryTableTimestamp: Long = System.currentTimeMillis()
+  ): DataFrame = {
     val dfs = ListBuffer[DataFrame]()
     val refs = ListBuffer[WeakReference[AnyRef]]()
 

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
@@ -71,7 +71,8 @@ object DeltaSharingCDFReader {
       removeFiles: Seq[RemoveFile],
       schema: StructType,
       isStreaming: Boolean,
-      refresher: () => Map[String, String]): DataFrame = {
+      refresher: () => Map[String, String],
+      lastQueryTableTimestamp: Long): DataFrame = {
     val dfs = ListBuffer[DataFrame]()
     val refs = ListBuffer[WeakReference[AnyRef]]()
 
@@ -92,7 +93,8 @@ object DeltaSharingCDFReader {
       getIdToUrl(addFiles, cdfFiles, removeFiles),
       refs,
       params.profileProvider,
-      refresher
+      refresher,
+      lastQueryTableTimestamp
     )
 
     dfs.reduce((df1, df2) => df1.unionAll(df2))

--- a/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -140,13 +140,27 @@ class CachedTableManager(
       idToUrl: Map[String, String],
       refs: Seq[WeakReference[AnyRef]],
       profileProvider: DeltaSharingProfileProvider,
-      refresher: () => Map[String, String]): Unit = {
+      refresher: () => Map[String, String],
+      lastQueryTableTimestamp: Long = System.currentTimeMillis()): Unit = {
     val customTablePath = profileProvider.getCustomTablePath(tablePath)
     val customRefresher = profileProvider.getCustomRefresher(refresher)
 
     val cachedTable = new CachedTable(
-      preSignedUrlExpirationMs + System.currentTimeMillis(),
-      idToUrl,
+      if (preSignedUrlExpirationMs + lastQueryTableTimestamp - System.currentTimeMillis() <
+        refreshThresholdMs) {
+        // If there is a refresh, start counting from now.
+        preSignedUrlExpirationMs + System.currentTimeMillis()
+      } else {
+        // Otherwise, start counting from lastQueryTableTimestamp.
+        preSignedUrlExpirationMs + lastQueryTableTimestamp
+      },
+      idToUrl = if (preSignedUrlExpirationMs + lastQueryTableTimestamp - System.currentTimeMillis() <
+        refreshThresholdMs) {
+        // force a refresh upon register
+        customRefresher()
+      } else {
+        idToUrl
+      },
       refs,
       System.currentTimeMillis(),
       customRefresher

--- a/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -154,8 +154,8 @@ class CachedTableManager(
         // Otherwise, start counting from lastQueryTableTimestamp.
         preSignedUrlExpirationMs + lastQueryTableTimestamp
       },
-      idToUrl = if (preSignedUrlExpirationMs + lastQueryTableTimestamp - System.currentTimeMillis() <
-        refreshThresholdMs) {
+      idToUrl = if (preSignedUrlExpirationMs + lastQueryTableTimestamp - System.currentTimeMillis()
+        < refreshThresholdMs) {
         // force a refresh upon register
         customRefresher()
       } else {

--- a/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -45,9 +45,9 @@ class CachedTable(
     val refresher: () => Map[String, String])
 
 class CachedTableManager(
-    preSignedUrlExpirationMs: Long,
+    val preSignedUrlExpirationMs: Long,
     refreshCheckIntervalMs: Long,
-    refreshThresholdMs: Long,
+    val refreshThresholdMs: Long,
     expireAfterAccessMs: Long) extends Logging {
 
   private val cache = new java.util.concurrent.ConcurrentHashMap[String, CachedTable]()

--- a/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -134,6 +134,8 @@ class CachedTableManager(
    *                signed url cache of this table form the cache.
    * @param profileProvider a profile Provider that can provide customized refresher function.
    * @param refresher A function to re-generate pre signed urls for the table.
+   * @param lastQueryTableTimestamp A timestamp to indicate the last time the idToUrl mapping is
+   *                                generated, to refresh the urls in time based on it.
    */
   def register(
       tablePath: String,

--- a/spark/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
@@ -81,6 +81,22 @@ class CachedTableManagerSuite extends SparkFunSuite {
         intercept[IllegalStateException](manager.getPreSignedUrl(
           provider.getCustomTablePath("test-table-path3"), "id1"))
       }
+
+      manager.register(
+        "test-table-path4",
+        Map("id1" -> "url1", "id2" -> "url2"),
+        Seq(new WeakReference(ref)),
+        provider,
+        () => {
+          Map("id1" -> "url3", "id2" -> "url4")
+        },
+        -1
+      )
+      // We should get new urls immediately because it's refreshed upon register
+      assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path4"),
+        "id1")._1 == "url3")
+      assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path4"),
+        "id2")._1 == "url4")
     } finally {
       manager.stop()
     }
@@ -108,7 +124,8 @@ class CachedTableManagerSuite extends SparkFunSuite {
       Thread.sleep(1000)
       // We should remove the cached table when it's not accessed
       intercept[IllegalStateException](manager.getPreSignedUrl(
-        provider.getCustomTablePath("test-table-path"), "id1"))
+        provider.getCustomTablePath("test-table-path"), "id1")
+      )
     } finally {
       manager.stop()
     }


### PR DESCRIPTION
Correct refreshing logic of pre-signed urls for delta sharing streaming:
1. refresh immediately if it already expired.
2. set the correct expiration time for a CachedTable 

Tested with a integration test from a notebook.