### PR TITLE
Support endingVersion in queryTable RPC

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1933,7 +1933,9 @@ The request body should be a JSON string containing the following optional field
 
 - **timestamp** (type: String, optional): an optional timestamp string in the [Timestamp Format](#timestamp-format),. If set, will return files as of the table version corresponding to the specified timestamp. This is only supported on tables with history sharing enabled.
 
-- **startingVersion** (type: Long, optional): an optional version number. If set, will return all data change files since startingVersion, including historical metadata if seen in the delta log.
+- **startingVersion** (type: Long, optional): an optional version number. If set, will return all data change files since startingVersion, inclusive, including historical metadata if seen in the delta log.
+
+- **endingVersion** (type: Long, optional): an optional version number, only used if startingVersion is set. If set, will return all data change files until endingVersion, inclusive, including historical metadata if seen in the delta log.
 
 When `predicateHints` and `limitHint` are both present, the server should apply `predicateHints` first then `limitHint`. As these two parameters are hints rather than enforcement, the client must always apply `predicateHints` and `limitHint` on the response returned by the server if it wishes to filter and limit the returned data. An empty JSON object (`{}`) should be provided when these two parameters are missing.
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1935,7 +1935,7 @@ The request body should be a JSON string containing the following optional field
 
 - **startingVersion** (type: Long, optional): an optional version number. If set, will return all data change files since startingVersion, inclusive, including historical metadata if seen in the delta log.
 
-- **endingVersion** (type: Long, optional): an optional version number, only used if startingVersion is set. If set, will return all data change files until endingVersion, inclusive, including historical metadata if seen in the delta log.
+- **endingVersion** (type: Long, optional): an optional version number, only used if startingVersion is set. If set, will return all data change files until endingVersion, inclusive, including historical metadata if seen in the delta log. If this parameter is not supported by server, all data change files until the latest table version will be returned.
 
 When `predicateHints` and `limitHint` are both present, the server should apply `predicateHints` first then `limitHint`. As these two parameters are hints rather than enforcement, the client must always apply `predicateHints` and `limitHint` on the response returned by the server if it wishes to filter and limit the returned data. An empty JSON object (`{}`) should be provided when these two parameters are missing.
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1936,6 +1936,7 @@ The request body should be a JSON string containing the following optional field
 - **startingVersion** (type: Long, optional): an optional version number. If set, will return all data change files since startingVersion, inclusive, including historical metadata if seen in the delta log.
 
 - **endingVersion** (type: Long, optional): an optional version number, only used if startingVersion is set. If set, the server can use it as a hint to avoid returning data change files after `endingVersion`. This is not enforcement. Hence, when sending the `endingVersion` parameter, the client should still handle the case that it may receive files after `endingVersion`.
+  - The combination of `statingVersion` and `endingVersion` can be used as query window for delta sharing streaming rpcs.
 
 When `predicateHints` and `limitHint` are both present, the server should apply `predicateHints` first then `limitHint`. As these two parameters are hints rather than enforcement, the client must always apply `predicateHints` and `limitHint` on the response returned by the server if it wishes to filter and limit the returned data. An empty JSON object (`{}`) should be provided when these two parameters are missing.
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1935,7 +1935,7 @@ The request body should be a JSON string containing the following optional field
 
 - **startingVersion** (type: Long, optional): an optional version number. If set, will return all data change files since startingVersion, inclusive, including historical metadata if seen in the delta log.
 
-- **endingVersion** (type: Long, optional): an optional version number, only used if startingVersion is set. If set, will return all data change files until endingVersion, inclusive, including historical metadata if seen in the delta log. If this parameter is not supported by server, all data change files until the latest table version will be returned.
+- **endingVersion** (type: Long, optional): an optional version number, only used if startingVersion is set. If set, the server can use it as a hint to avoid returning data change files after `endingVersion`. This is not enforcement. Hence, when sending the `endingVersion` parameter, the client should still handle the case that it may receive files after `endingVersion`.
 
 When `predicateHints` and `limitHint` are both present, the server should apply `predicateHints` first then `limitHint`. As these two parameters are hints rather than enforcement, the client must always apply `predicateHints` and `limitHint` on the response returned by the server if it wishes to filter and limit the returned data. An empty JSON object (`{}`) should be provided when these two parameters are missing.
 

--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ To use Delta Sharing connector interactively within the Spark’s Scala/Python s
 #### PySpark shell
 
 ```
-pyspark --packages io.delta:delta-sharing-spark_2.12:0.6.2
+pyspark --packages io.delta:delta-sharing-spark_2.12:0.6.4
 ```
 
 #### Scala Shell
 
 ```
-bin/spark-shell --packages io.delta:delta-sharing-spark_2.12:0.6.2
+bin/spark-shell --packages io.delta:delta-sharing-spark_2.12:0.6.4
 ```
 
 ### Set up a standalone project
@@ -148,7 +148,7 @@ You include Delta Sharing connector in your Maven project by adding it as a depe
 <dependency>
   <groupId>io.delta</groupId>
   <artifactId>delta-sharing-spark_2.12</artifactId>
-  <version>0.6.2</version>
+  <version>0.6.4</version>
 </dependency>
 ```
 
@@ -157,7 +157,7 @@ You include Delta Sharing connector in your Maven project by adding it as a depe
 You include Delta Sharing connector in your SBT project by adding the following line to your `build.sbt` file:
 
 ```scala
-libraryDependencies += "io.delta" %% "delta-sharing-spark" % "0.6.2"
+libraryDependencies += "io.delta" %% "delta-sharing-spark" % "0.6.4"
 ```
 
 ## Quick Start
@@ -489,7 +489,7 @@ You can use the pre-built docker image from https://hub.docker.com/r/deltaio/del
 ```
 docker run -p <host-port>:<container-port> \
   --mount type=bind,source=<the-server-config-yaml-file>,target=/config/delta-sharing-server-config.yaml \
-  deltaio/delta-sharing-server:0.6.2 -- --config /config/delta-sharing-server-config.yaml
+  deltaio/delta-sharing-server:0.6.4 -- --config /config/delta-sharing-server-config.yaml
 ```
 
 Note that `<container-port>` should be the same as the port defined inside the config file.

--- a/server/src/main/protobuf/protocol.proto
+++ b/server/src/main/protobuf/protocol.proto
@@ -58,7 +58,7 @@ message QueryTableRequest {
     optional int64 version = 3;
     // The table version corresponding to the timestamp being queried.
     optional string timestamp = 4;
-    // Query all data change files since startingVersion, inclusive
+    // Query all data change files since startingVersion, inclusive.
     optional int64 startingVersion = 5;
     // Query all data change files until endingVersion, inclusive. Only used when startingVersion
     // is set, otherwise will be ignored.

--- a/server/src/main/protobuf/protocol.proto
+++ b/server/src/main/protobuf/protocol.proto
@@ -58,8 +58,11 @@ message QueryTableRequest {
     optional int64 version = 3;
     // The table version corresponding to the timestamp being queried.
     optional string timestamp = 4;
-    // Query all data change files since startingVersion
+    // Query all data change files since startingVersion, inclusive
     optional int64 startingVersion = 5;
+    // Query all data change files until endingVersion, inclusive. Only used when startingVersion
+    // is set, otherwise will be ignored.
+    optional int64 endingVersion = 7;
 }
 
 message ListSharesResponse {

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -321,6 +321,10 @@ class DeltaSharingService(serverConfig: ServerConfig) {
           s"You can only query table data since version ${tableConfig.startVersion}."
         )
       }
+      if (request.endingVersion.isDefined &&
+        request.startingVersion.exists(_ > request.endingVersion.get)) {
+
+      }
     }
     val (version, actions) = deltaSharedTableLoader.loadTable(tableConfig).query(
       includeFiles = true,
@@ -329,7 +333,9 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       request.limitHint,
       request.version,
       request.timestamp,
-      request.startingVersion)
+      request.startingVersion,
+      request.endingVersion
+    )
     if (version < tableConfig.startVersion) {
       throw new DeltaSharingIllegalArgumentException(
         s"You can only query table data since version ${tableConfig.startVersion}."

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -282,7 +282,9 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       limitHint = None,
       version = None,
       timestamp = None,
-      startingVersion = None)
+      startingVersion = None,
+      endingVersion = None
+    )
     streamingOutput(Some(v), actions)
   }
 
@@ -323,7 +325,10 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       }
       if (request.endingVersion.isDefined &&
         request.startingVersion.exists(_ > request.endingVersion.get)) {
-
+        throw new DeltaSharingIllegalArgumentException(
+          s"startingVersion(${request.startingVersion.get}) must smaller than or equal to " +
+            s"endingVersion(${request.endingVersion.get})."
+        )
       }
     }
     val (version, actions) = deltaSharedTableLoader.loadTable(tableConfig).query(

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -326,7 +326,7 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       if (request.endingVersion.isDefined &&
         request.startingVersion.exists(_ > request.endingVersion.get)) {
         throw new DeltaSharingIllegalArgumentException(
-          s"startingVersion(${request.startingVersion.get}) must smaller than or equal to " +
+          s"startingVersion(${request.startingVersion.get}) must be smaller than or equal to " +
             s"endingVersion(${request.endingVersion.get})."
         )
       }

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaCDFErrors.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaCDFErrors.scala
@@ -38,6 +38,12 @@ object DeltaCDFErrors {
     )
   }
 
+  def endVersionAfterLatestVersion(end: Long, latest: Long): Throwable = {
+    new DeltaCDFIllegalArgumentException(s"Provided end version($end) is invalid. End version " +
+      s"cannot be greater than the latest version of the table($latest)."
+    )
+  }
+
   def endBeforeStartVersionInCDF(start: Long, end: Long): Throwable = {
     new DeltaCDFIllegalArgumentException(
       s"CDF range from start $start to end $end was invalid. End cannot be before start."

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -187,7 +187,9 @@ class DeltaSharedTable(
       limitHint: Option[Long],
       version: Option[Long],
       timestamp: Option[String],
-      startingVersion: Option[Long]): (Long, Seq[model.SingleAction]) = withClassLoader {
+      startingVersion: Option[Long],
+      endingVersion: Option[Long]
+  ): (Long, Seq[model.SingleAction]) = withClassLoader {
     // TODO Support `limitHint`
     if (Seq(version, timestamp, startingVersion).filter(_.isDefined).size >= 2) {
       throw new DeltaSharingIllegalArgumentException(
@@ -233,7 +235,7 @@ class DeltaSharedTable(
       if (startingVersion.isDefined) {
         // Only read changes up to snapshot.version, and ignore changes that are committed during
         // queryDataChangeSinceStartVersion.
-        queryDataChangeSinceStartVersion(startingVersion.get)
+        queryDataChangeSinceStartVersion(startingVersion.get, endingVersion)
       } else if (includeFiles) {
         val ts = if (isVersionQuery) {
           val timestampsByVersion = DeltaSharingHistoryManager.getTimestampsByVersion(
@@ -287,8 +289,11 @@ class DeltaSharedTable(
     snapshot.version -> actions
   }
 
-  private def queryDataChangeSinceStartVersion(startingVersion: Long): Seq[model.SingleAction] = {
-    val latestVersion = tableVersion
+  private def queryDataChangeSinceStartVersion(
+      startingVersion: Long,
+      endingVersion: Option[Long]
+  ): Seq[model.SingleAction] = {
+    val latestVersion = tableVersion.min(endingVersion.getOrElse(tableVersion))
     if (startingVersion > latestVersion) {
       throw DeltaCDFErrors.startVersionAfterLatestVersion(startingVersion, latestVersion)
     }
@@ -301,7 +306,8 @@ class DeltaSharedTable(
     )
 
     val actions = ListBuffer[model.SingleAction]()
-    deltaLog.getChanges(startingVersion, true).asScala.toSeq.foreach{versionLog =>
+    deltaLog.getChanges(startingVersion, true).asScala.toSeq
+      .takeWhile(_.getVersion <= latestVersion).foreach{ versionLog =>
       val v = versionLog.getVersion
       val versionActions = versionLog.getActions.asScala.map(x => ConversionUtils.convertActionJ(x))
       val ts = timestampsByVersion.get(v).orNull

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -307,7 +307,7 @@ class DeltaSharedTable(
 
     val actions = ListBuffer[model.SingleAction]()
     deltaLog.getChanges(startingVersion, true).asScala.toSeq
-      .takeWhile(_.getVersion <= latestVersion).foreach{ versionLog =>
+      .filter(_.getVersion <= latestVersion).foreach{ versionLog =>
       val v = versionLog.getVersion
       val versionActions = versionLog.getActions.asScala.map(x => ConversionUtils.convertActionJ(x))
       val ts = timestampsByVersion.get(v).orNull

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -300,10 +300,6 @@ class DeltaSharedTable(
     if (endingVersion.isDefined && endingVersion.get > latestVersion) {
       throw DeltaCDFErrors.endVersionAfterLatestVersion(endingVersion.get, latestVersion)
     }
-    if (endingVersion.isDefined && endingVersion.get < startingVersion) {
-      throw new IllegalArgumentException(s"startingVersion(${startingVersion.get}) must be " +
-        s"smaller than or equal to endingVersion(${endingVersion.get}).")
-    }
     latestVersion = latestVersion.min(endingVersion.getOrElse(latestVersion))
     val timestampsByVersion = DeltaSharingHistoryManager.getTimestampsByVersion(
       deltaLog.store,

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -928,6 +928,15 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       expectedErrorCode = 400,
       expectedErrorMessage = "startingVersion(3) must be smaller than or equal to endingVersion(2)"
     )
+    assertHttpError(
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/query"),
+      method = "POST",
+      data = Some("""
+        {"startingVersion": 2, "endingVersion": 10}
+      """),
+      expectedErrorCode = 400,
+      expectedErrorMessage = "End version cannot be greater than the latest version"
+    )
 
     // timestamp before the earliest version
     assertHttpError(

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -926,7 +926,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         {"startingVersion": 3, "endingVersion": 2}
       """),
       expectedErrorCode = 400,
-      expectedErrorMessage = "startingVersion(3) must smaller than or equal to endingVersion(2)"
+      expectedErrorMessage = "startingVersion(3) must be smaller than or equal to endingVersion(2)"
     )
 
     // timestamp before the earliest version

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -910,6 +910,24 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       expectedErrorCode = 400,
       expectedErrorMessage = "Not a numeric value: x3"
     )
+    assertHttpError(
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/query"),
+      method = "POST",
+      data = Some("""
+        {"startingVersion": "3", "endingVersion": "x3"}
+      """),
+      expectedErrorCode = 400,
+      expectedErrorMessage = "Not a numeric value: x3"
+    )
+    assertHttpError(
+      url = requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/query"),
+      method = "POST",
+      data = Some("""
+        {"startingVersion": 3, "endingVersion": 2}
+      """),
+      expectedErrorCode = 400,
+      expectedErrorMessage = "startingVersion(3) must smaller than or equal to endingVersion(2)"
+    )
 
     // timestamp before the earliest version
     assertHttpError(
@@ -943,11 +961,13 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
 
   integrationTest("cdf_table_cdf_enabled - timestamp on version 1 - /shares/{share}/schemas/{schema}/tables/{table}/query") {
     // 1651272635000, PST: 2022-04-29 15:50:35.0 -> version 1
+    // endingVersion is ignored
     val tsStr = new Timestamp(1651272635000L).toInstant.toString
     val p =
       s"""
          |{
-         | "timestamp": "$tsStr"
+         | "timestamp": "$tsStr",
+         | "endingVersion": 2
          |}
          |""".stripMargin
     val response = readNDJson(requestPath("/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/query"), Some("POST"), Some(p), Some(1))
@@ -1168,6 +1188,94 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(expectedMetadata == actions(2).metaData)
 
     assert(actions(3).add != null)
+  }
+
+  integrationTest("streaming_table_metadata_protocol - startingVersion with endingVersion success") {
+    val p =
+      s"""
+         |{
+         | "startingVersion": 0,
+         | "endingVersion": 2
+         |}
+         |""".stripMargin
+    val response = readNDJson(requestPath("/shares/share8/schemas/default/tables/streaming_table_metadata_protocol/query"), Some("POST"), Some(p), Some(0))
+    val actions = response.split("\n").map(JsonUtils.fromJson[SingleAction](_))
+    assert(actions.size == 4)
+
+    // version 0: CREATE TABLE, protocol/metadata
+    // version 1: INSERT
+    // version 2: ALTER TABLE, metadata
+    val expectedProtocol = Protocol(minReaderVersion = 1)
+    assert(expectedProtocol == actions(0).protocol)
+    var expectedMetadata = Metadata(
+      id = "eaca659e-28ac-4c68-8c72-0c96205c8160",
+      format = Format(),
+      schemaString = """{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}},{"name":"age","type":"integer","nullable":true,"metadata":{}},{"name":"birthday","type":"date","nullable":true,"metadata":{}}]}""",
+      partitionColumns = Nil,
+      version = 0)
+    assert(expectedMetadata == actions(1).metaData)
+
+    assert(actions(2).add != null)
+
+    // Check metadata for version 2.
+    expectedMetadata = expectedMetadata.copy(
+      configuration = Map("enableChangeDataFeed" -> "true"),
+      version = 2)
+    assert(expectedMetadata == actions(3).metaData)
+  }
+
+  integrationTest("streaming_table_metadata_protocol - startingVersion equal endingVersion success 1") {
+    val p =
+      s"""
+         |{
+         | "startingVersion": 1,
+         | "endingVersion": 1
+         |}
+         |""".stripMargin
+    val response = readNDJson(requestPath("/shares/share8/schemas/default/tables/streaming_table_metadata_protocol/query"), Some("POST"), Some(p), Some(1))
+    val actions = response.split("\n").map(JsonUtils.fromJson[SingleAction](_))
+    assert(actions.size == 3)
+
+    // version 2: ALTER TABLE, metadata
+    // Check metadata for version 2.
+    val expectedProtocol = Protocol(minReaderVersion = 1)
+    assert(expectedProtocol == actions(0).protocol)
+    var expectedMetadata = Metadata(
+      id = "eaca659e-28ac-4c68-8c72-0c96205c8160",
+      format = Format(),
+      schemaString = """{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}},{"name":"age","type":"integer","nullable":true,"metadata":{}},{"name":"birthday","type":"date","nullable":true,"metadata":{}}]}""",
+      partitionColumns = Nil,
+      version = 1)
+    assert(expectedMetadata == actions(1).metaData)
+
+    assert(actions(2).add != null)
+    assert(actions(2).add.version == 1)
+  }
+
+  integrationTest("streaming_table_metadata_protocol - startingVersion equal endingVersion success 2") {
+    val p =
+      s"""
+         |{
+         | "startingVersion": 2,
+         | "endingVersion": 2
+         |}
+         |""".stripMargin
+    val response = readNDJson(requestPath("/shares/share8/schemas/default/tables/streaming_table_metadata_protocol/query"), Some("POST"), Some(p), Some(2))
+    val actions = response.split("\n").map(JsonUtils.fromJson[SingleAction](_))
+    assert(actions.size == 2)
+
+    // version 2: ALTER TABLE, metadata
+    // Check metadata for version 2.
+    val expectedProtocol = Protocol(minReaderVersion = 1)
+    assert(expectedProtocol == actions(0).protocol)
+    var expectedMetadata = Metadata(
+      id = "eaca659e-28ac-4c68-8c72-0c96205c8160",
+      format = Format(),
+      schemaString = """{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}},{"name":"age","type":"integer","nullable":true,"metadata":{}},{"name":"birthday","type":"date","nullable":true,"metadata":{}}]}""",
+      partitionColumns = Nil,
+      configuration = Map("enableChangeDataFeed" -> "true"),
+      version = 2)
+    assert(expectedMetadata == actions(1).metaData)
   }
 
   integrationTest("streaming_notnull_to_null - no exceptions") {

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -58,7 +58,7 @@ private[sharing] trait DeltaSharingClient {
     timestampAsOf: Option[String],
     jsonPredicateHints: Option[String]): DeltaTableFiles
 
-  def getFiles(table: Table, startingVersion: Long): DeltaTableFiles
+  def getFiles(table: Table, startingVersion: Long, endingVersion: Option[Long]): DeltaTableFiles
 
   def getCDFFiles(
       table: Table,
@@ -80,6 +80,7 @@ private[sharing] case class QueryTableRequest(
   version: Option[Long],
   timestamp: Option[String],
   startingVersion: Option[Long],
+  endingVersion: Option[Long],
   jsonPredicateHints: Option[String]
 )
 
@@ -234,7 +235,15 @@ private[spark] class DeltaSharingRestClient(
       s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query")
     val (version, lines) = getNDJson(
       target,
-      QueryTableRequest(predicates, limit, versionAsOf, timestampAsOf, None, jsonPredicateHints)
+      QueryTableRequest(
+        predicates,
+        limit,
+        versionAsOf,
+        timestampAsOf,
+        None,
+        None,
+        jsonPredicateHints
+      )
     )
     require(versionAsOf.isEmpty || versionAsOf.get == version)
     val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
@@ -244,14 +253,18 @@ private[spark] class DeltaSharingRestClient(
     DeltaTableFiles(version, protocol, metadata, files)
   }
 
-  override def getFiles(table: Table, startingVersion: Long): DeltaTableFiles = {
+  override def getFiles(
+      table: Table,
+      startingVersion: Long,
+      endingVersion: Option[Long]
+  ): DeltaTableFiles = {
     val encodedShareName = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchemaName = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTableName = URLEncoder.encode(table.name, "UTF-8")
     val target = getTargetUrl(
       s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query")
     val (version, lines) = getNDJson(
-      target, QueryTableRequest(Nil, None, None, None, Some(startingVersion), None))
+      target, QueryTableRequest(Nil, None, None, None, Some(startingVersion), endingVersion, None))
     val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
     checkProtocol(protocol)
     val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
@@ -56,6 +56,13 @@ trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
     }
   }
 
+  val maxVersionsPerRpc: Option[Int] = options.get(MAX_VERSIONS_PER_RPC).map { str =>
+    Try(str.toInt).toOption.filter(_ > 0).getOrElse {
+      throw DeltaSharingErrors.illegalDeltaSharingOptionException(
+        MAX_VERSIONS_PER_RPC, str, "must be a positive integer")
+    }
+  }
+
   val ignoreChanges = options.get(IGNORE_CHANGES_OPTION).exists(toBoolean(_, IGNORE_CHANGES_OPTION))
 
   val ignoreDeletes = options.get(IGNORE_DELETES_OPTION).exists(toBoolean(_, IGNORE_DELETES_OPTION))
@@ -155,6 +162,10 @@ object DeltaSharingOptions extends Logging {
   val MAX_FILES_PER_TRIGGER_OPTION = "maxFilesPerTrigger"
   val MAX_FILES_PER_TRIGGER_OPTION_DEFAULT = 1000
   val MAX_BYTES_PER_TRIGGER_OPTION = "maxBytesPerTrigger"
+  // a delta sharing specific parameter, used to sepcify the max number of versions to query in
+  // one rpc in a streaming job.
+  val MAX_VERSIONS_PER_RPC = "maxVersionsPerRpc"
+  val MAX_VERSIONS_PER_RPC_DEFAULT = 100
   val IGNORE_CHANGES_OPTION = "ignoreChanges"
   val IGNORE_DELETES_OPTION = "ignoreDeletes"
   val SKIP_CHANGE_COMMITS_OPTION = "skipChangeCommits"

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -312,10 +312,22 @@ case class DeltaSharingSource(
       fromIndex: Long,
       currentLatestVersion: Long): Unit = {
     val tableFiles = deltaLog.client.getCDFFiles(
-      deltaLog.table, Map(DeltaSharingOptions.CDF_START_VERSION -> fromVersion.toString), true)
+      deltaLog.table,
+      Map(
+        DeltaSharingOptions.CDF_START_VERSION -> fromVersion.toString,
+        DeltaSharingOptions.CDF_END_VERSION -> lastQueriedTableVersion.toString
+      ),
+      true
+    )
     latestRefreshFunc = () => {
       val d = deltaLog.client.getCDFFiles(
-        deltaLog.table, Map(DeltaSharingOptions.CDF_START_VERSION -> fromVersion.toString), true)
+        deltaLog.table,
+        Map(
+          DeltaSharingOptions.CDF_START_VERSION -> fromVersion.toString,
+          DeltaSharingOptions.CDF_END_VERSION -> lastQueriedTableVersion.toString
+        ),
+        true
+      )
       DeltaSharingCDFReader.getIdToUrl(d.addFiles, d.cdfFiles, d.removeFiles)
     }
 

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -234,7 +234,8 @@ case class DeltaSharingSource(
    * @param isStartingVersion - If true, will load fromVersion as a table snapshot(including files
    *                            from previous versions). If false, will only load files since
    *                            fromVersion.
-   * @param endingVersionForQuery - The ending version used for the query.
+   * @param endingVersionForQuery - The ending version used for the query, always smaller than
+   *                                latestTableVersion.
    *                                This is used to insert an indexedFile for each version in the
    *                                sortedFetchedFiles, in order to ensure the offset move beyond
    *                                this version.
@@ -316,7 +317,8 @@ case class DeltaSharingSource(
    * @param fromVersion - a table version, initially would be the startingVersion or the latest
    *                      table version.
    * @param fromIndex - index of a file within the same version,
-   * @param endingVersionForQuery - The ending version used for the query.
+   * @param endingVersionForQuery - The ending version used for the query, always smaller than
+   *                                latestTableVersion.
    *                                This is used to insert an indexedFile for each version in the
    *                                sortedFetchedFiles, in order to ensure the offset move beyond
    *                                this version.

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -216,7 +216,7 @@ case class DeltaSharingSource(
     }
 
     val endingVersionForQuery = currentLatestVersion.min(fromVersion + maxVersionsPerRpc - 1)
-      s"$endingVersionForQuery")
+
     if (isStartingVersion || !options.readChangeFeed) {
       getTableFileChanges(fromVersion, fromIndex, isStartingVersion, endingVersionForQuery)
     } else {

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -215,6 +215,7 @@ case class DeltaSharingSource(
       return
     }
 
+    // using "fromVersion + maxVersionsPerRpc - 1" because the endingVersion is inclusive.
     val endingVersionForQuery = currentLatestVersion.min(fromVersion + maxVersionsPerRpc - 1)
 
     if (isStartingVersion || !options.readChangeFeed) {

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -268,9 +268,13 @@ case class DeltaSharingSource(
     } else {
       // If isStartingVersion is false, it means to fetch table changes since fromVersion, not
       // including files from previous versions.
-      val tableFiles = deltaLog.client.getFiles(deltaLog.table, fromVersion)
+      val tableFiles = deltaLog.client.getFiles(
+        deltaLog.table, fromVersion, Some(lastQueriedTableVersion)
+      )
       latestRefreshFunc = () => {
-        deltaLog.client.getFiles(deltaLog.table, fromVersion).addFiles.map { a =>
+        deltaLog.client.getFiles(
+          deltaLog.table, fromVersion, Some(lastQueriedTableVersion)
+        ).addFiles.map { a =>
           a.id -> a.url
         }.toMap
       }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingOptionsSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingOptionsSuite.scala
@@ -31,6 +31,7 @@ class DeltaSharingOptionsSuite extends SparkFunSuite {
     val options = new DeltaSharingOptions(Map.empty[String, String])
     assert(options.maxFilesPerTrigger.isEmpty)
     assert(options.maxBytesPerTrigger.isEmpty)
+    assert(options.maxVersionsPerRpc.isEmpty)
     assert(!options.ignoreChanges)
     assert(!options.ignoreDeletes)
     assert(!options.readChangeFeed)
@@ -42,6 +43,7 @@ class DeltaSharingOptionsSuite extends SparkFunSuite {
     var options = new DeltaSharingOptions(Map(
       "maxFilesPerTrigger" -> "11",
       "maxBytesPerTrigger" -> "12",
+      "maxVersionsPerRpc" -> "15",
       "ignoreChanges" -> "true",
       "ignoreDeletes" -> "true",
       "readChangeFeed" -> "true",
@@ -50,6 +52,7 @@ class DeltaSharingOptionsSuite extends SparkFunSuite {
     ))
     assert(options.maxFilesPerTrigger == Some(11))
     assert(options.maxBytesPerTrigger == Some(12))
+    assert(options.maxVersionsPerRpc == Some(15))
     assert(options.ignoreChanges)
     assert(options.ignoreDeletes)
     assert(options.readChangeFeed)
@@ -194,6 +197,12 @@ class DeltaSharingOptionsSuite extends SparkFunSuite {
     }.getMessage
     assert(errorMessage.contains("Invalid value '2mg' for option 'maxBytesPerTrigger', must be " +
       "a size configuration such as '10g'"))
+
+    errorMessage = intercept[IllegalArgumentException] {
+      new DeltaSharingOptions(Map("maxVersionsPerRpc" -> "-1"))
+    }.getMessage
+    assert(errorMessage.contains(
+      "Invalid value '-1' for option 'maxVersionsPerRpc', must be a positive integer"))
 
     // only one of options can be set
     errorMessage = intercept[IllegalArgumentException] {

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -294,7 +294,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
     try {
       val tableFiles = client.getFiles(
-        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"), 1L
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"), 1L, None
       )
       assert(tableFiles.version == 1)
       assert(tableFiles.addFiles.size == 4)
@@ -379,13 +379,127 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  integrationTest("getFiles with startingVersion - exception") {
+  integrationTest("getFiles with startingVersion/endingVersion - success 1") {
+    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
+    try {
+      val tableFiles = client.getFiles(
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"), 1L, Some(1L)
+      )
+      assert(tableFiles.version == 1)
+      assert(tableFiles.addFiles.size == 3)
+      val expectedAddFiles = Seq(
+        AddFileForCDF(
+          url = tableFiles.addFiles(0).url,
+          id = "60d0cf57f3e4367db154aa2c36152a1f",
+          partitionValues = Map.empty,
+          size = 1030,
+          stats = """{"numRecords":1,"minValues":{"name":"1","age":1,"birthday":"2020-01-01"},"maxValues":{"name":"1","age":1,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
+          version = 1,
+          timestamp = 1651272635000L
+        ),
+        AddFileForCDF(
+          url = tableFiles.addFiles(1).url,
+          id = "a6dc5694a4ebcc9a067b19c348526ad6",
+          partitionValues = Map.empty,
+          size = 1030,
+          stats = """{"numRecords":1,"minValues":{"name":"2","age":2,"birthday":"2020-01-01"},"maxValues":{"name":"2","age":2,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
+          version = 1,
+          timestamp = 1651272635000L
+        ),
+        AddFileForCDF(
+          url = tableFiles.addFiles(2).url,
+          id = "d7ed708546dd70fdff9191b3e3d6448b",
+          partitionValues = Map.empty,
+          size = 1030,
+          stats = """{"numRecords":1,"minValues":{"name":"3","age":3,"birthday":"2020-01-01"},"maxValues":{"name":"3","age":3,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
+          version = 1,
+          timestamp = 1651272635000L
+        )
+      )
+      assert(expectedAddFiles == tableFiles.addFiles.toList)
+    } finally {
+      client.close()
+    }
+  }
+
+  integrationTest("getFiles with startingVersion/endingVersion - success 2") {
+    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
+    try {
+      val tableFiles = client.getFiles(
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"), 2L, Some(3L)
+      )
+      assert(tableFiles.version == 2)
+      assert(tableFiles.addFiles.size == 1)
+      val expectedAddFiles = Seq(
+        AddFileForCDF(
+          url = tableFiles.addFiles(0).url,
+          id = "b875623be22c1fa1dfdeb0480fae6117",
+          partitionValues = Map.empty,
+          size = 1247,
+          stats = """{"numRecords":1,"minValues":{"name":"2","age":2,"birthday":"2020-02-02"},"maxValues":{"name":"2","age":2,"birthday":"2020-02-02"},"nullCount":{"name":0,"age":0,"birthday":0,"_change_type":1}}""",
+          version = 3,
+          timestamp = 1651272660000L
+        )
+      )
+      assert(expectedAddFiles == tableFiles.addFiles.toList)
+
+      assert(tableFiles.removeFiles.size == 2)
+      val expectedRemoveFiles = Seq(
+        RemoveFile(
+          url = tableFiles.removeFiles(0).url,
+          id = "d7ed708546dd70fdff9191b3e3d6448b",
+          partitionValues = Map.empty,
+          size = 1030,
+          version = 2,
+          timestamp = 1651272655000L
+        ),
+        RemoveFile(
+          url = tableFiles.removeFiles(1).url,
+          id = "a6dc5694a4ebcc9a067b19c348526ad6",
+          partitionValues = Map.empty,
+          size = 1030,
+          version = 3,
+          timestamp = 1651272660000L
+        )
+      )
+      assert(expectedRemoveFiles == tableFiles.removeFiles.toList)
+    } finally {
+      client.close()
+    }
+  }
+
+  integrationTest("getFiles with startingVersion/endingVersion - success 3") {
+    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
+    try {
+      val tableFiles = client.getFiles(
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"), 4L, Some(5L)
+      )
+      assert(tableFiles.version == 4)
+      assert(tableFiles.addFiles.size == 0)
+      assert(tableFiles.removeFiles.size == 0)
+
+      assert(tableFiles.additionalMetadatas.size == 1)
+      val v5Metadata = Metadata(
+        id = "16736144-3306-4577-807a-d3f899b77670",
+        format = Format(),
+        schemaString = """{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}},{"name":"age","type":"integer","nullable":true,"metadata":{}},{"name":"birthday","type":"date","nullable":true,"metadata":{}}]}""",
+        configuration = Map("enableChangeDataFeed" -> "true"),
+        partitionColumns = Nil,
+        version = 5)
+      assert(v5Metadata == tableFiles.additionalMetadatas(0))
+    } finally {
+      client.close()
+    }
+  }
+
+  integrationTest("getFiles with startingVersion/endingVersion - exception") {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
     try {
       var errorMessage = intercept[UnexpectedHttpStatus] {
         client.getFiles(
           Table(name = "table1", schema = "default", share = "share1"),
-          1
+          1,
+          None
         )
       }.getMessage
       assert(errorMessage.contains("Reading table by version or timestamp is not supported because change data feed is not enabled on table: share1.default.table1"))
@@ -393,10 +507,21 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       errorMessage = intercept[UnexpectedHttpStatus] {
         client.getFiles(
           Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
-          -1
+          -1,
+          None
         )
       }.getMessage
       assert(errorMessage.contains("startingVersion cannot be negative"))
+
+      errorMessage = intercept[UnexpectedHttpStatus] {
+        client.getFiles(
+          Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
+          2,
+          Some(1)
+        )
+      }.getMessage
+      assert(errorMessage.contains("startingVersion(2) must smaller than or equal to " +
+        "endingVersion(1)"))
     } finally {
       client.close()
     }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -520,7 +520,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
           Some(1)
         )
       }.getMessage
-      assert(errorMessage.contains("startingVersion(2) must smaller than or equal to " +
+      assert(errorMessage.contains("startingVersion(2) must be smaller than or equal to " +
         "endingVersion(1)"))
     } finally {
       client.close()

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceCDFSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceCDFSuite.scala
@@ -60,7 +60,6 @@ class DeltaSharingSourceCDFSuite extends QueryTest
   lazy val toNotNullTable = testProfileFile.getCanonicalPath +
     "#share8.default.streaming_cdf_null_to_notnull"
 
-  // allowed to query starting from version 1
   // VERSION 1: INSERT 2 rows, 1 add file
   // VERSION 2: INSERT 3 rows, 1 add file
   // VERSION 3: UPDATE 4 rows, 4 cdf files, 8 cdf rows
@@ -590,4 +589,94 @@ class DeltaSharingSourceCDFSuite extends QueryTest
       }
     }
   }
+
+  /**
+   * Test maxVersionsPerRpc
+   */
+  integrationTest("maxVersionsPerRpc - success") {
+    // VERSION 1: INSERT 2 rows, 1 add file
+    // VERSION 2: INSERT 3 rows, 1 add file
+    // VERSION 3: UPDATE 4 rows, 4 cdf files, 8 cdf rows
+    // VERSION 4: REMOVE 4 rows, 2 remove files
+    // maxVersionsPerRpc = 1
+    var processedRows = Seq(2, 3, 8, 4)
+    var query = withStreamReaderAtVersion()
+      .option("maxVersionsPerRpc", "1")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 2
+    processedRows = Seq(2, 11, 4)
+    query = withStreamReaderAtVersion()
+      .option("maxVersionsPerRpc", "2")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 3
+    processedRows = Seq(5, 12)
+    query = withStreamReaderAtVersion()
+      .option("maxVersionsPerRpc", "3")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 4
+    processedRows = Seq(13, 4)
+    query = withStreamReaderAtVersion()
+      .option("maxVersionsPerRpc", "4")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 5
+    processedRows = Seq(17)
+    query = withStreamReaderAtVersion()
+      .option("maxVersionsPerRpc", "5")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+  }
+
 }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -56,6 +56,12 @@ class DeltaSharingSourceSuite extends QueryTest
   lazy val partitionTablePath = testProfileFile.getCanonicalPath +
     "#share8.default.cdf_table_with_partition"
 
+  // VERSION 1: INSERT 2 rows, 1 add file
+  // VERSION 2: INSERT 3 rows, 1 add file
+  // VERSION 3: UPDATE 4 rows, 3 add files, 2 remove files, 5 rows
+  // VERSION 4: REMOVE 4 rows, 2 remove files
+  lazy val cdfTablePath = testProfileFile.getCanonicalPath + "#share8.default.streaming_cdf_table"
+
   lazy val toNullTable = testProfileFile.getCanonicalPath +
       "#share8.default.streaming_notnull_to_null"
   lazy val toNotNullTable = testProfileFile.getCanonicalPath +
@@ -470,6 +476,84 @@ class DeltaSharingSourceSuite extends QueryTest
       } finally {
         restartQuery.stop()
       }
+    }
+  }
+
+  /**
+   * Test maxVersionsPerRpc
+   */
+  integrationTest("maxVersionsPerRpc - success") {
+    // VERSION 1: INSERT 2 rows, 1 add file
+    // VERSION 2: INSERT 3 rows, 1 add file
+    // VERSION 3: UPDATE 4 rows, 4 cdf files, 4 new rows
+    // VERSION 4: REMOVE 4 rows, 2 remove files, no new rows
+
+    // maxVersionsPerRpc = 1
+    var processedRows = Seq(2, 3, 5)
+    var query = withStreamReaderAtVersion(path=cdfTablePath)
+      .option("maxVersionsPerRpc", "1")
+      .load()
+      .writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 2
+    processedRows = Seq(2, 8)
+    query = withStreamReaderAtVersion(path=cdfTablePath)
+      .option("maxVersionsPerRpc", "2")
+      .load()
+      .writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 3
+    processedRows = Seq(5, 5)
+    query = withStreamReaderAtVersion(path=cdfTablePath)
+      .option("maxVersionsPerRpc", "3")
+      .load()
+      .writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 4
+    processedRows = Seq(10)
+    query = withStreamReaderAtVersion(path=cdfTablePath)
+      .option("maxVersionsPerRpc", "4")
+      .load()
+      .writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
     }
   }
 

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -490,7 +490,7 @@ class DeltaSharingSourceSuite extends QueryTest
 
     // maxVersionsPerRpc = 1
     var processedRows = Seq(2, 3, 5)
-    var query = withStreamReaderAtVersion(path=cdfTablePath)
+    var query = withStreamReaderAtVersion(path = cdfTablePath)
       .option("maxVersionsPerRpc", "1")
       .load()
       .writeStream.format("console").start()
@@ -507,7 +507,7 @@ class DeltaSharingSourceSuite extends QueryTest
 
     // maxVersionsPerRpc = 2
     processedRows = Seq(2, 8)
-    query = withStreamReaderAtVersion(path=cdfTablePath)
+    query = withStreamReaderAtVersion(path = cdfTablePath)
       .option("maxVersionsPerRpc", "2")
       .load()
       .writeStream.format("console").start()
@@ -524,7 +524,7 @@ class DeltaSharingSourceSuite extends QueryTest
 
     // maxVersionsPerRpc = 3
     processedRows = Seq(5, 5)
-    query = withStreamReaderAtVersion(path=cdfTablePath)
+    query = withStreamReaderAtVersion(path = cdfTablePath)
       .option("maxVersionsPerRpc", "3")
       .load()
       .writeStream.format("console").start()
@@ -541,7 +541,7 @@ class DeltaSharingSourceSuite extends QueryTest
 
     // maxVersionsPerRpc = 4
     processedRows = Seq(10)
-    query = withStreamReaderAtVersion(path=cdfTablePath)
+    query = withStreamReaderAtVersion(path = cdfTablePath)
       .option("maxVersionsPerRpc", "4")
       .load()
       .writeStream.format("console").start()

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -86,7 +86,11 @@ class TestDeltaSharingClient(
     DeltaTableFiles(0, Protocol(0), metadata, addFiles)
   }
 
-  override def getFiles(table: Table, startingVersion: Long): DeltaTableFiles = {
+  override def getFiles(
+      table: Table,
+      startingVersion: Long,
+      endingVersion: Option[Long]
+  ): DeltaTableFiles = {
     // This is not used anywhere.
     DeltaTableFiles(0, Protocol(0), metadata, Nil, Nil, Nil, Nil)
   }


### PR DESCRIPTION
- Support endingVersion in queryTable RPC, this is to avoid fetching unneeded files from server upon refresh. 
- Support a new parameter: `maxVersionsPerRpc` for delta sharing streaming job.