### PR TITLE
Add an optional `expirationTimestamp` field for pre signed urls

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1939,7 +1939,7 @@ The request body should be a JSON string containing the following optional field
   - The combination of `statingVersion` and `endingVersion` can be used as query window for delta sharing streaming rpcs.
 
 When `predicateHints` and `limitHint` are both present, the server should apply `predicateHints` first then `limitHint`. As these two parameters are hints rather than enforcement, the client must always apply `predicateHints` and `limitHint` on the response returned by the server if it wishes to filter and limit the returned data. An empty JSON object (`{}`) should be provided when these two parameters are missing.
-    
+
 Example (See [API Response Format](#api-response-format) for more details about the format):
 
 `POST {prefix}/shares/vaccine_share/schemas/acme_vaccine_data/tables/vaccine_patients/query`

--- a/server/src/main/scala/io/delta/sharing/server/CloudFileSigner.scala
+++ b/server/src/main/scala/io/delta/sharing/server/CloudFileSigner.scala
@@ -40,6 +40,7 @@ import org.apache.hadoop.util.ReflectionUtils
 
 trait CloudFileSigner {
   def sign(path: Path): String
+  def getExpirationTimestamp: Long
 }
 
 class S3FileSigner(
@@ -61,6 +62,10 @@ class S3FileSigner(
       .withMethod(HttpMethod.GET)
       .withExpiration(expiration)
     s3Client.generatePresignedUrl(request).toString
+  }
+
+  override def getExpirationTimestamp: Long = {
+    System.currentTimeMillis() + SECONDS.toMillis(preSignedUrlTimeoutSeconds)
   }
 }
 
@@ -117,6 +122,10 @@ class AzureFileSigner(
     )
     val sasTokenCredentials = new StorageCredentialsSharedAccessSignature(sasToken)
     sasTokenCredentials.transformUri(blobRef.getUri).toString
+  }
+
+  override def getExpirationTimestamp: Long = {
+    System.currentTimeMillis() + SECONDS.toMillis(preSignedUrlTimeoutSeconds)
   }
 }
 
@@ -209,6 +218,10 @@ class GCSFileSigner(
     storage.signUrl(
       blobInfo, preSignedUrlTimeoutSeconds, SECONDS, Storage.SignUrlOption.withV4Signature())
       .toString
+  }
+
+  override def getExpirationTimestamp: Long = {
+    System.currentTimeMillis() + SECONDS.toMillis(preSignedUrlTimeoutSeconds)
   }
 }
 

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -78,6 +78,7 @@ case class AddFile(
     size: Long,
     @JsonRawValue
     stats: String = null,
+    expirationTimestamp: Long,
     timestamp: java.lang.Long = null,
     version: java.lang.Long = null) extends Action {
 
@@ -90,6 +91,7 @@ case class AddFileForCDF(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     partitionValues: Map[String, String],
     size: Long,
+    expirationTimestamp: Long,
     version: Long,
     timestamp: Long,
     @JsonRawValue
@@ -104,6 +106,7 @@ case class AddCDCFile(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     partitionValues: Map[String, String],
     size: Long,
+    expirationTimestamp: Long,
     timestamp: Long,
     version: Long)
     extends Action {
@@ -117,6 +120,7 @@ case class RemoveFile(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     partitionValues: Map[String, String],
     size: Long,
+    expirationTimestamp: Long,
     timestamp: Long,
     version: Long)
     extends Action {

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -78,7 +78,7 @@ case class AddFile(
     size: Long,
     @JsonRawValue
     stats: String = null,
-    expirationTimestamp: Long,
+    expirationTimestamp: java.lang.Long = null,
     timestamp: java.lang.Long = null,
     version: java.lang.Long = null) extends Action {
 
@@ -91,7 +91,7 @@ case class AddFileForCDF(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     partitionValues: Map[String, String],
     size: Long,
-    expirationTimestamp: Long,
+    expirationTimestamp: java.lang.Long = null,
     version: Long,
     timestamp: Long,
     @JsonRawValue
@@ -106,7 +106,7 @@ case class AddCDCFile(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     partitionValues: Map[String, String],
     size: Long,
-    expirationTimestamp: Long,
+    expirationTimestamp: java.lang.Long = null,
     timestamp: Long,
     version: Long)
     extends Action {
@@ -120,7 +120,7 @@ case class RemoveFile(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     partitionValues: Map[String, String],
     size: Long,
-    expirationTimestamp: Long,
+    expirationTimestamp: java.lang.Long = null,
     timestamp: Long,
     version: Long)
     extends Action {

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -269,7 +269,9 @@ class DeltaSharedTable(
         filteredFiles.map { addFile =>
           val cloudPath = absolutePath(deltaLog.dataPath, addFile.path)
           val signedUrl = fileSigner.sign(cloudPath)
-          val modelAddFile = model.AddFile(url = signedUrl,
+          val modelAddFile = model.AddFile(
+            url = signedUrl,
+            expirationTimestamp = fileSigner.getExpirationTimestamp,
             id = Hashing.md5().hashString(addFile.path, UTF_8).toString,
             partitionValues = addFile.partitionValues,
             size = addFile.size,
@@ -309,6 +311,7 @@ class DeltaSharedTable(
         case a: AddFile if a.dataChange =>
           val modelAddFile = model.AddFileForCDF(
             url = fileSigner.sign(absolutePath(deltaLog.dataPath, a.path)),
+            expirationTimestamp = fileSigner.getExpirationTimestamp,
             id = Hashing.md5().hashString(a.path, UTF_8).toString,
             partitionValues = a.partitionValues,
             size = a.size,
@@ -320,6 +323,7 @@ class DeltaSharedTable(
         case r: RemoveFile if r.dataChange =>
           val modelRemoveFile = model.RemoveFile(
             url = fileSigner.sign(absolutePath(deltaLog.dataPath, r.path)),
+            expirationTimestamp = fileSigner.getExpirationTimestamp,
             id = Hashing.md5().hashString(r.path, UTF_8).toString,
             partitionValues = r.partitionValues,
             size = r.size.get,
@@ -408,6 +412,7 @@ class DeltaSharedTable(
         val signedUrl = fileSigner.sign(cloudPath)
         val modelCDCFile = model.AddCDCFile(
           url = signedUrl,
+          expirationTimestamp = fileSigner.getExpirationTimestamp,
           id = Hashing.md5().hashString(addCDCFile.path, UTF_8).toString,
           partitionValues = addCDCFile.partitionValues,
           size = addCDCFile.size,
@@ -424,6 +429,7 @@ class DeltaSharedTable(
         val signedUrl = fileSigner.sign(cloudPath)
         val modelAddFile = model.AddFileForCDF(
           url = signedUrl,
+          expirationTimestamp = fileSigner.getExpirationTimestamp,
           id = Hashing.md5().hashString(addFile.path, UTF_8).toString,
           partitionValues = addFile.partitionValues,
           size = addFile.size,
@@ -441,6 +447,7 @@ class DeltaSharedTable(
         val signedUrl = fileSigner.sign(cloudPath)
         val modelRemoveFile = model.RemoveFile(
           url = signedUrl,
+          expirationTimestamp = fileSigner.getExpirationTimestamp,
           id = Hashing.md5().hashString(removeFile.path, UTF_8).toString,
           partitionValues = removeFile.partitionValues,
           size = removeFile.size.get,

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -266,18 +266,12 @@ class DeltaSharedTable(
           } else {
             filteredFiles
           }
-        var setUrlExpirationTimestamp: Boolean = false
         filteredFiles.map { addFile =>
           val cloudPath = absolutePath(deltaLog.dataPath, addFile.path)
           val signedUrl = fileSigner.sign(cloudPath)
           val modelAddFile = model.AddFile(
             url = signedUrl.url,
-            expirationTimestamp = if (!setUrlExpirationTimestamp) {
-              setUrlExpirationTimestamp = true
-              signedUrl.expirationTimestamp
-            } else {
-              null
-            },
+            expirationTimestamp = signedUrl.expirationTimestamp,
             id = Hashing.md5().hashString(addFile.path, UTF_8).toString,
             partitionValues = addFile.partitionValues,
             size = addFile.size,
@@ -309,7 +303,6 @@ class DeltaSharedTable(
     )
 
     val actions = ListBuffer[model.SingleAction]()
-    var setUrlExpirationTimestamp: Boolean = false
     deltaLog.getChanges(startingVersion, true).asScala.toSeq.foreach{versionLog =>
       val v = versionLog.getVersion
       val versionActions = versionLog.getActions.asScala.map(x => ConversionUtils.convertActionJ(x))
@@ -319,12 +312,7 @@ class DeltaSharedTable(
           val signedUrl = fileSigner.sign(absolutePath(deltaLog.dataPath, a.path))
           val modelAddFile = model.AddFileForCDF(
             url = signedUrl.url,
-            expirationTimestamp = if (!setUrlExpirationTimestamp) {
-              setUrlExpirationTimestamp = true
-              signedUrl.expirationTimestamp
-            } else {
-              null
-            },
+            expirationTimestamp = signedUrl.expirationTimestamp,
             id = Hashing.md5().hashString(a.path, UTF_8).toString,
             partitionValues = a.partitionValues,
             size = a.size,
@@ -337,12 +325,7 @@ class DeltaSharedTable(
           val signedUrl = fileSigner.sign(absolutePath(deltaLog.dataPath, r.path))
           val modelRemoveFile = model.RemoveFile(
             url = signedUrl.url,
-            expirationTimestamp = if (!setUrlExpirationTimestamp) {
-              setUrlExpirationTimestamp = true
-              signedUrl.expirationTimestamp
-            } else {
-              null
-            },
+            expirationTimestamp = signedUrl.expirationTimestamp,
             id = Hashing.md5().hashString(r.path, UTF_8).toString,
             partitionValues = r.partitionValues,
             size = r.size.get,
@@ -424,7 +407,6 @@ class DeltaSharedTable(
         actions.append(modelMetadata.wrap)
       }
     }
-    var setUrlExpirationTimestamp: Boolean = false
     changeFiles.foreach { cdcDataSpec =>
       cdcDataSpec.actions.foreach { action =>
         val addCDCFile = action.asInstanceOf[AddCDCFile]
@@ -432,12 +414,7 @@ class DeltaSharedTable(
         val signedUrl = fileSigner.sign(cloudPath)
         val modelCDCFile = model.AddCDCFile(
           url = signedUrl.url,
-          expirationTimestamp = if (!setUrlExpirationTimestamp) {
-            setUrlExpirationTimestamp = true
-            signedUrl.expirationTimestamp
-          } else {
-            null
-          },
+          expirationTimestamp = signedUrl.expirationTimestamp,
           id = Hashing.md5().hashString(addCDCFile.path, UTF_8).toString,
           partitionValues = addCDCFile.partitionValues,
           size = addCDCFile.size,
@@ -454,12 +431,7 @@ class DeltaSharedTable(
         val signedUrl = fileSigner.sign(cloudPath)
         val modelAddFile = model.AddFileForCDF(
           url = signedUrl.url,
-          expirationTimestamp = if (!setUrlExpirationTimestamp) {
-            setUrlExpirationTimestamp = true
-            signedUrl.expirationTimestamp
-          } else {
-            null
-          },
+          expirationTimestamp = signedUrl.expirationTimestamp,
           id = Hashing.md5().hashString(addFile.path, UTF_8).toString,
           partitionValues = addFile.partitionValues,
           size = addFile.size,
@@ -477,12 +449,7 @@ class DeltaSharedTable(
         val signedUrl = fileSigner.sign(cloudPath)
         val modelRemoveFile = model.RemoveFile(
           url = signedUrl.url,
-          expirationTimestamp = if (!setUrlExpirationTimestamp) {
-            setUrlExpirationTimestamp = true
-            signedUrl.expirationTimestamp
-          } else {
-            null
-          },
+          expirationTimestamp = signedUrl.expirationTimestamp,
           id = Hashing.md5().hashString(removeFile.path, UTF_8).toString,
           partitionValues = removeFile.partitionValues,
           size = removeFile.size.get,

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -1796,6 +1796,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       assert(expectedMetadata == JsonUtils.fromJson[SingleAction](metadata))
       val files = lines.drop(2)
       val actualFiles = files.map(f => JsonUtils.fromJson[SingleAction](f).file)
+      Console.println(s"----[linzhou]----url:${actualFiles(0).url}")
       assert(actualFiles.size == 1)
       val expectedFiles = Seq(
         AddFile(

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -542,7 +542,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         stats = """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T06:32:02.070Z","date":"2021-04-28"},"maxValues":{"eventTime":"2021-04-28T06:32:02.070Z","date":"2021-04-28"},"nullCount":{"eventTime":0,"date":0}}"""
       )
     )
-    assert(actualFiles.count(_.expirationTimestamp != null) == 1)
+    assert(actualFiles.count(_.expirationTimestamp != null) == 2)
     assert(expectedFiles == actualFiles.toList)
     verifyPreSignedUrl(actualFiles(0).url, 781)
     verifyPreSignedUrl(actualFiles(1).url, 781)
@@ -635,7 +635,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         stats = """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"maxValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"nullCount":{"eventTime":0}}"""
       )
     )
-    assert(actualFiles.count(_.expirationTimestamp != null) == 1)
+    assert(actualFiles.count(_.expirationTimestamp != null) == 2)
     assert(expectedFiles == actualFiles.toList)
     verifyPreSignedUrl(actualFiles(0).url, 573)
     verifyPreSignedUrl(actualFiles(1).url, 573)
@@ -756,7 +756,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         stats = """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:35:53.156Z"},"maxValues":{"eventTime":"2021-04-28T23:35:53.156Z"},"nullCount":{"eventTime":0}}"""
       )
     )
-    assert(actualFiles.count(_.expirationTimestamp != null) == 1)
+    assert(actualFiles.count(_.expirationTimestamp != null) == 3)
     assert(expectedFiles == actualFiles.toList)
     verifyPreSignedUrl(actualFiles(0).url, 778)
     verifyPreSignedUrl(actualFiles(1).url, 778)
@@ -845,7 +845,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         timestamp = 1651272635000L
       )
     )
-    assert(actualFiles.count(_.expirationTimestamp != null) == 1)
+    assert(actualFiles.count(_.expirationTimestamp != null) == 3)
     assert(expectedFiles == actualFiles.toList)
     verifyPreSignedUrl(actualFiles(0).url, 1030)
     verifyPreSignedUrl(actualFiles(1).url, 1030)
@@ -1012,7 +1012,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
         timestamp = 1651272635000L
       )
     )
-    assert(actualFiles.count(_.expirationTimestamp != null) == 1)
+    assert(actualFiles.count(_.expirationTimestamp != null) == 3)
     assert(expectedFiles == actualFiles.toList)
     verifyPreSignedUrl(actualFiles(0).url, 1030)
     verifyPreSignedUrl(actualFiles(1).url, 1030)
@@ -1042,7 +1042,6 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(expectedMetadata == JsonUtils.fromJson[SingleAction](metadata))
     val files = lines.drop(2)
     assert(files.size == 7)
-    assert(files.count(_.contains("expirationTimestamp")) == 1)
     // version 1: INSERT
     // version 2: INSERT
     // version 3: INSERT
@@ -1286,7 +1285,6 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(expectedMetadata == JsonUtils.fromJson[SingleAction](metadata))
     val files = lines.drop(2)
     assert(files.size == 5)
-    assert(files.count(_.contains("expirationTimestamp")) == 1)
     verifyAddCDCFile(
       files(0),
       size = 1301,
@@ -1360,7 +1358,6 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     val lines = response.split("\n")
     val files = lines.drop(2)
     assert(files.size == 6)
-    assert(files.count(_.contains("expirationTimestamp")) == 1)
     // In version 2, birthday is updated from 2020-01-01 to 2020-02-02 for one row, which result in
     // 2 cdc files below.
     verifyAddCDCFile(
@@ -1478,10 +1475,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(addFile.version == version)
     assert(addFile.timestamp == timestamp)
     verifyPreSignedUrl(addFile.url, size.toInt)
-    if (addFile.expirationTimestamp != null) {
-      val timeToExpiration = addFile.expirationTimestamp - System.currentTimeMillis()
-      assert(timeToExpiration < 60 * 60 * 1000 && timeToExpiration > 50 * 60 * 1000)
-    }
+    val timeToExpiration = addFile.expirationTimestamp - System.currentTimeMillis()
+    assert(timeToExpiration < 60 * 60 * 1000 && timeToExpiration > 50 * 60 * 1000)
   }
 
   private def verifyAddCDCFile(
@@ -1497,10 +1492,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(addCDCFile.version == version)
     assert(addCDCFile.timestamp == timestamp)
     verifyPreSignedUrl(addCDCFile.url, size.toInt)
-    if (addCDCFile.expirationTimestamp != null) {
-      val timeToExpiration = addCDCFile.expirationTimestamp - System.currentTimeMillis()
-      assert(timeToExpiration < 60 * 60 * 1000 && timeToExpiration > 50 * 60 * 1000)
-    }
+    val timeToExpiration = addCDCFile.expirationTimestamp - System.currentTimeMillis()
+    assert(timeToExpiration < 60 * 60 * 1000 && timeToExpiration > 50 * 60 * 1000)
   }
 
   private def verifyRemove(
@@ -1516,10 +1509,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(removeFile.version == version)
     assert(removeFile.timestamp == timestamp)
     verifyPreSignedUrl(removeFile.url, size.toInt)
-    if (removeFile.expirationTimestamp != null) {
-      val timeToExpiration = removeFile.expirationTimestamp - System.currentTimeMillis()
-      assert(timeToExpiration < 60 * 60 * 1000 && timeToExpiration > 50 * 60 * 1000)
-    }
+    val timeToExpiration = removeFile.expirationTimestamp - System.currentTimeMillis()
+    assert(timeToExpiration < 60 * 60 * 1000 && timeToExpiration > 50 * 60 * 1000)
   }
 
   integrationTest("table_data_loss_with_checkpoint - /shares/{share}/schemas/{schema}/tables/{table}/query") {

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -527,6 +527,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     val expectedFiles = Seq(
       AddFile(
         url = actualFiles(0).url,
+        expirationTimestamp = actualFiles(0).expirationTimestamp,
         id = "061cb3683a467066995f8cdaabd8667d",
         partitionValues = Map.empty,
         size = 781,
@@ -534,6 +535,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       ),
       AddFile(
         url = actualFiles(1).url,
+        expirationTimestamp = actualFiles(1).expirationTimestamp,
         id = "e268cbf70dbaa6143e7e9fa3e2d3b00e",
         partitionValues = Map.empty,
         size = 781,
@@ -617,6 +619,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     val expectedFiles = Seq(
       AddFile(
         url = actualFiles(0).url,
+        expirationTimestamp = actualFiles(0).expirationTimestamp,
         id = "9f1a49539c5cffe1ea7f9e055d5c003c",
         partitionValues = Map("date" -> "2021-04-28"),
         size = 573,
@@ -624,6 +627,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       ),
       AddFile(
         url = actualFiles(1).url,
+        expirationTimestamp = actualFiles(1).expirationTimestamp,
         id = "cd2209b32f5ed5305922dd50f5908a75",
         partitionValues = Map("date" -> "2021-04-28"),
         size = 573,
@@ -727,6 +731,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     val expectedFiles = Seq(
       AddFile(
         url = actualFiles(0).url,
+        expirationTimestamp = actualFiles(0).expirationTimestamp,
         id = "db213271abffec6fd6c7fc2aad9d4b3f",
         partitionValues = Map("date" -> "2021-04-28"),
         size = 778,
@@ -734,6 +739,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       ),
       AddFile(
         url = actualFiles(1).url,
+        expirationTimestamp = actualFiles(1).expirationTimestamp,
         id = "f1f8be229d8b18eb6d6a34255f2d7089",
         partitionValues = Map("date" -> "2021-04-28"),
         size = 778,
@@ -741,6 +747,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       ),
       AddFile(
         url = actualFiles(2).url,
+        expirationTimestamp = actualFiles(2).expirationTimestamp,
         id = "a892a55d770ee70b34ffb2ebf7dc2fd0",
         partitionValues = Map("date" -> "2021-04-28"),
         size = 573,
@@ -806,6 +813,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     val expectedFiles = Seq(
       AddFile(
         url = actualFiles(0).url,
+        expirationTimestamp = actualFiles(0).expirationTimestamp,
         id = "60d0cf57f3e4367db154aa2c36152a1f",
         partitionValues = Map.empty,
         size = 1030,
@@ -815,6 +823,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       ),
       AddFile(
         url = actualFiles(1).url,
+        expirationTimestamp = actualFiles(1).expirationTimestamp,
         id = "d7ed708546dd70fdff9191b3e3d6448b",
         partitionValues = Map.empty,
         size = 1030,
@@ -824,6 +833,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       ),
       AddFile(
         url = actualFiles(2).url,
+        expirationTimestamp = actualFiles(2).expirationTimestamp,
         id = "a6dc5694a4ebcc9a067b19c348526ad6",
         partitionValues = Map.empty,
         size = 1030,
@@ -966,9 +976,11 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     val files = lines.drop(2)
     val actualFiles = files.map(f => JsonUtils.fromJson[SingleAction](f).file)
     assert(actualFiles.size == 3)
+    Console.println(s"----[linzhou]----url:${actualFiles(0).url}")
     val expectedFiles = Seq(
       AddFile(
         url = actualFiles(0).url,
+        expirationTimestamp = actualFiles(0).expirationTimestamp,
         id = "60d0cf57f3e4367db154aa2c36152a1f",
         partitionValues = Map.empty,
         size = 1030,
@@ -978,6 +990,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       ),
       AddFile(
         url = actualFiles(1).url,
+        expirationTimestamp = actualFiles(1).expirationTimestamp,
         id = "d7ed708546dd70fdff9191b3e3d6448b",
         partitionValues = Map.empty,
         size = 1030,
@@ -987,6 +1000,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       ),
       AddFile(
         url = actualFiles(2).url,
+        expirationTimestamp = actualFiles(2).expirationTimestamp,
         id = "a6dc5694a4ebcc9a067b19c348526ad6",
         partitionValues = Map.empty,
         size = 1030,
@@ -1457,6 +1471,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(addFile.version == version)
     assert(addFile.timestamp == timestamp)
     verifyPreSignedUrl(addFile.url, size.toInt)
+    val timeToExpiration = addFile.expirationTimestamp - System.currentTimeMillis()
+    assert(timeToExpiration < 60 * 60 * 1000 && timeToExpiration > 50 * 60 * 1000)
   }
 
   private def verifyAddCDCFile(
@@ -1472,6 +1488,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(addCDCFile.version == version)
     assert(addCDCFile.timestamp == timestamp)
     verifyPreSignedUrl(addCDCFile.url, size.toInt)
+    val timeToExpiration = addCDCFile.expirationTimestamp - System.currentTimeMillis()
+    assert(timeToExpiration < 60 * 60 * 1000 && timeToExpiration > 50 * 60 * 1000)
   }
 
   private def verifyRemove(
@@ -1487,6 +1505,8 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(removeFile.version == version)
     assert(removeFile.timestamp == timestamp)
     verifyPreSignedUrl(removeFile.url, size.toInt)
+    val timeToExpiration = removeFile.expirationTimestamp - System.currentTimeMillis()
+    assert(timeToExpiration < 60 * 60 * 1000 && timeToExpiration > 50 * 60 * 1000)
   }
 
   integrationTest("table_data_loss_with_checkpoint - /shares/{share}/schemas/{schema}/tables/{table}/query") {
@@ -1796,11 +1816,11 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       assert(expectedMetadata == JsonUtils.fromJson[SingleAction](metadata))
       val files = lines.drop(2)
       val actualFiles = files.map(f => JsonUtils.fromJson[SingleAction](f).file)
-      Console.println(s"----[linzhou]----url:${actualFiles(0).url}")
       assert(actualFiles.size == 1)
       val expectedFiles = Seq(
         AddFile(
           url = actualFiles(0).url,
+          expirationTimestamp = actualFiles(0).expirationTimestamp,
           id = "84f5f9e4de01e99837f77bfc2b7215b0",
           partitionValues = Map("c2" -> "foo bar"),
           size = 568,
@@ -1832,6 +1852,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     val expectedFiles = Seq(
       AddFile(
         url = actualFiles(0).url,
+        expirationTimestamp = actualFiles(0).expirationTimestamp,
         id = "84f5f9e4de01e99837f77bfc2b7215b0",
         partitionValues = Map("c2" -> "foo bar"),
         size = 568,

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingProfileProvider.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingProfileProvider.scala
@@ -49,8 +49,8 @@ trait DeltaSharingProfileProvider {
 
   // Map[String, String] is the id to url map.
   // Long is the minimum url expiration time for all the urls.
-  def getCustomRefresher(refresher: () => (Map[String, String], Long)): () =>
-    (Map[String, String], Long) = {
+  def getCustomRefresher(refresher: () => (Map[String, String], Option[Long])): () =>
+    (Map[String, String], Option[Long]) = {
     refresher
   }
 }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingProfileProvider.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingProfileProvider.scala
@@ -47,7 +47,8 @@ trait DeltaSharingProfileProvider {
 
   def getCustomTablePath(tablePath: String): String = tablePath
 
-  def getCustomRefresher(refresher: () => Map[String, String]): () => Map[String, String] = {
+  def getCustomRefresher(refresher: () => (Map[String, String], Long)): () =>
+    (Map[String, String], Long) = {
     refresher
   }
 }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -297,6 +297,10 @@ case class DeltaSharingSource(
         s"size: ${newIdToUrl.size}).")
       lastQueryTableTimestamp = queryTimestamp
       minUrlExpirationTimestamp = newMinUrlExpiration
+      if (!CachedTableManager.INSTANCE.isValidUrlExpirationTime(minUrlExpirationTimestamp)) {
+        // reset to None to indicate that it's not a valid url expiration timestamp.
+        minUrlExpirationTimestamp = None
+      }
       var numUrlsRefreshed = 0
       sortedFetchedFiles = sortedFetchedFiles.map { indexedFile =>
         IndexedFile(

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -247,6 +247,11 @@ case class DeltaSharingSource(
     }
   }
 
+  // Validate the minimum url expiration timestamp, and set it to None if it's invalid.
+  // It's considered valid only when it gives enough time for the client to read data out of the
+  // pre-signed url. If not valid, we will use the spark config to decide the refresh schedule, and
+  // if the url expired before that, we'll leverage the driver log to debug why the expiration
+  // timestamp is invalid.
   private def validateMinUrlExpirationTimestamp(inputTimestamp: Option[Long] = None): Unit = {
     synchronized {
       if (inputTimestamp.isDefined) {

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
@@ -126,6 +126,7 @@ object DeltaSharingCDFReader {
       removeFiles.map(r => r.id -> r.url).toMap
   }
 
+  // Get the minimum url expiration time across all the cdf files returned from the server.
   def getMinUrlExpiration(
       addFiles: Seq[AddFileForCDF],
       cdfFiles: Seq[AddCDCFile],

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
@@ -134,7 +134,8 @@ object DeltaSharingCDFReader {
     var minUrlExpiration: Option[Long] = None
     addFiles.foreach { a =>
       if (a.expirationTimestamp != null) {
-        if (minUrlExpiration.isDefined && minUrlExpiration.get < a.expirationTimestamp) {
+        minUrlExpiration = if (
+          minUrlExpiration.isDefined && minUrlExpiration.get < a.expirationTimestamp) {
           minUrlExpiration
         } else {
           Some(a.expirationTimestamp)
@@ -143,7 +144,8 @@ object DeltaSharingCDFReader {
     }
     cdfFiles.foreach { c =>
       if (c.expirationTimestamp != null) {
-        if (minUrlExpiration.isDefined && minUrlExpiration.get < c.expirationTimestamp) {
+        minUrlExpiration = if (
+          minUrlExpiration.isDefined && minUrlExpiration.get < c.expirationTimestamp) {
           minUrlExpiration
         } else {
           Some(c.expirationTimestamp)
@@ -152,7 +154,8 @@ object DeltaSharingCDFReader {
     }
     removeFiles.foreach { r =>
       if (r.expirationTimestamp != null) {
-        if (minUrlExpiration.isDefined && minUrlExpiration.get < r.expirationTimestamp) {
+        minUrlExpiration = if (
+          minUrlExpiration.isDefined && minUrlExpiration.get < r.expirationTimestamp) {
           minUrlExpiration
         } else {
           Some(r.expirationTimestamp)

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -184,7 +184,8 @@ private[sharing] case class RemoteDeltaCDFAddFileIndex(
     // makePartitionDirectories and partitionSchema. So that partitionFilters can be correctly
     // applied.
     val updatedFiles = addFiles.map { a =>
-      AddFileForCDF(a.url, a.id, a.getPartitionValuesInDF, a.size, a.version, a.timestamp, a.stats)
+      AddFileForCDF(a.url, a.id, a.getPartitionValuesInDF, a.size, a.version, a.timestamp, a.stats,
+        a.expirationTimestamp)
     }
     val columnFilter = getColumnFilter(partitionFilters)
     val implicits = params.spark.implicits
@@ -208,7 +209,8 @@ private[sharing] case class RemoteDeltaCDCFileIndex(
     // makePartitionDirectories and partitionSchema. So that partitionFilters can be correctly
     // applied.
     val updatedFiles = cdfFiles.map { c =>
-      AddCDCFile(c.url, c.id, c.getPartitionValuesInDF, c.size, c.version, c.timestamp)
+      AddCDCFile(c.url, c.id, c.getPartitionValuesInDF, c.size, c.version, c.timestamp,
+        c.expirationTimestamp)
     }
     val columnFilter = getColumnFilter(partitionFilters)
     val implicits = params.spark.implicits
@@ -231,7 +233,8 @@ private[sharing] case class RemoteDeltaCDFRemoveFileIndex(
     // makePartitionDirectories and partitionSchema. So that partitionFilters can be correctly
     // applied.
     val updatedFiles = removeFiles.map { r =>
-      RemoveFile(r.url, r.id, r.getPartitionValuesInDF, r.size, r.version, r.timestamp)
+      RemoveFile(r.url, r.id, r.getPartitionValuesInDF, r.size, r.version, r.timestamp,
+        r.expirationTimestamp)
     }
     val columnFilter = getColumnFilter(partitionFilters)
     val implicits = params.spark.implicits

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -309,7 +309,8 @@ class RemoteSnapshot(
             var minUrlExpiration: Option[Long] = None
             val idToUrl = files.map { add =>
               if (add.expirationTimestamp != null) {
-                if (minUrlExpiration.isDefined && minUrlExpiration.get < add.expirationTimestamp) {
+                minUrlExpiration = if (minUrlExpiration.isDefined
+                  && minUrlExpiration.get < add.expirationTimestamp) {
                   minUrlExpiration
                 } else {
                   Some(add.expirationTimestamp)

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -320,7 +320,7 @@ class RemoteSnapshot(
             }.toMap
             (idToUrl, minUrlExpiration)
           },
-          if (minUrlExpirationTimestamp.isDefined) {
+          if (CachedTableManager.INSTANCE.isValidUrlExpirationTime(minUrlExpirationTimestamp)) {
             minUrlExpirationTimestamp.get
           } else {
             System.currentTimeMillis() + CachedTableManager.INSTANCE.preSignedUrlExpirationMs

--- a/spark/src/main/scala/io/delta/sharing/spark/model.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/model.scala
@@ -135,7 +135,8 @@ private[sharing] case class AddFile(
     @JsonRawValue
     stats: String = null,
     version: java.lang.Long = null,
-    timestamp: java.lang.Long = null) extends FileAction(url, id, partitionValues, size) {
+    timestamp: java.lang.Long = null,
+    expirationTimestamp: java.lang.Long = null) extends FileAction(url, id, partitionValues, size) {
 
   override def wrap: SingleAction = SingleAction(file = this)
 }
@@ -149,7 +150,8 @@ private[sharing] case class AddFileForCDF(
     version: Long,
     timestamp: Long,
     @JsonRawValue
-    stats: String = null) extends FileAction(url, id, partitionValues, size) {
+    stats: String = null,
+    expirationTimestamp: java.lang.Long = null) extends FileAction(url, id, partitionValues, size) {
 
   override def wrap: SingleAction = SingleAction(add = this)
 
@@ -170,7 +172,8 @@ private[sharing] case class AddCDCFile(
     override val partitionValues: Map[String, String],
     override val size: Long,
     version: Long,
-    timestamp: Long) extends FileAction(url, id, partitionValues, size) {
+    timestamp: Long,
+    expirationTimestamp: java.lang.Long = null) extends FileAction(url, id, partitionValues, size) {
 
   override def wrap: SingleAction = SingleAction(cdf = this)
 
@@ -190,7 +193,8 @@ private[sharing] case class RemoveFile(
     override val partitionValues: Map[String, String],
     override val size: Long,
     version: Long,
-    timestamp: Long) extends FileAction(url, id, partitionValues, size) {
+    timestamp: Long,
+    expirationTimestamp: java.lang.Long = null) extends FileAction(url, id, partitionValues, size) {
 
   override def wrap: SingleAction = SingleAction(remove = this)
 

--- a/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -69,9 +69,11 @@ class CachedTableManager(
     // It could also help the client from keeping refreshing endlessly.
     val isValid = expiration.isDefined && (
       expiration.get > (System.currentTimeMillis() + refreshThresholdMs))
-    if (!isValid) {
-      logWarning(s"Invalid url expiration timestamp(${expiration}), refreshThresholdMs: " +
-        s"$refreshThresholdMs, current: ${System.currentTimeMillis()}.")
+    if (!isValid && expiration.isDefined) {
+      val currentTs = System.currentTimeMillis()
+      logWarning(s"Invalid url expiration timestamp(${expiration}, " +
+        s"${new java.util.Date(expiration.get)}), refreshThresholdMs:$refreshThresholdMs, " +
+        s"current timestamp(${currentTs}, ${new java.util.Date(currentTs)}).")
     }
     isValid
   }

--- a/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -68,8 +68,6 @@ class CachedTableManager(
   }
 
   def getFomattedTS(ts: Long): String = {
-    // scalastyle:off println
-    Console.println(s"----[linzhou]----ts:$ts")
     new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(ts)
   }
 
@@ -79,10 +77,6 @@ class CachedTableManager(
     for (entry <- snapshot) {
       val tablePath = entry.getKey
       val cachedTable = entry.getValue
-      // scalastyle:off println
-      Console.println(s"----[linzhou]----check $tablePath at " +
-        s"${getFomattedTS(System.currentTimeMillis())}:" +
-        s"${cachedTable.expiration - System.currentTimeMillis()}")
       if (cachedTable.refs.forall(_.get == null)) {
         logInfo(s"Removing table $tablePath from the pre signed url cache as there are" +
           " no references pointed to it")
@@ -96,17 +90,11 @@ class CachedTableManager(
           s"${new java.util.Date(cachedTable.expiration)})")
         try {
           val (idToUrl, expiration) = cachedTable.refresher()
-          // scalastyle:off println
-          Console.println(s"----[linzhou]------refreshed, timeToExpier:" +
             s"${expiration - System.currentTimeMillis()}")
           val newTable = new CachedTable(
             if (isValidUrlExpirationTime(expiration)) {
-              Console.println(s"----[linzhou]------valid:" +
-                s"${expiration - System.currentTimeMillis()}")
               expiration
             } else {
-              Console.println(s"----[linzhou]------not-valid:" +
-                s"${expiration - System.currentTimeMillis()}")
               preSignedUrlExpirationMs + System.currentTimeMillis()
             },
             idToUrl,

--- a/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -90,10 +90,9 @@ class CachedTableManager(
           s"${new java.util.Date(cachedTable.expiration)})")
         try {
           val (idToUrl, expiration) = cachedTable.refresher()
-            s"${expiration - System.currentTimeMillis()}")
           val newTable = new CachedTable(
             if (isValidUrlExpirationTime(expiration)) {
-              expiration
+              expiration.min(preSignedUrlExpirationMs + System.currentTimeMillis())
             } else {
               preSignedUrlExpirationMs + System.currentTimeMillis()
             },

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -164,6 +164,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       val expectedFiles = Seq(
         AddFile(
           url = tableFiles.files(0).url,
+          expirationTimestamp = tableFiles.files(0).expirationTimestamp,
           id = "9f1a49539c5cffe1ea7f9e055d5c003c",
           partitionValues = Map("date" -> "2021-04-28"),
           size = 573,
@@ -171,6 +172,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         ),
         AddFile(
           url = tableFiles.files(1).url,
+          expirationTimestamp = tableFiles.files(1).expirationTimestamp,
           id = "cd2209b32f5ed5305922dd50f5908a75",
           partitionValues = Map("date" -> "2021-04-28"),
           size = 573,
@@ -178,6 +180,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         )
       )
       assert(expectedFiles == tableFiles.files.toList)
+      assert(tableFiles.files(0).expirationTimestamp > System.currentTimeMillis())
     } finally {
       client.close()
     }
@@ -198,6 +201,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       val expectedFiles = Seq(
         AddFile(
           url = tableFiles.files(0).url,
+          expirationTimestamp = tableFiles.files(0).expirationTimestamp,
           id = "60d0cf57f3e4367db154aa2c36152a1f",
           partitionValues = Map.empty,
           size = 1030,
@@ -207,6 +211,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         ),
         AddFile(
           url = tableFiles.files(1).url,
+          expirationTimestamp = tableFiles.files(1).expirationTimestamp,
           id = "d7ed708546dd70fdff9191b3e3d6448b",
           partitionValues = Map.empty,
           size = 1030,
@@ -216,6 +221,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         ),
         AddFile(
           url = tableFiles.files(2).url,
+          expirationTimestamp = tableFiles.files(2).expirationTimestamp,
           id = "a6dc5694a4ebcc9a067b19c348526ad6",
           partitionValues = Map.empty,
           size = 1030,
@@ -225,6 +231,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         )
       )
       assert(expectedFiles == tableFiles.files.toList)
+      assert(tableFiles.files(0).expirationTimestamp > System.currentTimeMillis())
     } finally {
       client.close()
     }
@@ -301,6 +308,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       val expectedAddFiles = Seq(
         AddFileForCDF(
           url = tableFiles.addFiles(0).url,
+          expirationTimestamp = tableFiles.addFiles(0).expirationTimestamp,
           id = "60d0cf57f3e4367db154aa2c36152a1f",
           partitionValues = Map.empty,
           size = 1030,
@@ -310,6 +318,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         ),
         AddFileForCDF(
           url = tableFiles.addFiles(1).url,
+          expirationTimestamp = tableFiles.addFiles(1).expirationTimestamp,
           id = "a6dc5694a4ebcc9a067b19c348526ad6",
           partitionValues = Map.empty,
           size = 1030,
@@ -319,6 +328,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         ),
         AddFileForCDF(
           url = tableFiles.addFiles(2).url,
+          expirationTimestamp = tableFiles.addFiles(2).expirationTimestamp,
           id = "d7ed708546dd70fdff9191b3e3d6448b",
           partitionValues = Map.empty,
           size = 1030,
@@ -328,6 +338,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         ),
         AddFileForCDF(
           url = tableFiles.addFiles(3).url,
+          expirationTimestamp = tableFiles.addFiles(3).expirationTimestamp,
           id = "b875623be22c1fa1dfdeb0480fae6117",
           partitionValues = Map.empty,
           size = 1247,
@@ -337,11 +348,13 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         )
       )
       assert(expectedAddFiles == tableFiles.addFiles.toList)
+      assert(tableFiles.addFiles(0).expirationTimestamp > System.currentTimeMillis())
 
       assert(tableFiles.removeFiles.size == 2)
       val expectedRemoveFiles = Seq(
         RemoveFile(
           url = tableFiles.removeFiles(0).url,
+          expirationTimestamp = tableFiles.removeFiles(0).expirationTimestamp,
           id = "d7ed708546dd70fdff9191b3e3d6448b",
           partitionValues = Map.empty,
           size = 1030,
@@ -350,6 +363,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         ),
         RemoveFile(
           url = tableFiles.removeFiles(1).url,
+          expirationTimestamp = tableFiles.removeFiles(1).expirationTimestamp,
           id = "a6dc5694a4ebcc9a067b19c348526ad6",
           partitionValues = Map.empty,
           size = 1030,
@@ -358,6 +372,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         )
       )
       assert(expectedRemoveFiles == tableFiles.removeFiles.toList)
+      assert(tableFiles.removeFiles(0).expirationTimestamp > System.currentTimeMillis())
 
       assert(tableFiles.additionalMetadatas.size == 2)
       val v4Metadata = Metadata(
@@ -425,6 +440,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       val expectedCdfFiles = Seq(
         AddCDCFile(
           url = tableFiles.cdfFiles(0).url,
+          expirationTimestamp = tableFiles.cdfFiles(0).expirationTimestamp,
           id = "6521ba910108d4b54d27beaa9fc2373f",
           partitionValues = Map.empty,
           size = 1301,
@@ -433,6 +449,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         ),
         AddCDCFile(
           url = tableFiles.cdfFiles(1).url,
+          expirationTimestamp = tableFiles.cdfFiles(1).expirationTimestamp,
           id = "2508998dce55bd726369e53761c4bc3f",
           partitionValues = Map.empty,
           size = 1416,
@@ -441,10 +458,13 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         )
       )
       assert(expectedCdfFiles == tableFiles.cdfFiles.toList)
+      assert(tableFiles.cdfFiles(1).expirationTimestamp > System.currentTimeMillis())
+
       assert(tableFiles.addFiles.size == 3)
       val expectedAddFiles = Seq(
         AddFileForCDF(
           url = tableFiles.addFiles(0).url,
+          expirationTimestamp = tableFiles.addFiles(0).expirationTimestamp,
           id = "60d0cf57f3e4367db154aa2c36152a1f",
           partitionValues = Map.empty,
           size = 1030,
@@ -454,6 +474,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         ),
         AddFileForCDF(
           url = tableFiles.addFiles(1).url,
+          expirationTimestamp = tableFiles.addFiles(1).expirationTimestamp,
           id = "a6dc5694a4ebcc9a067b19c348526ad6",
           partitionValues = Map.empty,
           size = 1030,
@@ -463,6 +484,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         ),
         AddFileForCDF(
           url = tableFiles.addFiles(2).url,
+          expirationTimestamp = tableFiles.addFiles(2).expirationTimestamp,
           id = "d7ed708546dd70fdff9191b3e3d6448b",
           partitionValues = Map.empty,
           size = 1030,
@@ -472,6 +494,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         )
       )
       assert(expectedAddFiles == tableFiles.addFiles.toList)
+      assert(tableFiles.addFiles(0).expirationTimestamp > System.currentTimeMillis())
     } finally {
       client.close()
     }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -405,6 +405,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       val expectedAddFiles = Seq(
         AddFileForCDF(
           url = tableFiles.addFiles(0).url,
+          expirationTimestamp = tableFiles.addFiles(0).expirationTimestamp,
           id = "60d0cf57f3e4367db154aa2c36152a1f",
           partitionValues = Map.empty,
           size = 1030,
@@ -414,6 +415,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         ),
         AddFileForCDF(
           url = tableFiles.addFiles(1).url,
+          expirationTimestamp = tableFiles.addFiles(1).expirationTimestamp,
           id = "a6dc5694a4ebcc9a067b19c348526ad6",
           partitionValues = Map.empty,
           size = 1030,
@@ -423,6 +425,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         ),
         AddFileForCDF(
           url = tableFiles.addFiles(2).url,
+          expirationTimestamp = tableFiles.addFiles(2).expirationTimestamp,
           id = "d7ed708546dd70fdff9191b3e3d6448b",
           partitionValues = Map.empty,
           size = 1030,
@@ -448,6 +451,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       val expectedAddFiles = Seq(
         AddFileForCDF(
           url = tableFiles.addFiles(0).url,
+          expirationTimestamp = tableFiles.addFiles(0).expirationTimestamp,
           id = "b875623be22c1fa1dfdeb0480fae6117",
           partitionValues = Map.empty,
           size = 1247,
@@ -462,6 +466,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       val expectedRemoveFiles = Seq(
         RemoveFile(
           url = tableFiles.removeFiles(0).url,
+          expirationTimestamp = tableFiles.removeFiles(0).expirationTimestamp,
           id = "d7ed708546dd70fdff9191b3e3d6448b",
           partitionValues = Map.empty,
           size = 1030,
@@ -470,6 +475,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         ),
         RemoveFile(
           url = tableFiles.removeFiles(1).url,
+          expirationTimestamp = tableFiles.removeFiles(1).expirationTimestamp,
           id = "a6dc5694a4ebcc9a067b19c348526ad6",
           partitionValues = Map.empty,
           size = 1030,

--- a/spark/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
@@ -42,7 +42,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(ref)),
         provider,
         () => {
-          Map("id1" -> "url1", "id2" -> "url2")
+          (Map("id1" -> "url1", "id2" -> "url2"), -1L)
         })
       assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path"),
         "id1")._1 == "url1")
@@ -55,7 +55,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(ref)),
         provider,
         () => {
-          Map("id1" -> "url3", "id2" -> "url4")
+          (Map("id1" -> "url3", "id2" -> "url4"), -1L)
         })
       // We should get the new urls eventually
       eventually(timeout(10.seconds)) {
@@ -71,7 +71,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(new AnyRef)),
         provider,
         () => {
-          Map("id1" -> "url3", "id2" -> "url4")
+          (Map("id1" -> "url3", "id2" -> "url4"), -1L)
         })
       // We should remove the cached table eventually
       eventually(timeout(10.seconds)) {
@@ -88,7 +88,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(ref)),
         provider,
         () => {
-          Map("id1" -> "url3", "id2" -> "url4")
+          (Map("id1" -> "url3", "id2" -> "url4"), -1L)
         },
         -1
       )
@@ -119,7 +119,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(ref)),
         provider,
         () => {
-          Map("id1" -> "url1", "id2" -> "url2")
+          (Map("id1" -> "url1", "id2" -> "url2"), -1L)
         })
       Thread.sleep(1000)
       // We should remove the cached table when it's not accessed

--- a/spark/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
@@ -42,7 +42,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(ref)),
         provider,
         () => {
-          (Map("id1" -> "url1", "id2" -> "url2"), -1L)
+          (Map("id1" -> "url1", "id2" -> "url2"), None)
         })
       assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path"),
         "id1")._1 == "url1")
@@ -55,7 +55,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(ref)),
         provider,
         () => {
-          (Map("id1" -> "url3", "id2" -> "url4"), -1L)
+          (Map("id1" -> "url3", "id2" -> "url4"), None)
         })
       // We should get the new urls eventually
       eventually(timeout(10.seconds)) {
@@ -71,7 +71,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(new AnyRef)),
         provider,
         () => {
-          (Map("id1" -> "url3", "id2" -> "url4"), -1L)
+          (Map("id1" -> "url3", "id2" -> "url4"), None)
         })
       // We should remove the cached table eventually
       eventually(timeout(10.seconds)) {
@@ -88,7 +88,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(ref)),
         provider,
         () => {
-          (Map("id1" -> "url3", "id2" -> "url4"), -1L)
+          (Map("id1" -> "url3", "id2" -> "url4"), None)
         },
         -1
       )
@@ -104,7 +104,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
 
   test("refresh based on url expiration") {
     val manager = new CachedTableManager(
-      preSignedUrlExpirationMs = 4000,
+      preSignedUrlExpirationMs = 6000,
       refreshCheckIntervalMs = 1000,
       refreshThresholdMs = 1000,
       expireAfterAccessMs = 60000
@@ -122,17 +122,69 @@ class CachedTableManagerSuite extends SparkFunSuite {
           refreshTime += 1
           (
             Map("id1" -> ("url" + refreshTime.toString), "id2" -> "url4"),
-            System.currentTimeMillis() + 1900
+            Some(System.currentTimeMillis() + 1900)
           )
         },
         System.currentTimeMillis() + 1900
       )
-      // We should refresh 5 times within 10 seconds based on (System.currentTimeMillis() + 1900).
+      // We should refresh at least 5 times within 10 seconds based on
+      // (System.currentTimeMillis() + 1900).
       eventually(timeout(10.seconds)) {
         assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path"),
           "id1")._1 == "url5")
         assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path"),
           "id2")._1 == "url4")
+      }
+
+      var refreshTime2 = 0
+      manager.register(
+        "test-table-path2",
+        Map("id1" -> "url1", "id2" -> "url2"),
+        Seq(new WeakReference(ref)),
+        provider,
+        () => {
+          refreshTime2 += 1
+          (
+            Map("id1" -> ("url" + refreshTime2.toString), "id2" -> "url4"),
+            Some(System.currentTimeMillis() + 4900)
+          )
+        },
+        System.currentTimeMillis() + 4900
+      )
+      // We should refresh 2 times within 10 seconds based on (System.currentTimeMillis() + 4900).
+      eventually(timeout(10.seconds)) {
+        assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path2"),
+          "id1")._1 == "url2")
+        assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path2"),
+          "id2")._1 == "url4")
+      }
+
+      var refreshTime3 = 0
+      manager.register(
+        "test-table-path3",
+        Map("id1" -> "url1", "id2" -> "url2"),
+        Seq(new WeakReference(ref)),
+        provider,
+        () => {
+          refreshTime3 += 1
+          (
+            Map("id1" -> ("url" + refreshTime3.toString), "id2" -> "url4"),
+            Some(System.currentTimeMillis() - 4900)
+          )
+        },
+        System.currentTimeMillis() + 6000
+      )
+      // We should refresh 1 times within 10 seconds based on (preSignedUrlExpirationMs = 6000).
+      try {
+        eventually(timeout(10.seconds)) {
+          assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path3"),
+            "id1")._1 == "url2")
+          assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path3"),
+            "id2")._1 == "url4")
+        }
+      } catch {
+        case e: Throwable =>
+          assert(e.getMessage.contains("did not equal"))
       }
     } finally {
       manager.stop()
@@ -156,7 +208,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(ref)),
         provider,
         () => {
-          (Map("id1" -> "url1", "id2" -> "url2"), -1L)
+          (Map("id1" -> "url1", "id2" -> "url2"), None)
         })
       Thread.sleep(1000)
       // We should remove the cached table when it's not accessed


### PR DESCRIPTION
- In delta sharing sever, add expirationTimestamp for each action in the response
- In delta sharing client, update refresh function to return the min expiration timestamp across all urls.
- In delta sharing client, refresh based on the expiration timestamp
- In DeltaSharingSource, updated the refresh function to refresh the `sortedFetchedFiles`, so it doesn't have to do an extra local refresh -- delegate the refresh to CachedTableManager entirely.