### PR TITLE
Add maxRetryDuration in the retry logic in spark client; consolidate configs; add unit tests

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -97,6 +97,7 @@ private[spark] class DeltaSharingRestClient(
     profileProvider: DeltaSharingProfileProvider,
     timeoutInSeconds: Int = 120,
     numRetries: Int = 10,
+    maxRetryDuration: Long = Long.MaxValue,
     sslTrustAll: Boolean = false,
     forStreaming: Boolean = false) extends DeltaSharingClient {
 
@@ -424,7 +425,7 @@ private[spark] class DeltaSharingRestClient(
       allowNoContent: Boolean = false,
       fetchAsOneString: Boolean = false
   ): (Option[Long], Seq[String]) = {
-    RetryUtils.runWithExponentialBackoff(numRetries) {
+    RetryUtils.runWithExponentialBackoff(numRetries, maxRetryDuration) {
       val profile = profileProvider.getProfile
       val response = client.execute(
         getHttpHost(profile.endpoint),

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingFileSystem.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingFileSystem.scala
@@ -29,40 +29,19 @@ import org.apache.spark.delta.sharing.{PreSignedUrlCache, PreSignedUrlFetcher}
 import org.apache.spark.network.util.JavaUtils
 
 import io.delta.sharing.spark.model.FileAction
+import io.delta.sharing.spark.util.{ConfUtils, RetryUtils}
 
 /** Read-only file system for delta paths. */
 private[sharing] class DeltaSharingFileSystem extends FileSystem {
   import DeltaSharingFileSystem._
 
-  lazy private val numRetries = {
-    val numRetries = getConf.getInt("spark.delta.sharing.network.numRetries", 10)
-    if (numRetries < 0) {
-      throw new IllegalArgumentException(
-        "spark.delta.sharing.network.numRetries must not be negative")
-    }
-    numRetries
-  }
-
-  lazy private val timeoutInSeconds = {
-    val timeoutStr = getConf.get("spark.delta.sharing.network.timeout", "320s")
-    val timeoutInSeconds = JavaUtils.timeStringAs(timeoutStr, TimeUnit.SECONDS)
-    if (timeoutInSeconds < 0) {
-      throw new IllegalArgumentException(
-        "spark.delta.sharing.network.timeout must not be negative")
-    }
-    if (timeoutInSeconds > Int.MaxValue) {
-      throw new IllegalArgumentException(
-        s"spark.delta.sharing.network.timeout is too big: $timeoutStr")
-    }
-    timeoutInSeconds.toInt
-  }
+  lazy private val numRetries = ConfUtils.numRetries(getConf)
+  lazy private val maxRetryDurationMillis = ConfUtils.maxRetryDurationMillis(getConf)
+  lazy private val timeoutInSeconds = ConfUtils.timeoutInSeconds(getConf)
 
   lazy private val httpClient = {
-    val maxConnections = getConf.getInt("spark.delta.sharing.network.maxConnections", 64)
-    if (maxConnections < 0) {
-      throw new IllegalArgumentException(
-        "spark.delta.sharing.network.maxConnections must not be negative")
-    }
+    val c = getConf()
+    val maxConnections = ConfUtils.maxConnections(getConf)
     val config = RequestConfig.custom()
       .setConnectTimeout(timeoutInSeconds * 1000)
       .setConnectionRequestTimeout(timeoutInSeconds * 1000)
@@ -97,7 +76,15 @@ private[sharing] class DeltaSharingFileSystem extends FileSystem {
       new FSDataInputStream(new InMemoryHttpInputStream(new URI(fetcher.getUrl())))
     } else {
       new FSDataInputStream(
-        new RandomAccessHttpInputStream(httpClient, fetcher, path.fileSize, statistics, numRetries))
+        new RandomAccessHttpInputStream(
+          httpClient,
+          fetcher,
+          path.fileSize,
+          statistics,
+          numRetries,
+          maxRetryDurationMillis
+        )
+      )
     }
   }
 

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingFileSystem.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingFileSystem.scala
@@ -40,7 +40,6 @@ private[sharing] class DeltaSharingFileSystem extends FileSystem {
   lazy private val timeoutInSeconds = ConfUtils.timeoutInSeconds(getConf)
 
   lazy private val httpClient = {
-    val c = getConf()
     val maxConnections = ConfUtils.maxConnections(getConf)
     val config = RequestConfig.custom()
       .setConnectTimeout(timeoutInSeconds * 1000)

--- a/spark/src/main/scala/io/delta/sharing/spark/RandomAccessHttpInputStream.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RandomAccessHttpInputStream.scala
@@ -62,7 +62,8 @@ private[sharing] class RandomAccessHttpInputStream(
     fetcher: PreSignedUrlFetcher,
     contentLength: Long,
     stats: FileSystem.Statistics,
-    numRetries: Int) extends FSInputStream with Logging {
+    numRetries: Int,
+    maxRetryDuration: Long = Long.MaxValue) extends FSInputStream with Logging {
 
   private var closed = false
   private var pos = 0L
@@ -146,7 +147,7 @@ private[sharing] class RandomAccessHttpInputStream(
     } else {
       logDebug(s"Opening file $uri at pos $pos")
 
-     val entity = RetryUtils.runWithExponentialBackoff(numRetries) {
+     val entity = RetryUtils.runWithExponentialBackoff(numRetries, maxRetryDuration) {
         val httpRequest = createHttpRequest(pos)
         val response = client.execute(httpRequest)
         val status = response.getStatusLine()

--- a/spark/src/main/scala/io/delta/sharing/spark/util/ConfUtils.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/util/ConfUtils.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark.util
+
+import java.util.concurrent.TimeUnit
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.network.util.JavaUtils
+import org.apache.spark.sql.internal.SQLConf
+
+object ConfUtils {
+
+  val NUM_RETRIES_CONF = "spark.delta.sharing.network.numRetries"
+  val NUM_RETRIES_DEFAULT = 10
+
+  val MAX_RETRY_DURATION_CONF = "spark.delta.sharing.network.maxRetryDuration"
+  val MAX_RETRY_DURATION_DEFAULT_MILLIS = 10L * 60L* 1000L /* 10 mins */
+
+  val TIMEOUT_CONF = "spark.delta.sharing.network.timeout"
+  val TIMEOUT_DEFAULT = "320s"
+
+  val MAX_CONNECTION_CONF = "spark.delta.sharing.network.maxConnections"
+  val MAX_CONNECTION_DEFAULT = 64
+
+  def numRetries(conf: Configuration): Int = {
+    val numRetries = conf.getInt(NUM_RETRIES_CONF, NUM_RETRIES_DEFAULT)
+    validateNonNeg(numRetries, NUM_RETRIES_CONF)
+    numRetries
+  }
+
+  def numRetries(conf: SQLConf): Int = {
+    val numRetries = conf.getConfString(NUM_RETRIES_CONF, NUM_RETRIES_DEFAULT.toString).toInt
+    validateNonNeg(numRetries, NUM_RETRIES_CONF)
+    numRetries
+  }
+
+  def maxRetryDurationMillis(conf: Configuration): Long = {
+    val maxDur = conf.getLong(MAX_RETRY_DURATION_CONF, MAX_RETRY_DURATION_DEFAULT_MILLIS)
+    validateNonNeg(maxDur, MAX_RETRY_DURATION_CONF)
+    maxDur
+  }
+
+  def maxRetryDurationMillis(conf: SQLConf): Long = {
+    val maxDur =
+      conf.getConfString(MAX_RETRY_DURATION_CONF, MAX_RETRY_DURATION_DEFAULT_MILLIS.toString).toLong
+    validateNonNeg(maxDur, MAX_RETRY_DURATION_CONF)
+    maxDur
+  }
+
+  def timeoutInSeconds(conf: Configuration): Int = {
+    val timeoutStr = conf.get(TIMEOUT_CONF, TIMEOUT_DEFAULT)
+    toTimeout(timeoutStr)
+  }
+
+  def timeoutInSeconds(conf: SQLConf): Int = {
+    val timeoutStr = conf.getConfString(TIMEOUT_CONF, TIMEOUT_DEFAULT)
+    toTimeout(timeoutStr)
+  }
+
+  def maxConnections(conf: Configuration): Int = {
+    val maxConn = conf.getInt(MAX_CONNECTION_CONF, MAX_CONNECTION_DEFAULT)
+    validateNonNeg(maxConn, MAX_CONNECTION_CONF)
+    maxConn
+  }
+
+  private def toTimeout(timeoutStr: String): Int = {
+    val timeoutInSeconds = JavaUtils.timeStringAs(timeoutStr, TimeUnit.SECONDS)
+    validateNonNeg(timeoutInSeconds, TIMEOUT_CONF)
+    if (timeoutInSeconds > Int.MaxValue) {
+      throw new IllegalArgumentException(TIMEOUT_CONF + " is too big: " +  timeoutStr)
+    }
+    timeoutInSeconds.toInt
+  }
+
+
+  private def validateNonNeg(value: Long, conf: String): Unit = {
+    if (value < 0L) {
+      throw new IllegalArgumentException(conf + " must not be negative")
+    }
+  }
+}

--- a/spark/src/main/scala/io/delta/sharing/spark/util/RetryUtils.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/util/RetryUtils.scala
@@ -27,18 +27,34 @@ private[sharing] object RetryUtils extends Logging {
   // Expose it for testing
   @volatile var sleeper: Long => Unit = (sleepMs: Long) => Thread.sleep(sleepMs)
 
-  def runWithExponentialBackoff[T](numRetries: Int)(func: => T): T = {
+  def runWithExponentialBackoff[T](
+      numRetries: Int,
+      maxDurationMillis: Long = Long.MaxValue)(func: => T): T = {
     var times = 0
     var sleepMs = 100
+    val startTime = System.currentTimeMillis()
     while (true) {
       times += 1
+      val retryStartTime = System.currentTimeMillis()
       try {
         return func
       } catch {
-        case NonFatal(e) if shouldRetry(e) && times <= numRetries =>
-          logWarning(s"Sleeping $sleepMs ms to retry because of error: ${e.getMessage}", e)
-          sleeper(sleepMs)
-          sleepMs *= 2
+        case e: Exception =>
+          val totalDuration = System.currentTimeMillis() - startTime
+          val retryDuration = System.currentTimeMillis() - retryStartTime
+          logError(
+            "Error during retry attempt " + times + ", retryDuration=" + retryDuration +
+            ", totalDuration=" + totalDuration + " : " + e.getMessage,
+            e
+          )
+          if (shouldRetry(e) && times <= numRetries && totalDuration <= maxDurationMillis) {
+            logWarning(s"Sleeping $sleepMs ms to retry")
+            sleeper(sleepMs)
+            sleepMs *= 2
+          } else {
+            logWarning(s"Not retrying delta sharing rpc")
+            throw e
+          }
       }
     }
     throw new IllegalStateException("Should not happen")
@@ -54,6 +70,7 @@ private[sharing] object RetryUtils extends Logging {
         } else {
           false
         }
+      case _: java.net.SocketTimeoutException => true
       case _: InterruptedException => false
       case _: InterruptedIOException => false
       case _: IOException => true

--- a/spark/src/main/scala/io/delta/sharing/spark/util/RetryUtils.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/util/RetryUtils.scala
@@ -52,7 +52,7 @@ private[sharing] object RetryUtils extends Logging {
             sleeper(sleepMs)
             sleepMs *= 2
           } else {
-            logWarning(s"Not retrying delta sharing rpc")
+            logError(s"Not retrying delta sharing rpc on error: ${e.getMessage}", e)
             throw e
           }
       }

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -34,6 +34,7 @@ class TestDeltaSharingClient(
     profileProvider: DeltaSharingProfileProvider = new TestDeltaSharingProfileProvider,
     timeoutInSeconds: Int = 120,
     numRetries: Int = 10,
+    maxRetryDuration: Long = Long.MaxValue,
     sslTrustAll: Boolean = false,
     includeHistoricalMetadata: Boolean = false) extends DeltaSharingClient {
 

--- a/spark/src/test/scala/io/delta/sharing/spark/util/ConfUtilsSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/util/ConfUtilsSuite.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark.util
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.internal.SQLConf
+
+class ConfUtilsSuite extends SparkFunSuite {
+  import ConfUtils._
+
+  private def newConf(properties: Map[String, String] = Map.empty): Configuration = {
+    val conf = new Configuration()
+    properties.foreach(p => conf.setStrings(p._1, p._2))
+    conf
+  }
+
+  private def newSqlConf(properties: Map[String, String] = Map.empty): SQLConf = {
+    val sqlConf = new SQLConf()
+    properties.foreach(p => sqlConf.setConfString(p._1, p._2))
+    sqlConf
+  }
+
+  test("numRetries") {
+    assert(numRetries(newConf()) == NUM_RETRIES_DEFAULT)
+    assert(numRetries(newConf(Map(NUM_RETRIES_CONF -> "100"))) == 100)
+    intercept[IllegalArgumentException] {
+      numRetries(newConf(Map(NUM_RETRIES_CONF -> "-1")))
+    }.getMessage.contains(NUM_RETRIES_CONF)
+
+    assert(numRetries(newSqlConf()) == NUM_RETRIES_DEFAULT)
+    assert(numRetries(newSqlConf(Map(NUM_RETRIES_CONF -> "50"))) == 50)
+    intercept[IllegalArgumentException] {
+      numRetries(newSqlConf(Map(NUM_RETRIES_CONF -> "-1")))
+    }.getMessage.contains(NUM_RETRIES_CONF)
+  }
+
+  test("maxRetryDuration") {
+    assert(maxRetryDurationMillis(newConf()) == MAX_RETRY_DURATION_DEFAULT_MILLIS)
+    assert(maxRetryDurationMillis(newConf(Map(MAX_RETRY_DURATION_CONF -> "50000"))) == 50000L)
+    intercept[IllegalArgumentException] {
+      maxRetryDurationMillis(newConf(Map(MAX_RETRY_DURATION_CONF -> "-1")))
+    }.getMessage.contains(MAX_RETRY_DURATION_CONF)
+
+    assert(maxRetryDurationMillis(newSqlConf()) == MAX_RETRY_DURATION_DEFAULT_MILLIS)
+    assert(maxRetryDurationMillis(newSqlConf(Map(MAX_RETRY_DURATION_CONF -> "25000"))) == 25000L)
+    intercept[IllegalArgumentException] {
+      maxRetryDurationMillis(newSqlConf(Map(MAX_RETRY_DURATION_CONF -> "-1")))
+    }.getMessage.contains(MAX_RETRY_DURATION_CONF)
+  }
+
+  test("timeout") {
+    assert(timeoutInSeconds(newConf()) == 320)
+    assert(timeoutInSeconds(newConf(Map(TIMEOUT_CONF -> "100s"))) == 100)
+    intercept[IllegalArgumentException] {
+      timeoutInSeconds(newConf(Map(TIMEOUT_CONF -> "-1")))
+    }.getMessage.contains(TIMEOUT_CONF)
+    intercept[IllegalArgumentException] {
+      timeoutInSeconds(newConf(Map(TIMEOUT_CONF -> "9999999999")))
+    }.getMessage.contains(TIMEOUT_CONF)
+
+    assert(timeoutInSeconds(newSqlConf()) == 320)
+    assert(timeoutInSeconds(newSqlConf(Map(TIMEOUT_CONF -> "50s"))) == 50)
+    intercept[IllegalArgumentException] {
+      timeoutInSeconds(newSqlConf(Map(TIMEOUT_CONF -> "-1")))
+    }.getMessage.contains(TIMEOUT_CONF)
+    intercept[IllegalArgumentException] {
+      timeoutInSeconds(newSqlConf(Map(TIMEOUT_CONF -> "9999999999")))
+    }.getMessage.contains(TIMEOUT_CONF)
+  }
+
+  test("maxConnections") {
+    assert(maxConnections(newConf()) == MAX_CONNECTION_DEFAULT)
+    assert(maxConnections(newConf(Map(MAX_CONNECTION_CONF -> "100"))) == 100)
+    intercept[IllegalArgumentException] {
+      maxConnections(newConf(Map(MAX_CONNECTION_CONF -> "-1")))
+    }.getMessage.contains(MAX_CONNECTION_CONF)
+  }
+}


### PR DESCRIPTION
In this PR, we are making the following changes:
- Add a maxRetryDurationLimit to the retry logic.
- Retry on socket timeout.
- Refactor/Consolidate spark configs
- Add unit tests.