### PR TITLE
Add documentation for integrating R2

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ We use an R2 implementation of the [S3 API](https://developers.cloudflare.com/r2
   </property>
 </configuration>
 ```
-Replace `YOUR-ACCESS-KEY` with your generated API token's R2 access key ID, `YOUR-SECRET-KEY` with your generated API token's secret access key, and `YOUR-ACCOUNT-ID` with your Cloudflare account ID.
+Replace `YOUR-ACCESS-KEY` with your generated API token's R2 access key ID, `YOUR-SECRET-KEY` with your generated API token's secret access key, and `YOUR-ACCOUNT-ID` with your Cloudflare account ID. `fs.s3a.paging.maximum` must be manually set to 1000 since R2 only supports `MaxKeys` <= 1000 and Hadoop sets the value to 5000 by default. 
 
 **Note**: S3 and R2 credentials cannot be configured simultaneously.
 

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="KEY_PATH"
 Replace `KEY_PATH` with path of the JSON file that contains your service account key.
 
 ### Cloudflare R2
-We use an R2 implementation of the [S3 API](https://developers.cloudflare.com/r2/api/s3/api/) and `hadoop-aws` to read Cloudflare R2. You must [generate an API token](https://developers.cloudflare.com/r2/api/s3/tokens/) for usage with existing S3-compatible SDKs. These credentials can be specified in substitute of the S3 credentials in a Hadoop configuration file named `core-site.xml` within the server's `conf` directory. For R2 to work, you also need to directly specify the S3 endpoint and reduce `fs.s3a.paging.maximum` from Hadoop's default of 5000 to 1000 since R2 only supports `MaxKeys` <= 1000.
+We use an R2 implementation of the [S3 API](https://developers.cloudflare.com/r2/api/s3/api/) and `hadoop-aws` to read Cloudflare R2. Table paths in the server config file should use the `s3a://` scheme. You must [generate an API token](https://developers.cloudflare.com/r2/api/s3/tokens/) for usage with existing S3-compatible SDKs. These credentials can be specified in substitute of the S3 credentials in a Hadoop configuration file named `core-site.xml` within the server's `conf` directory. For R2 to work, you also need to directly specify the S3 endpoint and reduce `fs.s3a.paging.maximum` from Hadoop's default of 5000 to 1000 since R2 only supports `MaxKeys` <= 1000.
 ```xml
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>

--- a/README.md
+++ b/README.md
@@ -457,6 +457,34 @@ export GOOGLE_APPLICATION_CREDENTIALS="KEY_PATH"
 
 Replace `KEY_PATH` with path of the JSON file that contains your service account key.
 
+### Cloudflare R2
+We use an R2 implementation of the [S3 API](https://developers.cloudflare.com/r2/api/s3/api/) and `hadoop-aws` to read Cloudflare R2. You must [generate an API token](https://developers.cloudflare.com/r2/api/s3/tokens/) for usage with existing S3-compatible SDKs. These credentials can be specified in substitute of the S3 credentials in a Hadoop configuration file named `core-site.xml` within the server's `conf` directory. For R2 to work, you also need to directly specify the S3 endpoint and reduce `fs.s3a.paging.maximum` from 5000 to 1000.
+```xml
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>fs.s3a.access.key</name>
+    <value>YOUR-ACCESS-KEY</value>
+  </property>
+  <property>
+    <name>fs.s3a.secret.key</name>
+    <value>YOUR-SECRET-KEY</value>
+  </property>
+  <property>
+    <name>fs.s3a.endpoint</name>
+    <value>https://YOUR-ACCOUNT-ID.r2.cloudflarestorage.com</value>
+  </property>
+  <property>
+    <name>fs.s3a.paging.maximum</name>
+    <value>1000</value>
+  </property>
+</configuration>
+```
+Replace `YOUR-ACCESS-KEY` with your generated API token's R2 access key ID, `YOUR-SECRET-KEY` with your generated API token's secret access key, and `YOUR-ACCOUNT-ID` with your Cloudflare account ID.
+
+**Note**: S3 and R2 credentials cannot be configured simultaneously.
+
 ## Authorization
 
 The server supports a basic authorization with pre-configed bearer token. You can add the following config to your server yaml file:

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="KEY_PATH"
 Replace `KEY_PATH` with path of the JSON file that contains your service account key.
 
 ### Cloudflare R2
-We use an R2 implementation of the [S3 API](https://developers.cloudflare.com/r2/api/s3/api/) and `hadoop-aws` to read Cloudflare R2. You must [generate an API token](https://developers.cloudflare.com/r2/api/s3/tokens/) for usage with existing S3-compatible SDKs. These credentials can be specified in substitute of the S3 credentials in a Hadoop configuration file named `core-site.xml` within the server's `conf` directory. For R2 to work, you also need to directly specify the S3 endpoint and reduce `fs.s3a.paging.maximum` from 5000 to 1000.
+We use an R2 implementation of the [S3 API](https://developers.cloudflare.com/r2/api/s3/api/) and `hadoop-aws` to read Cloudflare R2. You must [generate an API token](https://developers.cloudflare.com/r2/api/s3/tokens/) for usage with existing S3-compatible SDKs. These credentials can be specified in substitute of the S3 credentials in a Hadoop configuration file named `core-site.xml` within the server's `conf` directory. For R2 to work, you also need to directly specify the S3 endpoint and reduce `fs.s3a.paging.maximum` from Hadoop's default of 5000 to 1000 since R2 only supports `MaxKeys` <= 1000.
 ```xml
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
@@ -481,7 +481,7 @@ We use an R2 implementation of the [S3 API](https://developers.cloudflare.com/r2
   </property>
 </configuration>
 ```
-Replace `YOUR-ACCESS-KEY` with your generated API token's R2 access key ID, `YOUR-SECRET-KEY` with your generated API token's secret access key, and `YOUR-ACCOUNT-ID` with your Cloudflare account ID. `fs.s3a.paging.maximum` must be manually set to 1000 since R2 only supports `MaxKeys` <= 1000 and Hadoop sets the value to 5000 by default. 
+Replace `YOUR-ACCESS-KEY` with your generated API token's R2 access key ID, `YOUR-SECRET-KEY` with your generated API token's secret access key, and `YOUR-ACCOUNT-ID` with your Cloudflare account ID.
 
 **Note**: S3 and R2 credentials cannot be configured simultaneously.
 

--- a/server/src/test/scala/io/delta/sharing/server/config/ServerConfigSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/config/ServerConfigSuite.scala
@@ -83,6 +83,15 @@ class ServerConfigSuite extends FunSuite {
               id = "00000000-0000-0000-0000-000000000003"
             )
           ))
+        )),
+        ShareConfig("share4", Arrays.asList(
+          SchemaConfig("schema4", Arrays.asList(
+            TableConfig(
+              "table5",
+              "s3a://<bucket-name>/<the-table-path>",
+              id = "00000000-0000-0000-0000-000000000004"
+            )
+          ))
         ))
       )
       val serverConfig = new ServerConfig()

--- a/server/src/universal/conf/delta-sharing-server.yaml.template
+++ b/server/src/universal/conf/delta-sharing-server.yaml.template
@@ -31,6 +31,14 @@ shares:
       # Google Cloud Storage (GCS). See https://github.com/delta-io/delta-sharing#google-cloud-storage for how to config the credentials
       location: "gs://<bucket-name>/<the-table-path>"
       id: "00000000-0000-0000-0000-000000000003"
+- name: "share4"
+  schemas:
+    - name: "schema4"
+      tables:
+        - name: "table5"
+          # Cloudflare R2. See https://github.com/delta-io/delta-sharing#cloudflare-r2 for how to config the credentials
+          location: "s3a://<bucket-name>/<the-table-path>"
+          id: "00000000-0000-0000-0000-000000000004"
 # Set the host name that the server will use
 host: "localhost"
 # Set the port that the server will listen on. Note: using ports below 1024 


### PR DESCRIPTION
Add documentation for integrating Cloudflare R2. This implementation uses the R2 implementation of the S3 API and instructs on how to specify proper configurations to connect to R2. 

Closes #310 