### PR TITLE
Fix for issue #320

### DIFF
--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -161,7 +161,7 @@ class DeltaSharingReader:
         protocol = url.scheme
         proxy = getproxies()
         if len(proxy) != 0:
-            filesystem = fsspec.filesystem(protocol,trust_env=True)
+            filesystem = fsspec.filesystem(protocol, client_kwargs={"trust_env":True})
         else:
             filesystem = fsspec.filesystem(protocol)
 

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -16,6 +16,7 @@
 from typing import Any, Callable, Dict, Optional, Sequence
 from urllib.parse import urlparse
 from json import loads
+from urllib.request import getproxies
 
 import fsspec
 import pandas as pd
@@ -158,7 +159,11 @@ class DeltaSharingReader:
             import delta_sharing._yarl_patch  # noqa: F401
 
         protocol = url.scheme
-        filesystem = fsspec.filesystem(protocol)
+        proxy = getproxies()
+        if proxy != 0:
+            filesystem = fsspec.filesystem(protocol,trust_env=True)
+        else:
+            filesystem = fsspec.filesystem(protocol)
 
         pa_dataset = dataset(source=action.url, format="parquet", filesystem=filesystem)
         pa_table = pa_dataset.head(limit) if limit is not None else pa_dataset.to_table()

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -160,7 +160,7 @@ class DeltaSharingReader:
 
         protocol = url.scheme
         proxy = getproxies()
-        if proxy != 0:
+        if len(proxy) != 0:
             filesystem = fsspec.filesystem(protocol,trust_env=True)
         else:
             filesystem = fsspec.filesystem(protocol)


### PR DESCRIPTION
The issue with the proxy env variables not being used when reading the data via the pre-signed urls when using the "load_as_pandas" which uses the fsspec and aiohttp libraries to read the data via the pre-signed urls.

this fix will make sure that the fsspec and aiohttp clients created will use the proxy settings if the proxy env variables are set in the environment.