### PR TITLE
Support endingVersion in queryTable RPC in delta-sharing 0.6

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1933,7 +1933,10 @@ The request body should be a JSON string containing the following optional field
 
 - **timestamp** (type: String, optional): an optional timestamp string in the [Timestamp Format](#timestamp-format),. If set, will return files as of the table version corresponding to the specified timestamp. This is only supported on tables with history sharing enabled.
 
-- **startingVersion** (type: Long, optional): an optional version number. If set, will return all data change files since startingVersion, including historical metadata if seen in the delta log.
+- **startingVersion** (type: Long, optional): an optional version number. If set, will return all data change files since startingVersion, inclusive, including historical metadata if seen in the delta log.
+
+- **endingVersion** (type: Long, optional): an optional version number, only used if startingVersion is set. If set, the server can use it as a hint to avoid returning data change files after `endingVersion`. This is not enforcement. Hence, when sending the `endingVersion` parameter, the client should still handle the case that it may receive files after `endingVersion`.
+  - The combination of `statingVersion` and `endingVersion` can be used as query window for delta sharing streaming rpcs.
 
 When `predicateHints` and `limitHint` are both present, the server should apply `predicateHints` first then `limitHint`. As these two parameters are hints rather than enforcement, the client must always apply `predicateHints` and `limitHint` on the response returned by the server if it wishes to filter and limit the returned data. An empty JSON object (`{}`) should be provided when these two parameters are missing.
 

--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ To use Delta Sharing connector interactively within the Spark’s Scala/Python s
 #### PySpark shell
 
 ```
-pyspark --packages io.delta:delta-sharing-spark_2.12:0.6.2
+pyspark --packages io.delta:delta-sharing-spark_2.12:0.6.4
 ```
 
 #### Scala Shell
 
 ```
-bin/spark-shell --packages io.delta:delta-sharing-spark_2.12:0.6.2
+bin/spark-shell --packages io.delta:delta-sharing-spark_2.12:0.6.4
 ```
 
 ### Set up a standalone project
@@ -148,7 +148,7 @@ You include Delta Sharing connector in your Maven project by adding it as a depe
 <dependency>
   <groupId>io.delta</groupId>
   <artifactId>delta-sharing-spark_2.12</artifactId>
-  <version>0.6.2</version>
+  <version>0.6.4</version>
 </dependency>
 ```
 
@@ -157,7 +157,7 @@ You include Delta Sharing connector in your Maven project by adding it as a depe
 You include Delta Sharing connector in your SBT project by adding the following line to your `build.sbt` file:
 
 ```scala
-libraryDependencies += "io.delta" %% "delta-sharing-spark" % "0.6.2"
+libraryDependencies += "io.delta" %% "delta-sharing-spark" % "0.6.4"
 ```
 
 ## Quick Start
@@ -489,7 +489,7 @@ You can use the pre-built docker image from https://hub.docker.com/r/deltaio/del
 ```
 docker run -p <host-port>:<container-port> \
   --mount type=bind,source=<the-server-config-yaml-file>,target=/config/delta-sharing-server-config.yaml \
-  deltaio/delta-sharing-server:0.6.2 -- --config /config/delta-sharing-server-config.yaml
+  deltaio/delta-sharing-server:0.6.4 -- --config /config/delta-sharing-server-config.yaml
 ```
 
 Note that `<container-port>` should be the same as the port defined inside the config file.

--- a/server/src/main/protobuf/protocol.proto
+++ b/server/src/main/protobuf/protocol.proto
@@ -58,8 +58,11 @@ message QueryTableRequest {
     optional int64 version = 3;
     // The table version corresponding to the timestamp being queried.
     optional string timestamp = 4;
-    // Query all data change files since startingVersion
+    // Query all data change files since startingVersion, inclusive.
     optional int64 startingVersion = 5;
+    // Query all data change files until endingVersion, inclusive. Only used when startingVersion
+    // is set, otherwise will be ignored.
+    optional int64 endingVersion = 7;
 }
 
 message ListSharesResponse {

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaCDFErrors.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaCDFErrors.scala
@@ -38,6 +38,12 @@ object DeltaCDFErrors {
     )
   }
 
+  def endVersionAfterLatestVersion(end: Long, latest: Long): Throwable = {
+    new DeltaCDFIllegalArgumentException(s"Provided end version($end) is invalid. End version " +
+      s"cannot be greater than the latest version of the table($latest)."
+    )
+  }
+
   def endBeforeStartVersionInCDF(start: Long, end: Long): Throwable = {
     new DeltaCDFIllegalArgumentException(
       s"CDF range from start $start to end $end was invalid. End cannot be before start."

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
@@ -56,6 +56,13 @@ trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
     }
   }
 
+  val maxVersionsPerRpc: Option[Int] = options.get(MAX_VERSIONS_PER_RPC).map { str =>
+    Try(str.toInt).toOption.filter(_ > 0).getOrElse {
+      throw DeltaSharingErrors.illegalDeltaSharingOptionException(
+        MAX_VERSIONS_PER_RPC, str, "must be a positive integer")
+    }
+  }
+
   val ignoreChanges = options.get(IGNORE_CHANGES_OPTION).exists(toBoolean(_, IGNORE_CHANGES_OPTION))
 
   val ignoreDeletes = options.get(IGNORE_DELETES_OPTION).exists(toBoolean(_, IGNORE_DELETES_OPTION))
@@ -155,6 +162,10 @@ object DeltaSharingOptions extends Logging {
   val MAX_FILES_PER_TRIGGER_OPTION = "maxFilesPerTrigger"
   val MAX_FILES_PER_TRIGGER_OPTION_DEFAULT = 1000
   val MAX_BYTES_PER_TRIGGER_OPTION = "maxBytesPerTrigger"
+  // a delta sharing specific parameter, used to sepcify the max number of versions to query in
+  // one rpc in a streaming job.
+  val MAX_VERSIONS_PER_RPC = "maxVersionsPerRpc"
+  val MAX_VERSIONS_PER_RPC_DEFAULT = 100
   val IGNORE_CHANGES_OPTION = "ignoreChanges"
   val IGNORE_DELETES_OPTION = "ignoreDeletes"
   val SKIP_CHANGE_COMMITS_OPTION = "skipChangeCommits"

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -145,8 +145,11 @@ case class DeltaSharingSource(
   private var sortedFetchedFiles: Seq[IndexedFile] = Seq.empty
 
   private var lastGetVersionTimestamp: Long = -1
-  private var lastQueriedTableVersion: Long = -1
+  private var latestTableVersion: Long = -1
   private val QUERY_TABLE_VERSION_INTERVAL_MILLIS = 30000 // 30 seconds
+  private val maxVersionsPerRpc: Int = options.maxVersionsPerRpc.getOrElse(
+    DeltaSharingOptions.MAX_VERSIONS_PER_RPC_DEFAULT
+  )
 
   // The latest function used to fetch presigned urls for the delta sharing table, record it in
   // a variable to be used by the CachedTableManager to refresh the presigned urls if the query
@@ -165,10 +168,10 @@ case class DeltaSharingSource(
     val currentTimeMillis = System.currentTimeMillis()
     if (lastGetVersionTimestamp == -1 ||
       (currentTimeMillis - lastGetVersionTimestamp) >= QUERY_TABLE_VERSION_INTERVAL_MILLIS) {
-      lastQueriedTableVersion = deltaLog.client.getTableVersion(deltaLog.table)
+      latestTableVersion = deltaLog.client.getTableVersion(deltaLog.table)
       lastGetVersionTimestamp = currentTimeMillis
     }
-    lastQueriedTableVersion
+    latestTableVersion
   }
 
   // The actual order of files doesn't matter much.
@@ -212,10 +215,13 @@ case class DeltaSharingSource(
       return
     }
 
+    // using "fromVersion + maxVersionsPerRpc - 1" because the endingVersion is inclusive.
+    val endingVersionForQuery = currentLatestVersion.min(fromVersion + maxVersionsPerRpc - 1)
+
     if (isStartingVersion || !options.readChangeFeed) {
-      getTableFileChanges(fromVersion, fromIndex, isStartingVersion, currentLatestVersion)
+      getTableFileChanges(fromVersion, fromIndex, isStartingVersion, endingVersionForQuery)
     } else {
-      getCDFFileChanges(fromVersion, fromIndex, currentLatestVersion)
+      getCDFFileChanges(fromVersion, fromIndex, endingVersionForQuery)
     }
   }
 
@@ -229,16 +235,17 @@ case class DeltaSharingSource(
    * @param isStartingVersion - If true, will load fromVersion as a table snapshot(including files
    *                            from previous versions). If false, will only load files since
    *                            fromVersion.
-   * @param currentLatestVersion - The latest table version returned from the delta sharing server.
-   *                               This is used to insert an indexedFile for each version in the
-   *                               sortedFetchedFiles, in order to ensure the offset move beyond
-   *                               this version.
+   * @param endingVersionForQuery - The ending version used for the query, always smaller than
+   *                                latestTableVersion.
+   *                                This is used to insert an indexedFile for each version in the
+   *                                sortedFetchedFiles, in order to ensure the offset move beyond
+   *                                this version.
    */
   private def getTableFileChanges(
       fromVersion: Long,
       fromIndex: Long,
       isStartingVersion: Boolean,
-      currentLatestVersion: Long): Unit = {
+      endingVersionForQuery: Long): Unit = {
     lastQueryTableTimestamp = System.currentTimeMillis()
     if (isStartingVersion) {
       // If isStartingVersion is true, it means to fetch the snapshot at the fromVersion, which may
@@ -277,14 +284,18 @@ case class DeltaSharingSource(
     } else {
       // If isStartingVersion is false, it means to fetch table changes since fromVersion, not
       // including files from previous versions.
-      val tableFiles = deltaLog.client.getFiles(deltaLog.table, fromVersion)
+      val tableFiles = deltaLog.client.getFiles(
+        deltaLog.table, fromVersion, Some(endingVersionForQuery)
+      )
       latestRefreshFunc = () => {
-        deltaLog.client.getFiles(deltaLog.table, fromVersion).addFiles.map { a =>
+        deltaLog.client.getFiles(
+          deltaLog.table, fromVersion, Some(endingVersionForQuery)
+        ).addFiles.map { a =>
           a.id -> a.url
         }.toMap
       }
       val allAddFiles = validateCommitAndFilterAddFiles(tableFiles).groupBy(a => a.version)
-      for (v <- fromVersion to currentLatestVersion) {
+      for (v <- fromVersion to endingVersionForQuery) {
 
         val vAddFiles = allAddFiles.getOrElse(v, ArrayBuffer[AddFileForCDF]())
         val numFiles = vAddFiles.size
@@ -307,21 +318,34 @@ case class DeltaSharingSource(
    * @param fromVersion - a table version, initially would be the startingVersion or the latest
    *                      table version.
    * @param fromIndex - index of a file within the same version,
-   * @param currentLatestVersion - The latest table version returned from the delta sharing server.
-   *                               This is used to insert an indexedFile for each version in the
-   *                               sortedFetchedFiles, in order to ensure the offset move beyond
-   *                               this version.
+   * @param endingVersionForQuery - The ending version used for the query, always smaller than
+   *                                latestTableVersion.
+   *                                This is used to insert an indexedFile for each version in the
+   *                                sortedFetchedFiles, in order to ensure the offset move beyond
+   *                                this version.
    */
   private def getCDFFileChanges(
       fromVersion: Long,
       fromIndex: Long,
-      currentLatestVersion: Long): Unit = {
+      endingVersionForQuery: Long): Unit = {
     lastQueryTableTimestamp = System.currentTimeMillis()
     val tableFiles = deltaLog.client.getCDFFiles(
-      deltaLog.table, Map(DeltaSharingOptions.CDF_START_VERSION -> fromVersion.toString), true)
+      deltaLog.table,
+      Map(
+        DeltaSharingOptions.CDF_START_VERSION -> fromVersion.toString,
+        DeltaSharingOptions.CDF_END_VERSION -> endingVersionForQuery.toString
+      ),
+      true
+    )
     latestRefreshFunc = () => {
       val d = deltaLog.client.getCDFFiles(
-        deltaLog.table, Map(DeltaSharingOptions.CDF_START_VERSION -> fromVersion.toString), true)
+        deltaLog.table,
+        Map(
+          DeltaSharingOptions.CDF_START_VERSION -> fromVersion.toString,
+          DeltaSharingOptions.CDF_END_VERSION -> endingVersionForQuery.toString
+        ),
+        true
+      )
       DeltaSharingCDFReader.getIdToUrl(d.addFiles, d.cdfFiles, d.removeFiles)
     }
 
@@ -336,7 +360,7 @@ case class DeltaSharingSource(
     val perVersionCdfFiles = tableFiles.cdfFiles.groupBy(f => f.version)
     val perVersionRemoveFiles = tableFiles.removeFiles.groupBy(f => f.version)
 
-    for (v <- fromVersion to currentLatestVersion) {
+    for (v <- fromVersion to endingVersionForQuery) {
       if (perVersionCdfFiles.contains(v)) {
         // Process cdf files if it exists, and ignore add/remove files. This is the property of
         // delta table, when cdf file exists in a version, it represents the same data change as

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -217,6 +217,12 @@ case class DeltaSharingSource(
 
     // using "fromVersion + maxVersionsPerRpc - 1" because the endingVersion is inclusive.
     val endingVersionForQuery = currentLatestVersion.min(fromVersion + maxVersionsPerRpc - 1)
+    if (endingVersionForQuery < currentLatestVersion) {
+      logInfo(s"Reducing ending version for delta sharing rpc of table " +
+        s"${deltaLog.table.toString} from currentLatestVersion" +
+        s"($currentLatestVersion) to endingVersionForQuery($endingVersionForQuery), fromVersion:" +
+        s"$fromVersion, maxVersionsPerRpc: $maxVersionsPerRpc.")
+    }
 
     if (isStartingVersion || !options.readChangeFeed) {
       getTableFileChanges(fromVersion, fromIndex, isStartingVersion, endingVersionForQuery)

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingOptionsSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingOptionsSuite.scala
@@ -31,6 +31,7 @@ class DeltaSharingOptionsSuite extends SparkFunSuite {
     val options = new DeltaSharingOptions(Map.empty[String, String])
     assert(options.maxFilesPerTrigger.isEmpty)
     assert(options.maxBytesPerTrigger.isEmpty)
+    assert(options.maxVersionsPerRpc.isEmpty)
     assert(!options.ignoreChanges)
     assert(!options.ignoreDeletes)
     assert(!options.readChangeFeed)
@@ -42,6 +43,7 @@ class DeltaSharingOptionsSuite extends SparkFunSuite {
     var options = new DeltaSharingOptions(Map(
       "maxFilesPerTrigger" -> "11",
       "maxBytesPerTrigger" -> "12",
+      "maxVersionsPerRpc" -> "15",
       "ignoreChanges" -> "true",
       "ignoreDeletes" -> "true",
       "readChangeFeed" -> "true",
@@ -50,6 +52,7 @@ class DeltaSharingOptionsSuite extends SparkFunSuite {
     ))
     assert(options.maxFilesPerTrigger == Some(11))
     assert(options.maxBytesPerTrigger == Some(12))
+    assert(options.maxVersionsPerRpc == Some(15))
     assert(options.ignoreChanges)
     assert(options.ignoreDeletes)
     assert(options.readChangeFeed)
@@ -194,6 +197,12 @@ class DeltaSharingOptionsSuite extends SparkFunSuite {
     }.getMessage
     assert(errorMessage.contains("Invalid value '2mg' for option 'maxBytesPerTrigger', must be " +
       "a size configuration such as '10g'"))
+
+    errorMessage = intercept[IllegalArgumentException] {
+      new DeltaSharingOptions(Map("maxVersionsPerRpc" -> "-1"))
+    }.getMessage
+    assert(errorMessage.contains(
+      "Invalid value '-1' for option 'maxVersionsPerRpc', must be a positive integer"))
 
     // only one of options can be set
     errorMessage = intercept[IllegalArgumentException] {

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -294,7 +294,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
     try {
       val tableFiles = client.getFiles(
-        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"), 1L
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"), 1L, None
       )
       assert(tableFiles.version == 1)
       assert(tableFiles.addFiles.size == 4)
@@ -379,13 +379,127 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  integrationTest("getFiles with startingVersion - exception") {
+  integrationTest("getFiles with startingVersion/endingVersion - success 1") {
+    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
+    try {
+      val tableFiles = client.getFiles(
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"), 1L, Some(1L)
+      )
+      assert(tableFiles.version == 1)
+      assert(tableFiles.addFiles.size == 3)
+      val expectedAddFiles = Seq(
+        AddFileForCDF(
+          url = tableFiles.addFiles(0).url,
+          id = "60d0cf57f3e4367db154aa2c36152a1f",
+          partitionValues = Map.empty,
+          size = 1030,
+          stats = """{"numRecords":1,"minValues":{"name":"1","age":1,"birthday":"2020-01-01"},"maxValues":{"name":"1","age":1,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
+          version = 1,
+          timestamp = 1651272635000L
+        ),
+        AddFileForCDF(
+          url = tableFiles.addFiles(1).url,
+          id = "a6dc5694a4ebcc9a067b19c348526ad6",
+          partitionValues = Map.empty,
+          size = 1030,
+          stats = """{"numRecords":1,"minValues":{"name":"2","age":2,"birthday":"2020-01-01"},"maxValues":{"name":"2","age":2,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
+          version = 1,
+          timestamp = 1651272635000L
+        ),
+        AddFileForCDF(
+          url = tableFiles.addFiles(2).url,
+          id = "d7ed708546dd70fdff9191b3e3d6448b",
+          partitionValues = Map.empty,
+          size = 1030,
+          stats = """{"numRecords":1,"minValues":{"name":"3","age":3,"birthday":"2020-01-01"},"maxValues":{"name":"3","age":3,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
+          version = 1,
+          timestamp = 1651272635000L
+        )
+      )
+      assert(expectedAddFiles == tableFiles.addFiles.toList)
+    } finally {
+      client.close()
+    }
+  }
+
+  integrationTest("getFiles with startingVersion/endingVersion - success 2") {
+    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
+    try {
+      val tableFiles = client.getFiles(
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"), 2L, Some(3L)
+      )
+      assert(tableFiles.version == 2)
+      assert(tableFiles.addFiles.size == 1)
+      val expectedAddFiles = Seq(
+        AddFileForCDF(
+          url = tableFiles.addFiles(0).url,
+          id = "b875623be22c1fa1dfdeb0480fae6117",
+          partitionValues = Map.empty,
+          size = 1247,
+          stats = """{"numRecords":1,"minValues":{"name":"2","age":2,"birthday":"2020-02-02"},"maxValues":{"name":"2","age":2,"birthday":"2020-02-02"},"nullCount":{"name":0,"age":0,"birthday":0,"_change_type":1}}""",
+          version = 3,
+          timestamp = 1651272660000L
+        )
+      )
+      assert(expectedAddFiles == tableFiles.addFiles.toList)
+
+      assert(tableFiles.removeFiles.size == 2)
+      val expectedRemoveFiles = Seq(
+        RemoveFile(
+          url = tableFiles.removeFiles(0).url,
+          id = "d7ed708546dd70fdff9191b3e3d6448b",
+          partitionValues = Map.empty,
+          size = 1030,
+          version = 2,
+          timestamp = 1651272655000L
+        ),
+        RemoveFile(
+          url = tableFiles.removeFiles(1).url,
+          id = "a6dc5694a4ebcc9a067b19c348526ad6",
+          partitionValues = Map.empty,
+          size = 1030,
+          version = 3,
+          timestamp = 1651272660000L
+        )
+      )
+      assert(expectedRemoveFiles == tableFiles.removeFiles.toList)
+    } finally {
+      client.close()
+    }
+  }
+
+  integrationTest("getFiles with startingVersion/endingVersion - success 3") {
+    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
+    try {
+      val tableFiles = client.getFiles(
+        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"), 4L, Some(5L)
+      )
+      assert(tableFiles.version == 4)
+      assert(tableFiles.addFiles.size == 0)
+      assert(tableFiles.removeFiles.size == 0)
+
+      assert(tableFiles.additionalMetadatas.size == 1)
+      val v5Metadata = Metadata(
+        id = "16736144-3306-4577-807a-d3f899b77670",
+        format = Format(),
+        schemaString = """{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}},{"name":"age","type":"integer","nullable":true,"metadata":{}},{"name":"birthday","type":"date","nullable":true,"metadata":{}}]}""",
+        configuration = Map("enableChangeDataFeed" -> "true"),
+        partitionColumns = Nil,
+        version = 5)
+      assert(v5Metadata == tableFiles.additionalMetadatas(0))
+    } finally {
+      client.close()
+    }
+  }
+
+  integrationTest("getFiles with startingVersion/endingVersion - exception") {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
     try {
       var errorMessage = intercept[UnexpectedHttpStatus] {
         client.getFiles(
           Table(name = "table1", schema = "default", share = "share1"),
-          1
+          1,
+          None
         )
       }.getMessage
       assert(errorMessage.contains("Reading table by version or timestamp is not supported because change data feed is not enabled on table: share1.default.table1"))
@@ -393,10 +507,21 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       errorMessage = intercept[UnexpectedHttpStatus] {
         client.getFiles(
           Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
-          -1
+          -1,
+          None
         )
       }.getMessage
       assert(errorMessage.contains("startingVersion cannot be negative"))
+
+      errorMessage = intercept[UnexpectedHttpStatus] {
+        client.getFiles(
+          Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
+          2,
+          Some(1)
+        )
+      }.getMessage
+      assert(errorMessage.contains("startingVersion(2) must be smaller than or equal to " +
+        "endingVersion(1)"))
     } finally {
       client.close()
     }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceCDFSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceCDFSuite.scala
@@ -60,7 +60,6 @@ class DeltaSharingSourceCDFSuite extends QueryTest
   lazy val toNotNullTable = testProfileFile.getCanonicalPath +
     "#share8.default.streaming_cdf_null_to_notnull"
 
-  // allowed to query starting from version 1
   // VERSION 1: INSERT 2 rows, 1 add file
   // VERSION 2: INSERT 3 rows, 1 add file
   // VERSION 3: UPDATE 4 rows, 4 cdf files, 8 cdf rows
@@ -590,4 +589,94 @@ class DeltaSharingSourceCDFSuite extends QueryTest
       }
     }
   }
+
+  /**
+   * Test maxVersionsPerRpc
+   */
+  integrationTest("maxVersionsPerRpc - success") {
+    // VERSION 1: INSERT 2 rows, 1 add file
+    // VERSION 2: INSERT 3 rows, 1 add file
+    // VERSION 3: UPDATE 4 rows, 4 cdf files, 8 cdf rows
+    // VERSION 4: REMOVE 4 rows, 2 remove files
+    // maxVersionsPerRpc = 1
+    var processedRows = Seq(2, 3, 8, 4)
+    var query = withStreamReaderAtVersion()
+      .option("maxVersionsPerRpc", "1")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 2
+    processedRows = Seq(2, 11, 4)
+    query = withStreamReaderAtVersion()
+      .option("maxVersionsPerRpc", "2")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 3
+    processedRows = Seq(5, 12)
+    query = withStreamReaderAtVersion()
+      .option("maxVersionsPerRpc", "3")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 4
+    processedRows = Seq(13, 4)
+    query = withStreamReaderAtVersion()
+      .option("maxVersionsPerRpc", "4")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 5
+    processedRows = Seq(17)
+    query = withStreamReaderAtVersion()
+      .option("maxVersionsPerRpc", "5")
+      .load().writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+  }
+
 }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -56,6 +56,12 @@ class DeltaSharingSourceSuite extends QueryTest
   lazy val partitionTablePath = testProfileFile.getCanonicalPath +
     "#share8.default.cdf_table_with_partition"
 
+  // VERSION 1: INSERT 2 rows, 1 add file
+  // VERSION 2: INSERT 3 rows, 1 add file
+  // VERSION 3: UPDATE 4 rows, 3 add files, 2 remove files, 5 rows
+  // VERSION 4: REMOVE 4 rows, 2 remove files
+  lazy val cdfTablePath = testProfileFile.getCanonicalPath + "#share8.default.streaming_cdf_table"
+
   lazy val toNullTable = testProfileFile.getCanonicalPath +
       "#share8.default.streaming_notnull_to_null"
   lazy val toNotNullTable = testProfileFile.getCanonicalPath +
@@ -470,6 +476,84 @@ class DeltaSharingSourceSuite extends QueryTest
       } finally {
         restartQuery.stop()
       }
+    }
+  }
+
+  /**
+   * Test maxVersionsPerRpc
+   */
+  integrationTest("maxVersionsPerRpc - success") {
+    // VERSION 1: INSERT 2 rows, 1 add file
+    // VERSION 2: INSERT 3 rows, 1 add file
+    // VERSION 3: UPDATE 4 rows, 4 cdf files, 4 new rows
+    // VERSION 4: REMOVE 4 rows, 2 remove files, no new rows
+
+    // maxVersionsPerRpc = 1
+    var processedRows = Seq(2, 3, 5)
+    var query = withStreamReaderAtVersion(path = cdfTablePath)
+      .option("maxVersionsPerRpc", "1")
+      .load()
+      .writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 2
+    processedRows = Seq(2, 8)
+    query = withStreamReaderAtVersion(path = cdfTablePath)
+      .option("maxVersionsPerRpc", "2")
+      .load()
+      .writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 3
+    processedRows = Seq(5, 5)
+    query = withStreamReaderAtVersion(path = cdfTablePath)
+      .option("maxVersionsPerRpc", "3")
+      .load()
+      .writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
+    }
+
+    // maxVersionsPerRpc = 4
+    processedRows = Seq(10)
+    query = withStreamReaderAtVersion(path = cdfTablePath)
+      .option("maxVersionsPerRpc", "4")
+      .load()
+      .writeStream.format("console").start()
+    try {
+      query.processAllAvailable()
+      val progress = query.recentProgress.filter(_.numInputRows != 0)
+      assert(progress.length === processedRows.size)
+      progress.zipWithIndex.map { case (p, index) =>
+        assert(p.numInputRows === processedRows(index))
+      }
+    } finally {
+      query.stop()
     }
   }
 

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -87,7 +87,11 @@ class TestDeltaSharingClient(
     DeltaTableFiles(0, Protocol(0), metadata, addFiles)
   }
 
-  override def getFiles(table: Table, startingVersion: Long): DeltaTableFiles = {
+  override def getFiles(
+      table: Table,
+      startingVersion: Long,
+      endingVersion: Option[Long]
+  ): DeltaTableFiles = {
     // This is not used anywhere.
     DeltaTableFiles(0, Protocol(0), metadata, Nil, Nil, Nil, Nil)
   }


### PR DESCRIPTION
This is a cherry-pick of https://github.com/delta-io/delta-sharing/pull/304 [commit](https://github.com/delta-io/delta-sharing/commit/8b211cfbbd322a40683e01f0d4f0720c4d0a976a) 
- Support endingVersion in queryTable RPC, this is to avoid fetching unneeded files from server upon refresh. 
- Support a new parameter: `maxVersionsPerRpc` for delta sharing streaming job.
- Added logInfo which is not in the original PR, I will add that in a separate PR.