### PR TITLE
[not needed] [Prototype] E2E testing with queryDeltaLog

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
@@ -49,7 +49,12 @@ private[sharing] class DeltaSharingDataSource
     val options = new DeltaSharingOptions(parameters)
     val path = options.options.getOrElse("path", throw DeltaSharingErrors.pathNotSpecifiedException)
 
-    val deltaLog = RemoteDeltaLog(path)
+    // TODO:
+    //  1. create delta sharing client
+    //  2. getMetadata
+    //  3. Prepare custom relation with custom file index
+    //  4. in file index class, getFiles, and prepare delta log.
+    val deltaLog = RemoteDeltaLog(path, queryDeltaLog = true)
     deltaLog.createRelation(options.versionAsOf, options.timestampAsOf, options.cdfOptions)
   }
 

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -232,6 +232,12 @@ case class DeltaSharingSource(
 
     // using "fromVersion + maxVersionsPerRpc - 1" because the endingVersion is inclusive.
     val endingVersionForQuery = currentLatestVersion.min(fromVersion + maxVersionsPerRpc - 1)
+    if (endingVersionForQuery < currentLatestVersion) {
+      logInfo(s"Reducing ending version for delta sharing rpc of table " +
+        s"${deltaLog.table.toString} from currentLatestVersion" +
+        s"($currentLatestVersion) to endingVersionForQuery($endingVersionForQuery), fromVersion:" +
+        s"$fromVersion, maxVersionsPerRpc: $maxVersionsPerRpc.")
+    }
 
     if (isStartingVersion || !options.readChangeFeed) {
       getTableFileChanges(fromVersion, fromIndex, isStartingVersion, endingVersionForQuery)

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -530,4 +530,40 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
     }
     assert(e.getMessage.contains("LOCATION must be specified"))
   }
+
+  integrationTest("queryDeltaLog test") {
+    val tablePath = testProfileFile.getCanonicalPath + "#share8.default.cdf_table_with_partition"
+
+    val expected = Seq(
+      Row("1", 1, sqlDate("2020-01-01")),
+      Row("2", 2, sqlDate("2020-02-02"))
+    )
+    val result = spark.read.format("deltaSharing").load(tablePath)
+    checkAnswer(result, expected)
+
+    // should work when filtering on partition columns
+    val filtered = spark.read.format("deltaSharing")
+      .load(tablePath)
+      .filter($"birthday" === "2020-01-01")
+
+    checkAnswer(
+      filtered,
+      Seq(
+        Row("1", 1, sqlDate("2020-01-01"))
+      )
+    )
+
+    // should work when filtering on non-partition columns
+    val filtered2 = spark.read.format("deltaSharing")
+      .load(tablePath)
+      .filter($"age" === "2")
+      .select("name", "birthday")
+
+    checkAnswer(
+      filtered2,
+      Seq(
+        Row("2", sqlDate("2020-02-02"))
+      )
+    )
+  }
 }


### PR DESCRIPTION
1. client able to query delta log [done]
2. spark able to parse response with queryDeltaLog[WIP]
3. delta sharing file system able to store and serve the response as deltalog with the help of SparkEnv.get.blockManager
4. delta log able to produce BaseRelation or DataFrame with the response.