### PR TITLE
[Branch-0.6] Double check sortedFetchedFiles and set previousOffset

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -836,6 +836,8 @@ case class DeltaSharingSource(
   }
 
   override def getBatch(startOffsetOption: Option[Offset], end: Offset): DataFrame = {
+    logInfo(s"getBatch with startOffsetOption($startOffsetOption) and end($end), " +
+      s"for table(id:$tableId, name:${deltaLog.table.toString})")
     val endOffset = DeltaSharingSourceOffset(tableId, end)
 
     val (startVersion, startIndex, isStartingVersion, startSourceVersion) = if (


### PR DESCRIPTION
1. Double check sortedFetchedFiles, to ensure we return the correct file set asked by the spark streaming engine.
2. set previousOffset even the returned DataFrame is empty.