### PR TITLE
[main] Double check sortedFetchedFiles and set previousOffset

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -628,7 +628,9 @@ case class DeltaSharingSource(
         // This may happen when there's a protocol change of the table, or optimize of a table where
         // there are no data files with dataChange=true, so the server won't return any files for
         // the version.
-        appendToSortedFetchedFiles(IndexedFile(v, -1, add = null, isSnapshot = false, isLast = true))
+        appendToSortedFetchedFiles(
+          IndexedFile(v, -1, add = null, isSnapshot = false, isLast = true)
+        )
       }
     }
   }


### PR DESCRIPTION
1. Double check sortedFetchedFiles, to ensure we return the correct file set asked by the spark streaming engine.
2. Set previousOffset even the returned DataFrame is empty.
3. Added more logging.

same changes as https://github.com/delta-io/delta-sharing/pull/342 and https://github.com/delta-io/delta-sharing/pull/343