### PR TITLE
Spark client changes for Json V2 predicates.

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -45,6 +45,12 @@ object ConfUtils {
   val CLIENT_CLASS_CONF = "spark.delta.sharing.client.class"
   val CLIENT_CLASS_DEFAULT = "io.delta.sharing.client.DeltaSharingRestClient"
 
+  val JSON_PREDICATE_CONF = "spark.delta.sharing.jsonPredicateHints.enabled"
+  val JSON_PREDICATE_DEFAULT = "true"
+
+  val JSON_PREDICATE_V2_CONF = "spark.delta.sharing.jsonPredicateV2Hints.enabled"
+  val JSON_PREDICATE_V2_DEFAULT = "false"
+
   def numRetries(conf: Configuration): Int = {
     val numRetries = conf.getInt(NUM_RETRIES_CONF, NUM_RETRIES_DEFAULT)
     validateNonNeg(numRetries, NUM_RETRIES_CONF)
@@ -98,6 +104,14 @@ object ConfUtils {
     conf.getConfString(CLIENT_CLASS_CONF, CLIENT_CLASS_DEFAULT)
   }
 
+  def jsonPredicatesEnabled(conf: SQLConf): Boolean = {
+    conf.getConfString(JSON_PREDICATE_CONF, JSON_PREDICATE_DEFAULT).toBoolean
+  }
+
+  def jsonPredicatesV2Enabled(conf: SQLConf): Boolean = {
+    conf.getConfString(JSON_PREDICATE_V2_CONF, JSON_PREDICATE_V2_DEFAULT).toBoolean
+  }
+
   private def toTimeout(timeoutStr: String): Int = {
     val timeoutInSeconds = JavaUtils.timeStringAs(timeoutStr, TimeUnit.SECONDS)
     validateNonNeg(timeoutInSeconds, TIMEOUT_CONF)
@@ -106,7 +120,6 @@ object ConfUtils {
     }
     timeoutInSeconds.toInt
   }
-
 
   private def validateNonNeg(value: Long, conf: String): Unit = {
     if (value < 0L) {

--- a/spark/src/main/scala/io/delta/sharing/spark/filters/OpConverter.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/filters/OpConverter.scala
@@ -41,6 +41,8 @@ import org.apache.spark.sql.types.{
   BooleanType => SqlBooleanType,
   DataType => SqlDataType,
   DateType => SqlDateType,
+  DoubleType => SqlDoubleType,
+  FloatType => SqlFloatType,
   IntegerType => SqlIntegerType,
   LongType => SqlLongType,
   StringType => SqlStringType
@@ -185,6 +187,8 @@ object OpConverter {
       case SqlLongType => OpDataTypes.LongType
       case SqlStringType => OpDataTypes.StringType
       case SqlDateType => OpDataTypes.DateType
+      case SqlDoubleType => OpDataTypes.DoubleType
+      case SqlFloatType => OpDataTypes.FloatType
 
       case _ =>
         throw new IllegalArgumentException("Unsupported data type " + sqlType)

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -170,7 +170,9 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
          |    {"op":"column","name":"cost","valueType":"float"},
          |    {"op":"literal","value":"23.5","valueType":"float"}]}
          |]}""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")
-    spark.sessionState.conf.setConfString("spark.delta.sharing.jsonPredicateV2Hints.enabled", "true")
+    spark.sessionState.conf.setConfString(
+      "spark.delta.sharing.jsonPredicateV2Hints.enabled", "true"
+    )
     fileIndex.listFiles(Seq(partitionSqlEq), Seq(dataSqlEq))
     assert(TestDeltaSharingClient.jsonPredicateHints.size === 1)
     val receivedJson2 = TestDeltaSharingClient.jsonPredicateHints(0)
@@ -179,7 +181,9 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
 
     // With json predicates disabled, we should not get anything.
     spark.sessionState.conf.setConfString("spark.delta.sharing.jsonPredicateHints.enabled", "false")
-    spark.sessionState.conf.setConfString("spark.delta.sharing.jsonPredicateV2Hints.enabled", "false")
+    spark.sessionState.conf.setConfString(
+      "spark.delta.sharing.jsonPredicateV2Hints.enabled", "false"
+    )
     fileIndex.listFiles(Seq(partitionSqlEq), Seq(dataSqlEq))
     assert(TestDeltaSharingClient.jsonPredicateHints.size === 0)
   }

--- a/spark/src/test/scala/io/delta/sharing/spark/filters/JsonPredicateSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/filters/JsonPredicateSuite.scala
@@ -369,6 +369,30 @@ class JsonPredicateSuite extends SparkFunSuite {
     test_op(op)
   }
 
+  test("Float test") {
+    val op = ColumnOp(name = "cost", valueType = "float")
+    op.validate(true)
+
+    // Check that we can convert to json and back.
+    val op_json = JsonUtils.toJson[BaseOp](op)
+    val expected_json = """{"op":"column","name":"cost","valueType":"float"}"""
+    assert(op_json == expected_json)
+    val op_from_json = JsonUtils.fromJson[BaseOp](op_json)
+    op_from_json.validate(true)
+  }
+
+  test("Double test") {
+    val op = LiteralOp(value = "2.0005", valueType = "double")
+    op.validate(true)
+
+    // Check that we can convert to json and back.
+    val op_json = JsonUtils.toJson[BaseOp](op)
+    val expected_json = """{"op":"literal","value":"2.0005","valueType":"double"}"""
+    assert(op_json == expected_json)
+    val op_from_json = JsonUtils.fromJson[BaseOp](op_json)
+    op_from_json.validate(true)
+  }
+
   test("stress test") {
     val op = AndOp(Seq(
       GreaterThanOp(Seq(

--- a/spark/src/test/scala/io/delta/sharing/spark/filters/OpConverterSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/filters/OpConverterSuite.scala
@@ -42,6 +42,8 @@ import org.apache.spark.sql.types.{
   BooleanType => SqlBooleanType,
   DataType => SqlDataType,
   DateType => SqlDateType,
+  DoubleType => SqlDoubleType,
+  FloatType => SqlFloatType,
   IntegerType => SqlIntegerType,
   LongType => SqlLongType,
   StringType => SqlStringType
@@ -274,6 +276,24 @@ class OpConverterSuite extends SparkFunSuite {
     assert(op.evalExpectBoolean(EvalContext(Map.empty)) == false)
     assert(op.evalExpectBoolean(EvalContext(Map("userId" -> "23"))) == true)
     assert(op.evalExpectBoolean(EvalContext(Map("userId" -> "24"))) == false)
+  }
+
+  test("float test") {
+    val sqlColumn = SqlAttributeReference("cost", SqlFloatType)()
+    val sqlLiteral = SqlLiteral("100.5")
+    val sqlGTE = SqlGreaterThanOrEqual(sqlColumn, sqlLiteral)
+
+    val op = OpConverter.convert(Seq(sqlGTE)).get
+    op.validate(true)
+  }
+
+  test("Double test") {
+    val sqlColumn = SqlAttributeReference("cost", SqlDoubleType)()
+    val sqlLiteral = SqlLiteral("10.5")
+    val sqlEq = SqlEqualTo(sqlColumn, sqlLiteral)
+
+    val op = OpConverter.convert(Seq(sqlEq)).get
+    op.validate(true)
   }
 
   test("In test") {


### PR DESCRIPTION
In the PR, we make the following changes.
1) Convert data Filters into json predicates.
2) Combine partiton and data Filters into combined json predicate op using an AND.
3) Add support for Float/Double types.
4) Unit tests.
The changes are off by default and behind a spark config.