### PR TITLE
Pagination for QueryTable from starting_version

### DIFF
--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -552,7 +552,7 @@ class DeltaSharedTable(
     if (endingVersion.isDefined && endingVersion.get > latestVersion) {
       throw DeltaCDFErrors.endVersionAfterLatestVersion(endingVersion.get, latestVersion)
     }
-    // We override (start, end) in subsequent page calls because:
+    // We use (start, end) from the page token instead of the original request because:
     // - Versions that are processed in previous pages can be skipped.
     // - Versions that are committed after the first page call should be ignored, especially
     //   when the endingVersion is not specified and resolved to latestVersion.


### PR DESCRIPTION
- [Part 1](https://github.com/delta-io/delta-sharing/pull/352): Pagination for QueryTable at snapshot
  - [Part 2](https://github.com/delta-io/delta-sharing/pull/353): Pagination for QueryTable from starting_version [[files changed](https://github.com/delta-io/delta-sharing/pull/353/files)]
    - [Part 3](https://github.com/delta-io/delta-sharing/pull/354): Pagination for QueryTableChanges [[files changed](https://github.com/delta-io/delta-sharing/pull/354/files/ac7c8aaa6e011f9ca682e1d45b05c875eaa91834..ecd6bf410cc2d1ce5ded4091266ee899b2a8eb74)]
      - [Part 4](https://github.com/delta-io/delta-sharing/pull/356): Client change [[files changed](https://github.com/delta-io/delta-sharing/pull/356/files/ecd6bf410cc2d1ce5ded4091266ee899b2a8eb74..f6d7d1e1b9b772034953440b6590c543f7d9927d)]

---

Support pagination for QueryTable from starting_version in reference server.

**Note:** this pr is based on #352. Please use the link above to review incremental changes.

This is part 2 for issue https://github.com/delta-io/delta-sharing/issues/351.