### PR TITLE
Query table pagination in Delta Sharing client

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/model.scala
+++ b/client/src/main/scala/io/delta/sharing/client/model.scala
@@ -68,7 +68,7 @@ private[sharing] case class SingleAction(
     remove: RemoveFile = null,
     metaData: Metadata = null,
     protocol: Protocol = null,
-    nextPageToken: NextPageToken = null) {
+    endStreamAction: EndStreamAction = null) {
 
   def unwrap: Action = {
     if (file != null) {
@@ -114,8 +114,11 @@ private[sharing] case class Protocol(minReaderVersion: Int) extends Action {
   override def wrap: SingleAction = SingleAction(protocol = this)
 }
 
-private[sharing] case class NextPageToken(token: String) extends Action {
-  override def wrap: SingleAction = SingleAction(nextPageToken = this)
+private[sharing] case class EndStreamAction(
+    nextPageToken: String,
+    minUrlExpirationTimestamp: java.lang.Long)
+  extends Action {
+  override def wrap: SingleAction = SingleAction(endStreamAction = this)
 }
 
 // A common base class for all file actions.

--- a/client/src/main/scala/io/delta/sharing/client/model.scala
+++ b/client/src/main/scala/io/delta/sharing/client/model.scala
@@ -67,7 +67,8 @@ private[sharing] case class SingleAction(
     cdf: AddCDCFile = null,
     remove: RemoveFile = null,
     metaData: Metadata = null,
-    protocol: Protocol = null) {
+    protocol: Protocol = null,
+    nextPageToken: NextPageToken = null) {
 
   def unwrap: Action = {
     if (file != null) {
@@ -111,6 +112,10 @@ private[sharing] sealed trait Action {
 
 private[sharing] case class Protocol(minReaderVersion: Int) extends Action {
   override def wrap: SingleAction = SingleAction(protocol = this)
+}
+
+private[sharing] case class NextPageToken(token: String) extends Action {
+  override def wrap: SingleAction = SingleAction(nextPageToken = this)
 }
 
 // A common base class for all file actions.

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -55,7 +55,7 @@ object ConfUtils {
   val QUERY_PAGINATION_ENABLED_DEFAULT = "false"
 
   val MAX_FILES_CONF = "spark.delta.sharing.maxFilesPerQueryRequest"
-  val MAX_FILES_DEFAULT = 10000
+  val MAX_FILES_DEFAULT = 100000
 
   def numRetries(conf: Configuration): Int = {
     val numRetries = conf.getInt(NUM_RETRIES_CONF, NUM_RETRIES_DEFAULT)

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -51,6 +51,12 @@ object ConfUtils {
   val JSON_PREDICATE_V2_CONF = "spark.delta.sharing.jsonPredicateV2Hints.enabled"
   val JSON_PREDICATE_V2_DEFAULT = "false"
 
+  val QUERY_PAGINATION_ENABLED_CONF = "spark.delta.sharing.queryPagination.enabled"
+  val QUERY_PAGINATION_ENABLED_DEFAULT = "false"
+
+  val MAX_FILES_CONF = "spark.delta.sharing.maxFilesPerQueryRequest"
+  val MAX_FILES_DEFAULT = 10000
+
   def numRetries(conf: Configuration): Int = {
     val numRetries = conf.getInt(NUM_RETRIES_CONF, NUM_RETRIES_DEFAULT)
     validateNonNeg(numRetries, NUM_RETRIES_CONF)
@@ -112,6 +118,16 @@ object ConfUtils {
     conf.getConfString(JSON_PREDICATE_V2_CONF, JSON_PREDICATE_V2_DEFAULT).toBoolean
   }
 
+  def queryTablePaginationEnabled(conf: SQLConf): Boolean = {
+    conf.getConfString(QUERY_PAGINATION_ENABLED_CONF, QUERY_PAGINATION_ENABLED_DEFAULT).toBoolean
+  }
+
+  def maxFilesPerQueryRequest(conf: SQLConf): Int = {
+    val maxFiles = conf.getConfString(MAX_FILES_CONF, MAX_FILES_DEFAULT.toString).toInt
+    validatePositive(maxFiles, MAX_FILES_CONF)
+    maxFiles
+  }
+
   private def toTimeout(timeoutStr: String): Int = {
     val timeoutInSeconds = JavaUtils.timeStringAs(timeoutStr, TimeUnit.SECONDS)
     validateNonNeg(timeoutInSeconds, TIMEOUT_CONF)
@@ -124,6 +140,12 @@ object ConfUtils {
   private def validateNonNeg(value: Long, conf: String): Unit = {
     if (value < 0L) {
       throw new IllegalArgumentException(conf + " must not be negative")
+    }
+  }
+
+  private def validatePositive(value: Int, conf: String): Unit = {
+    if (value <= 0) {
+      throw new IllegalArgumentException(conf + " must be positive")
     }
   }
 }

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -42,7 +42,9 @@ class TestDeltaSharingClient(
     maxRetryDuration: Long = Long.MaxValue,
     sslTrustAll: Boolean = false,
     forStreaming: Boolean = false,
-    responseFormat: String = DeltaSharingOptions.RESPONSE_FORMAT_PARQUET
+    responseFormat: String = DeltaSharingOptions.RESPONSE_FORMAT_PARQUET,
+    queryTablePaginationEnabled: Boolean = false,
+    maxFilesPerReq: Int = 10000
   ) extends DeltaSharingClient {
 
   private val metadataString =


### PR DESCRIPTION
- [Part 1](https://github.com/delta-io/delta-sharing/pull/352): Pagination for QueryTable at snapshot
  - [Part 2](https://github.com/delta-io/delta-sharing/pull/353): Pagination for QueryTable from starting_version
    - [Part 3](https://github.com/delta-io/delta-sharing/pull/354): Pagination for QueryTableChanges
      - [Part 4](https://github.com/delta-io/delta-sharing/pull/362): Rename JSON object to endStreamAction and return minUrlExpirationTimestamp
        - [Part 5](https://github.com/delta-io/delta-sharing/pull/356): Delta Sharing client changes

---

Change delta sharing client to send paginated request by looping internally to fetch all pages.

This is part 5 for issue https://github.com/delta-io/delta-sharing/issues/351