### PR TITLE
Use JsonRawValue in fasterxml.jackson instead of codehaus.jackson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,6 @@ lazy val spark = (project in file("spark")) settings(
   releaseSettings,
   libraryDependencies ++= Seq(
     "org.apache.httpcomponents" % "httpclient" % "4.5.13",
-    "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.13",
     "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
     "org.apache.spark" %% "spark-catalyst" % sparkVersion % "test" classifier "tests",
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",

--- a/spark/src/main/scala/io/delta/sharing/spark/model.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/model.scala
@@ -16,9 +16,8 @@
 
 package io.delta.sharing.spark.model
 
-import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.{JsonInclude, JsonRawValue}
 import org.apache.spark.sql.types.{DataType, LongType, StringType}
-import org.codehaus.jackson.annotate.JsonRawValue
 
 // Information about CDF columns.
 private[sharing] object CDFColumnInfo {

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceCDFSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceCDFSuite.scala
@@ -562,21 +562,28 @@ class DeltaSharingSourceCDFSuite extends QueryTest
         query.stop()
       }
 
-      // There are 5 checkpoints for 5 getBatch(), which is caused by maxFilesPerTrigger = 1,
-      // remove the latest 3 checkpoints.
-      val checkpointFiles = FileUtils.listFiles(checkpointDir, null, true).asScala
-      checkpointFiles.foreach{ f =>
-        if (!f.isDirectory() && (f.getCanonicalPath.endsWith("2") ||
-          f.getCanonicalPath.endsWith("3") || f.getCanonicalPath.endsWith("4"))) {
-          f.delete()
-        }
-      }
-
       val restartQuery = withStreamReaderAtVersion()
         .option("maxFilesPerTrigger", "1")
         .load().select("age").writeStream.format("console")
         .option("checkpointLocation", checkpointDir.getCanonicalPath)
         .start()
+      // There are 5 checkpoints for 5 getBatch(), which is caused by maxFilesPerTrigger = 1,
+      // remove the latest 3 checkpoints.
+      val checkpointFiles = FileUtils.listFiles(checkpointDir, null, true).asScala
+      checkpointFiles.foreach{ f =>
+        if (!f.isDirectory() && (f.getCanonicalPath.endsWith("2") ||
+          f.getCanonicalPath.endsWith("3") || f.getCanonicalPath.endsWith("4") ||
+          f.getCanonicalPath.endsWith("2.crc") || f.getCanonicalPath.endsWith("3.crc") ||
+          f.getCanonicalPath.endsWith("4.crc") || f.getCanonicalPath.endsWith("metadata.crc"))) {
+          f.delete()
+        }
+
+        // SparkStructuredStreaming requires query id match to reuse a checkpoint.
+        if (f.getCanonicalPath.endsWith("metadata")) {
+          FileUtils.writeStringToFile(f, s"""{"id":"${restartQuery.id}"}""")
+        }
+      }
+
       try {
         restartQuery.processAllAvailable()
         val progress = restartQuery.recentProgress.filter(_.numInputRows != 0)

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -452,29 +452,39 @@ class DeltaSharingSourceSuite extends QueryTest
       )
       checkAnswer(spark.read.format("parquet").load(outputDir.getCanonicalPath), expected)
 
-      // There are 4 checkpoints, remove the latest 2.
-      val checkpointFiles = FileUtils.listFiles(checkpointDir, null, true).asScala
-      checkpointFiles.foreach{ f =>
-        if (!f.isDirectory() &&
-          (f.getCanonicalPath.endsWith("2") || f.getCanonicalPath.endsWith("3"))) {
-          f.delete()
-        }
-      }
-
-      val restartQuery = withStreamReaderAtVersion()
+      val newQuery = withStreamReaderAtVersion()
         .option("maxFilesPerTrigger", "1")
         .load().writeStream.format("console")
         .option("checkpointLocation", checkpointDir.getCanonicalPath)
         .start()
+
+      // There are 4 checkpoints, remove the latest 2.
+      val checkpointFiles = FileUtils.listFiles(checkpointDir, null, true).asScala
+      checkpointFiles.foreach{ f =>
+        if (!f.isDirectory() &&
+          (f.getCanonicalPath.endsWith("2") || f.getCanonicalPath.endsWith("3") ||
+            f.getCanonicalPath.endsWith("2.crc") || f.getCanonicalPath.endsWith("3.crc") ||
+            f.getCanonicalPath.endsWith("metadata.crc"))) {
+          f.delete()
+        }
+        // The metadata contains a single line of json, which is the queryid:
+        //   {"id":"aaaabbbb-cccc-dddd-eeee-ffffgggghhhh"}
+        // SparkStructuredStreaming requires query id match to reuse a checkpoint.
+        if (f.getCanonicalPath.endsWith("metadata")) {
+          FileUtils.writeStringToFile(f, s"""{"id":"${newQuery.id}"}""")
+        }
+      }
+
+
       try {
-        restartQuery.processAllAvailable()
-        val progress = restartQuery.recentProgress.filter(_.numInputRows != 0)
+        newQuery.processAllAvailable()
+        val progress = newQuery.recentProgress.filter(_.numInputRows != 0)
         assert(progress.length === 2)
         progress.foreach {
           p => assert(p.numInputRows === 1)
         }
       } finally {
-        restartQuery.stop()
+        newQuery.stop()
       }
     }
   }


### PR DESCRIPTION
1. Use JsonRawValue in fasterxml.jackson instead of codehaus.jackson, to fix vulnerability check in DBR.
2. Fix streaming test failures with checkpoint caused by upgrade of new dependency.