### PR TITLE
Fix two build errors: use a static Cast init function and isinstance for type comparison in python 

### DIFF
--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -183,7 +183,7 @@ class DeltaSharingReader:
 
         if for_cdf:
             # Add the change type col name to non cdc actions.
-            if type(action) != AddCdcFile:
+            if not isinstance(action, AddCdcFile):
                 pdf[DeltaSharingReader._change_type_col_name()] = action.get_change_type_col_value()
 
             # If available, add timestamp and version columns from the action.

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
@@ -102,8 +102,8 @@ trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
   // The input string is quite flexible, and can be in any timezone, examples of accepted format:
   // "2022", "2022-01-01", "2022-01-01 00:00:00" "2022-01-01T00:00:00-08:00", etc.
   private def getFormattedTimestamp(str: String): String = {
-    val castResult = Cast(
-    Literal(str), TimestampType, Option(SQLConf.get.sessionLocalTimeZone), false).eval()
+    val castResult = new Cast(
+    Literal(str), TimestampType, Option(SQLConf.get.sessionLocalTimeZone)).eval()
     if (castResult == null) {
       throw DeltaSharingErrors.timestampInvalid(str)
     }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
@@ -103,7 +103,7 @@ trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
   // "2022", "2022-01-01", "2022-01-01 00:00:00" "2022-01-01T00:00:00-08:00", etc.
   private def getFormattedTimestamp(str: String): String = {
     val castResult = Cast(
-    Literal(str), TimestampType, Option(SQLConf.get.sessionLocalTimeZone)).eval()
+    Literal(str), TimestampType, Option(SQLConf.get.sessionLocalTimeZone), false).eval()
     if (castResult == null) {
       throw DeltaSharingErrors.timestampInvalid(str)
     }


### PR DESCRIPTION
Fix two build errors: 

1. use a static Cast init function to allow delta-sharing-spark work for multiple spark versions. 
2. use isinstance for type comparison in python. 