### PR TITLE
Introduce EndStreamAction and return minUrlExpirationTimestamp for paginated request

### DIFF
--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -26,7 +26,7 @@ case class SingleAction(
     remove: RemoveFile = null,
     metaData: Metadata = null,
     protocol: Protocol = null,
-    nextPageToken: NextPageToken = null) {
+    endStreamAction: EndStreamAction = null) {
 
   def unwrap: Action = {
     if (file != null) {
@@ -41,8 +41,8 @@ case class SingleAction(
       metaData
     } else if (protocol != null) {
       protocol
-    } else if (nextPageToken != null) {
-      nextPageToken
+    } else if (endStreamAction != null) {
+      endStreamAction
     } else {
       null
     }
@@ -134,12 +134,18 @@ case class RemoveFile(
 }
 
 /**
- * A token to retrieve the subsequent page of a query. The server that supports pagination will
- * return a nextPageToken at the end of the response when there are more files available than
- * the page size specified by the user.
+ * An action that is returned as the last line of the streaming response. It allows the server
+ * to include additional data that might be dynamically generated while the streaming message
+ * is sent, such as:
+ *  - nextPageToken: a token used to retrieve the subsequent page of a query
+ *  - minUrlExpirationTimestamp: the minimum url expiration timestamp of the urls returned in
+ *    current response
  */
-case class NextPageToken(token: String) extends Action {
-  override def wrap: SingleAction = SingleAction(nextPageToken = this)
+case class EndStreamAction(
+    nextPageToken: String,
+    minUrlExpirationTimestamp: java.lang.Long
+  ) extends Action {
+  override def wrap: SingleAction = SingleAction(endStreamAction = this)
 }
 
 object Action {


### PR DESCRIPTION
- [Part 1](https://github.com/delta-io/delta-sharing/pull/352): Pagination for QueryTable at snapshot
  - [Part 2](https://github.com/delta-io/delta-sharing/pull/353): Pagination for QueryTable from starting_version
    - [Part 3](https://github.com/delta-io/delta-sharing/pull/354): Pagination for QueryTableChanges
      - [Part 4](https://github.com/delta-io/delta-sharing/pull/362): Rename JSON object to endStreamAction and return minUrlExpirationTimestamp
        - [Part 5](https://github.com/delta-io/delta-sharing/pull/356): Delta Sharing client changes

---

Introduce a new action type `EndStreamAction` in streaming response. This action should always be returned as the last line. For now, it includes two optional fields:

- nextPageToken: used to retrieve the subsequent page
- minUrlExpirationTimestamp: the minimum expiration timestamp of the pre-signed urls returned in the response

To make the change backwards compatible, we will return it only when `maxFiles` is specified (since it only contains pagination related fields for now). As we expand its usage later (e.g. to return proper error message), we can add it to the `deltaSharingCapabilities` header.

This is part 4 for issue https://github.com/delta-io/delta-sharing/issues/351