### PR TITLE
Fix a couple build issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,10 +46,8 @@ lazy val client = (project in file("client")) settings(
   name := "delta-sharing-client",
   commonSettings,
   scalaStyleSettings,
-  releaseSettings,
   libraryDependencies ++= Seq(
     "org.apache.httpcomponents" % "httpclient" % "4.5.13",
-    "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.13",
     "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
     "org.apache.spark" %% "spark-catalyst" % sparkVersion % "test" classifier "tests",
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",

--- a/client/src/main/scala/io/delta/sharing/client/model.scala
+++ b/client/src/main/scala/io/delta/sharing/client/model.scala
@@ -16,9 +16,8 @@
 
 package io.delta.sharing.client.model
 
-import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.{JsonInclude, JsonRawValue}
 import org.apache.spark.sql.types.{DataType, LongType, StringType}
-import org.codehaus.jackson.annotate.JsonRawValue
 
 // Information about CDF columns.
 private[sharing] object CDFColumnInfo {

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -183,7 +183,7 @@ class DeltaSharingReader:
 
         if for_cdf:
             # Add the change type col name to non cdc actions.
-            if type(action) != AddCdcFile:
+            if not isinstance(action, AddCdcFile):
                 pdf[DeltaSharingReader._change_type_col_name()] = action.get_change_type_col_value()
 
             # If available, add timestamp and version columns from the action.

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
@@ -104,7 +104,7 @@ trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
   // The input string is quite flexible, and can be in any timezone, examples of accepted format:
   // "2022", "2022-01-01", "2022-01-01 00:00:00" "2022-01-01T00:00:00-08:00", etc.
   private def getFormattedTimestamp(str: String): String = {
-    val castResult = Cast(
+    val castResult = new Cast(
     Literal(str), TimestampType, Option(SQLConf.get.sessionLocalTimeZone)).eval()
     if (castResult == null) {
       throw DeltaSharingErrors.timestampInvalid(str)


### PR DESCRIPTION
1. Use JsonRawValue in fasterxml.jackson instead of codehaus.jackson, to fix vulnerability check in DBR.
2. use a static Cast init function to allow delta-sharing-spark work for multiple spark versions.
3. use isinstance for type comparison in python.