### PR TITLE
Protocol update: content-type request header in /query should be optional

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1658,7 +1658,11 @@ This is the API for clients to read data from a table.
 </tr>
 <tr>
 <td>Method</td>
-<td>`POST`</td>
+<td>
+
+`POST`
+
+</td>
 </tr>
 <tr>
 <td>Headers</td>
@@ -1666,7 +1670,7 @@ This is the API for clients to read data from a table.
 
 `Authorization: Bearer {token}`
 
-`Content-Type: application/json; charset=utf-8`
+Optional: `Content-Type: application/json; charset=utf-8`
 
 </td>
 </tr>


### PR DESCRIPTION
Many Delta Sharing connectors already do not send over the content-type header in the request. Existing Delta Sharing servers already accept requests without the header. This guidance will further ensure that existing connectors do not break and give more flexibility for the server.

Also fixed some formatting issues.