### PR TITLE
misc: api-description.yml license aligned with delta-sharing

### DIFF
--- a/delta-sharing-protocl-api-description.yml
+++ b/delta-sharing-protocl-api-description.yml
@@ -7,9 +7,6 @@ info:
   title: Delta Sharing Protocol
   contact:
     email: ""
-  license:
-    name: "AGPL v3.0"
-    url: "https://www.gnu.org/licenses/agpl-3.0.en.html"
 
 servers:
   - url: 'http://localhost:8000/api/v1'


### PR DESCRIPTION
In discussion with original author of
delta-sharing-protocl-api-description.yml file (R. Tyler Croy), listing this file as AGPL 3.0 was a clerical error when it was brought over from its original project.
This modification fixes the clerical error by removing the license information from the file, thus aligning it with the license of the project. This is being done at the request of the author.

Here is the exchange with @rtyler that prompted this mod: "
That's a good catch @Christian Daudt , I originally authored that file as part of riverbank, a rust delta-sharing server which I had originally licensed as AGPL before it entered the delta-incubator.
When I updated to the Apache license I forgot about that little note, that's a clerical error and can be cleaned up.
"