### PR TITLE
Add timestamp support in spark connector for V2 predicates.

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/filters/JsonPredicates.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/filters/JsonPredicates.scala
@@ -38,9 +38,10 @@ object OpDataTypes {
   val DateType = "date"
   val FloatType = "float"
   val DoubleType = "double"
+  val TimestampType = "timestamp"
 
   val supportedTypes = Set(BoolType, IntType, LongType, StringType, DateType)
-  val supportedTypesV2 = supportedTypes ++ Set(FloatType, DoubleType)
+  val supportedTypesV2 = supportedTypes ++ Set(FloatType, DoubleType, TimestampType)
 
   // Returns true if the specified valueType is supported.
   def isSupportedType(valueType: String, forV2: Boolean): Boolean = {


### PR DESCRIPTION
In this PR, we add timestamp support in V2 predicates.