### PR TITLE
Fix bug where to_pandas doesn't properly handle the case when column names between Delta and parquet metadata are different in casing

### DIFF
--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -112,7 +112,7 @@ class DeltaSharingReader:
             ignore_index=True,
             copy=False,
         )
-        
+
         col_map = {}
         for col in merged.columns:
             col_map[col.lower()] = col

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -107,8 +107,8 @@ def test_to_pandas_partitioned(tmp_path):
             metadata = Metadata(
                 schema_string=(
                     '{"fields":['
-                    '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
-                    '{"metadata":{},"name":"b","nullable":true,"type":"string"}'
+                    '{"metadata":{},"name":"A","nullable":true,"type":"long"},'
+                    '{"metadata":{},"name":"B","nullable":true,"type":"string"}'
                     '],"type":"struct"}'
                 )
             )
@@ -116,14 +116,14 @@ def test_to_pandas_partitioned(tmp_path):
                 AddFile(
                     url=str(tmp_path / "pdf1.parquet"),
                     id="pdf1",
-                    partition_values={"b": "x"},
+                    partition_values={"B": "x"},
                     size=0,
                     stats="",
                 ),
                 AddFile(
                     url=str(tmp_path / "pdf2.parquet"),
                     id="pdf2",
-                    partition_values={"b": "y"},
+                    partition_values={"B": "y"},
                     size=0,
                     stats="",
                 ),
@@ -136,9 +136,9 @@ def test_to_pandas_partitioned(tmp_path):
     pdf = reader.to_pandas()
 
     expected1 = pdf1.copy()
-    expected1["b"] = "x"
+    expected1["B"] = "x"
     expected2 = pdf2.copy()
-    expected2["b"] = "y"
+    expected2["B"] = "y"
     expected = pd.concat([expected1, expected2]).reset_index(drop=True)
 
     pd.testing.assert_frame_equal(pdf, expected)


### PR DESCRIPTION
There's a bug where calling `to_pandas` on a partitioned table with differing Delta and parquet metadata, the resulting pandas dataframe would result in the columns being None. Specifically the difference in the metadata is the casing in the column names. 

ex: 
Delta columns: ["MARKET", "DATA", "branch"]
Parquet columns: ["market", "data", "branch"]

This PR fixes that issue by performing a case-insensitive lookup of the columns.