### PR TITLE
Support refresh token in delta sharing server

### DIFF
--- a/server/src/main/protobuf/protocol.proto
+++ b/server/src/main/protobuf/protocol.proto
@@ -54,6 +54,15 @@ message QueryTableRequest {
     optional int32 maxFiles = 9;
     // The page token used to retrieve the subsequent page.
     optional string pageToken = 10;
+    // Whether or not to return a refresh token in the response. Only used in latest snapshot query
+    // AND first page query. For long running queries, delta sharing spark may make additional request
+    // to refresh pre-signed urls, and there might be table changes between the initial request and
+    // the refresh request. The refresh token will contain version information to make sure that
+    // the refresh request returns the same set of files.
+    optional bool includeRefreshToken = 11;
+    // The refresh token used to refresh pre-signed urls. Only used in latest snapshot query AND
+    // first page query.
+    optional string refreshToken = 12;
 
     // Only one of the three parameters can be supported in a single query.
     // If none of them is specified, the query is for the latest version.
@@ -135,4 +144,14 @@ message QueryTablePageToken {
     optional int64 expiration_timestamp = 7;
     // The latest version of the table when the first page request is received.
     optional int64 latest_version = 8;
+}
+
+// Define a special class to generate the refresh token for latest snapshot query.
+message RefreshToken {
+    // Id of the table being queried.
+    optional string id = 1;
+    // Only used in queryTable at snapshot, refers to the version being queried.
+    optional int64 version = 2;
+    // The expiration timestamp of the refresh token in milliseconds.
+    optional int64 expiration_timestamp = 3;
 }

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -321,6 +321,8 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       endingVersion = None,
       maxFiles = None,
       pageToken = None,
+      includeRefreshToken = false,
+      refreshToken = None,
       responseFormat = responseFormat)
     streamingOutput(Some(v), responseFormat, actions)
   }
@@ -336,8 +338,8 @@ class DeltaSharingService(serverConfig: ServerConfig) {
     val capabilitiesMap = getDeltaSharingCapabilitiesMap(
       req.headers().get(DELTA_SHARING_CAPABILITIES_HEADER)
     )
-    val numVersionParams = Seq(request.version, request.timestamp, request.startingVersion)
-      .filter(_.isDefined).size
+    val numVersionParams =
+      Seq(request.version, request.timestamp, request.startingVersion).count(_.isDefined)
     if (numVersionParams > 1) {
       throw new DeltaSharingIllegalArgumentException(ErrorStrings.multipleParametersSetErrorMsg(
         Seq("version", "timestamp", "startingVersion"))
@@ -351,6 +353,26 @@ class DeltaSharingService(serverConfig: ServerConfig) {
     }
     if (request.maxFiles.exists(_ <= 0)) {
       throw new DeltaSharingIllegalArgumentException("maxFiles must be positive.")
+    }
+    if (numVersionParams > 0 && request.includeRefreshToken.contains(true)) {
+      throw new DeltaSharingIllegalArgumentException(
+        "includeRefreshToken must be used in latest version query."
+      )
+    }
+    if (request.pageToken.isDefined && request.includeRefreshToken.contains(true)) {
+      throw new DeltaSharingIllegalArgumentException(
+        "includeRefreshToken must be used in the first page request."
+      )
+    }
+    if (numVersionParams > 0 && request.refreshToken.isDefined) {
+      throw new DeltaSharingIllegalArgumentException(
+        "refreshToken must be used in latest version query."
+      )
+    }
+    if (request.pageToken.isDefined && request.refreshToken.isDefined) {
+      throw new DeltaSharingIllegalArgumentException(
+        "refreshToken must be used in the first page request."
+      )
     }
 
     val start = System.currentTimeMillis
@@ -387,6 +409,8 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       request.endingVersion,
       request.maxFiles,
       request.pageToken,
+      request.includeRefreshToken.getOrElse(false),
+      request.refreshToken,
       responseFormat = responseFormat)
     if (version < tableConfig.startVersion) {
       throw new DeltaSharingIllegalArgumentException(

--- a/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
+++ b/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
@@ -61,7 +61,9 @@ case class ServerConfig(
     // The maximum page size permitted by queryTable/queryTableChanges API.
     @BeanProperty var queryTablePageSizeLimit: Int,
     // The TTL of the page token generated in queryTable/queryTableChanges API (in milliseconds).
-    @BeanProperty var queryTablePageTokenTtlMs: Int
+    @BeanProperty var queryTablePageTokenTtlMs: Int,
+    // The TTL of the refresh token generated in queryTable API (in milliseconds).
+    @BeanProperty var refreshTokenTtlMs: Int
 ) extends ConfigItem {
   import ServerConfig._
 
@@ -82,7 +84,8 @@ case class ServerConfig(
       evaluateJsonPredicateHints = false,
       requestTimeoutSeconds = 30,
       queryTablePageSizeLimit = 10000,
-      queryTablePageTokenTtlMs = 259200000 // 3 days
+      queryTablePageTokenTtlMs = 259200000, // 3 days
+      refreshTokenTtlMs = 3600000 // 1 hour
     )
   }
 

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -137,11 +137,13 @@ case class RemoveFile(
  * An action that is returned as the last line of the streaming response. It allows the server
  * to include additional data that might be dynamically generated while the streaming message
  * is sent, such as:
+ *  - refreshToken: a token used to refresh pre-signed urls for a long running query
  *  - nextPageToken: a token used to retrieve the subsequent page of a query
  *  - minUrlExpirationTimestamp: the minimum url expiration timestamp of the urls returned in
  *    current response
  */
 case class EndStreamAction(
+    refreshToken: String,
     nextPageToken: String,
     minUrlExpirationTimestamp: java.lang.Long
   ) extends Action {

--- a/server/src/universal/conf/delta-sharing-server.yaml.template
+++ b/server/src/universal/conf/delta-sharing-server.yaml.template
@@ -61,3 +61,5 @@ evaluateJsonPredicateHints: false
 queryTablePageSizeLimit: 10000
 # The TTL of the page token generated in queryTable/queryTableChanges API (in milliseconds).
 queryTablePageTokenTtlMs: 259200000
+# The TTL of the refresh token generated in queryTable API (in milliseconds).
+queryTablePageTokenTtlMs: 3600000


### PR DESCRIPTION
Use this [link]() to review incremental changes.

- [stack/refresh-token-server]() [[file changed]()]
  - [stack/refresh-token-client]() [[file changed]()]
    - [stack/refresh-token-spark]() [[file changed]()]

---

This pr adds refresh token support in delta sharing server. This is part 1 of https://github.com/delta-io/delta-sharing/issues/383.