### PR TITLE
Support refresh token in delta sharing client

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -412,11 +412,12 @@ class DeltaSharingRestClient(
       logWarning("EndStreamAction is not returned in the response for paginated query.")
     }
     // Extract refresh token if available
-    val refreshToken = if (endAction != null) {
-      Option(endAction.refreshToken)
-    } else {
-      None
-    }
+    val refreshToken =
+      if (endAction != null && endAction.refreshToken != null && endAction.refreshToken.nonEmpty) {
+        Some(endAction.refreshToken)
+      } else {
+        None
+      }
     val minUrlExpirationTimestamp = if (endAction != null) {
       Option(endAction.minUrlExpirationTimestamp)
     } else {

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -271,7 +271,7 @@ class DeltaSharingRestClient(
     val encodedTableName = URLEncoder.encode(table.name, "UTF-8")
     val target = getTargetUrl(
       s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query")
-    val request = QueryTableRequest(
+    val request: QueryTableRequest = QueryTableRequest(
       predicateHints = predicates,
       limitHint = limit,
       version = versionAsOf,
@@ -339,7 +339,7 @@ class DeltaSharingRestClient(
     val encodedTableName = URLEncoder.encode(table.name, "UTF-8")
     val target = getTargetUrl(
       s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query")
-    val request = QueryTableRequest(
+    val request: QueryTableRequest = QueryTableRequest(
       predicateHints = Nil,
       limitHint = None,
       version = None,

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -294,7 +294,9 @@ class DeltaSharingRestClient(
       val (version, respondedFormat, lines) = getNDJson(target, request)
       val (filteredLines, endStreamAction) = maybeExtractEndStreamAction(lines)
       val refreshTokenOpt = endStreamAction.flatMap { e =>
-        Option(e.refreshToken)
+        Option(e.refreshToken).flatMap { token =>
+          if (token.isEmpty) None else Some(token)
+        }
       }
       if (includeRefreshToken && refreshTokenOpt.isEmpty) {
         logWarning("includeRefreshToken=true but refresh token is not returned.")
@@ -403,7 +405,9 @@ class DeltaSharingRestClient(
     val metadata = filteredLines(1)
     // Extract refresh token if available
     val refreshToken = endStreamAction.flatMap { e =>
-      Option(e.refreshToken)
+      Option(e.refreshToken).flatMap { token =>
+        if (token.isEmpty) None else Some(token)
+      }
     }
     val minUrlExpirationTimestamp = endStreamAction.flatMap { e =>
       Option(e.minUrlExpirationTimestamp)

--- a/client/src/main/scala/io/delta/sharing/client/model.scala
+++ b/client/src/main/scala/io/delta/sharing/client/model.scala
@@ -50,7 +50,8 @@ private[sharing] case class DeltaTableFiles(
     cdfFiles: Seq[AddCDCFile] = Nil,
     removeFiles: Seq[RemoveFile] = Nil,
     additionalMetadatas: Seq[Metadata] = Nil,
-    lines: Seq[String] = Nil)
+    lines: Seq[String] = Nil,
+    refreshToken: Option[String] = None)
 
 private[sharing] case class Share(name: String)
 
@@ -114,6 +115,7 @@ private[sharing] case class Protocol(minReaderVersion: Int) extends Action {
 }
 
 private[sharing] case class EndStreamAction(
+    refreshToken: String,
     nextPageToken: String,
     minUrlExpirationTimestamp: java.lang.Long)
   extends Action {

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientDeltaSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientDeltaSuite.scala
@@ -100,14 +100,16 @@ class DeltaSharingRestClientDeltaSuite extends DeltaSharingIntegrationTest {
       assert(tableFiles.lines(2).contains("""","id":"9f1a49539c5cffe1ea7f9e055d5c003c","partitionValues":{"date":"2021-04-28"},"size":573,"modificationTime":1619652839000,"dataChange":false,"stats":"{\"numRecords\":1,\"minValues\":{\"eventTime\":\"2021-04-28T23:33:57.955Z\"},\"maxValues\":{\"eventTime\":\"2021-04-28T23:33:57.955Z\"},\"nullCount\":{\"eventTime\":0}}","expirationTimestamp":"""))
       assert(tableFiles.lines(3).startsWith("""{"add":{"path":"https://delta-exchange-test.s3.us-west-2.amazonaws.com/delta-exchange-test/table2/date%3D2021-04-28/part-00000-591723a8-6a27-4240-a90e-57426f4736d2.c000.snappy.parquet?X-Amz-Algorithm="""))
       assert(tableFiles.lines(3).contains("""","id":"cd2209b32f5ed5305922dd50f5908a75","partitionValues":{"date":"2021-04-28"},"size":573,"modificationTime":1619652832000,"dataChange":false,"stats":"{\"numRecords\":1,\"minValues\":{\"eventTime\":\"2021-04-28T23:33:48.719Z\"},\"maxValues\":{\"eventTime\":\"2021-04-28T23:33:48.719Z\"},\"nullCount\":{\"eventTime\":0}}","expirationTimestamp":"""))
+      // Refresh token should be returned in latest snapshot query
       assert(tableFiles.refreshToken.nonEmpty)
     }
 
     val client = getDeltaSharingClientWithDeltaResponse
+    val table = Table(name = "table2", schema = "default", share = "share2")
     try {
       val tableFiles =
         client.getFiles(
-          table = Table(name = "table2", schema = "default", share = "share2"),
+          table,
           predicates = Nil,
           limit = None,
           versionAsOf = None,
@@ -116,7 +118,7 @@ class DeltaSharingRestClientDeltaSuite extends DeltaSharingIntegrationTest {
           refreshToken = None)
       verifyTableFiles(tableFiles)
       val refreshedTableFiles = client.getFiles(
-        table = Table(name = "table2", schema = "default", share = "share2"),
+        table,
         predicates = Nil,
         limit = None,
         versionAsOf = None,
@@ -147,6 +149,7 @@ class DeltaSharingRestClientDeltaSuite extends DeltaSharingIntegrationTest {
       assert(tableFiles.lines(2).startsWith(commonPrefix))
       assert(tableFiles.lines(3).startsWith(commonPrefix))
       assert(tableFiles.lines(4).startsWith(commonPrefix))
+      // Refresh token shouldn't be returned in version query
       assert(tableFiles.refreshToken.isEmpty)
     } finally {
       client.close()

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -295,6 +295,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       )
       assert(expectedFiles == tableFiles.files.toList)
       assert(tableFiles.files(0).expirationTimestamp > System.currentTimeMillis())
+      // Refresh token should be returned in latest snapshot query
       assert(tableFiles.refreshToken.nonEmpty)
     }
 
@@ -305,10 +306,11 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         queryTablePaginationEnabled = paginationEnabled,
         maxFilesPerReq = 1
       )
+      val table = Table(name = "table2", schema = "default", share = "share2")
       try {
         val tableFiles =
           client.getFiles(
-            table = Table(name = "table2", schema = "default", share = "share2"),
+            table,
             predicates = Nil,
             limit = None,
             versionAsOf = None,
@@ -319,7 +321,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         verifyTableFiles(tableFiles)
         val refreshedTableFiles =
           client.getFiles(
-            table = Table(name = "table2", schema = "default", share = "share2"),
+            table,
             predicates = Nil,
             limit = None,
             versionAsOf = None,
@@ -382,6 +384,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       )
       assert(expectedFiles == tableFiles.files.toList)
       assert(tableFiles.files(0).expirationTimestamp > System.currentTimeMillis())
+      // Refresh token shouldn't be returned in version query
+      assert(tableFiles.refreshToken.isEmpty)
     } finally {
       client.close()
     }

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -25,6 +25,7 @@ import io.delta.sharing.client.model.{
   AddCDCFile,
   AddFile,
   AddFileForCDF,
+  DeltaTableFiles,
   Format,
   Metadata,
   Protocol,
@@ -260,6 +261,43 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
   }
 
   integrationTest("getFiles") {
+    def verifyTableFiles(tableFiles: DeltaTableFiles): Unit = {
+      assert(tableFiles.version == 2)
+      assert(Protocol(minReaderVersion = 1) == tableFiles.protocol)
+      val expectedMetadata = Metadata(
+        id = "f8d5c169-3d01-4ca3-ad9e-7dc3355aedb2",
+        format = Format(),
+        schemaString =
+          """{"type":"struct","fields":[{"name":"eventTime","type":"timestamp","nullable":true,"metadata":{}},{"name":"date","type":"date","nullable":true,"metadata":{}}]}""",
+        partitionColumns = Seq("date")
+      )
+      assert(expectedMetadata == tableFiles.metadata)
+      assert(tableFiles.files.size == 2)
+      val expectedFiles = Seq(
+        AddFile(
+          url = tableFiles.files(0).url,
+          expirationTimestamp = tableFiles.files(0).expirationTimestamp,
+          id = "9f1a49539c5cffe1ea7f9e055d5c003c",
+          partitionValues = Map("date" -> "2021-04-28"),
+          size = 573,
+          stats =
+            """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:33:57.955Z"},"maxValues":{"eventTime":"2021-04-28T23:33:57.955Z"},"nullCount":{"eventTime":0}}"""
+        ),
+        AddFile(
+          url = tableFiles.files(1).url,
+          expirationTimestamp = tableFiles.files(1).expirationTimestamp,
+          id = "cd2209b32f5ed5305922dd50f5908a75",
+          partitionValues = Map("date" -> "2021-04-28"),
+          size = 573,
+          stats =
+            """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"maxValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"nullCount":{"eventTime":0}}"""
+        )
+      )
+      assert(expectedFiles == tableFiles.files.toList)
+      assert(tableFiles.files(0).expirationTimestamp > System.currentTimeMillis())
+      assert(tableFiles.refreshToken.nonEmpty)
+    }
+
     Seq(true, false).foreach { paginationEnabled =>
       val client = new DeltaSharingRestClient(
         testProfileProvider,
@@ -270,46 +308,26 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       try {
         val tableFiles =
           client.getFiles(
-            Table(name = "table2", schema = "default", share = "share2"),
-            Nil,
-            None,
-            None,
-            None,
-            None
+            table = Table(name = "table2", schema = "default", share = "share2"),
+            predicates = Nil,
+            limit = None,
+            versionAsOf = None,
+            timestampAsOf = None,
+            jsonPredicateHints = None,
+            refreshToken = None
           )
-        assert(tableFiles.version == 2)
-        assert(Protocol(minReaderVersion = 1) == tableFiles.protocol)
-        val expectedMetadata = Metadata(
-          id = "f8d5c169-3d01-4ca3-ad9e-7dc3355aedb2",
-          format = Format(),
-          schemaString =
-            """{"type":"struct","fields":[{"name":"eventTime","type":"timestamp","nullable":true,"metadata":{}},{"name":"date","type":"date","nullable":true,"metadata":{}}]}""",
-          partitionColumns = Seq("date")
-        )
-        assert(expectedMetadata == tableFiles.metadata)
-        assert(tableFiles.files.size == 2)
-        val expectedFiles = Seq(
-          AddFile(
-            url = tableFiles.files(0).url,
-            expirationTimestamp = tableFiles.files(0).expirationTimestamp,
-            id = "9f1a49539c5cffe1ea7f9e055d5c003c",
-            partitionValues = Map("date" -> "2021-04-28"),
-            size = 573,
-            stats =
-              """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:33:57.955Z"},"maxValues":{"eventTime":"2021-04-28T23:33:57.955Z"},"nullCount":{"eventTime":0}}"""
-          ),
-          AddFile(
-            url = tableFiles.files(1).url,
-            expirationTimestamp = tableFiles.files(1).expirationTimestamp,
-            id = "cd2209b32f5ed5305922dd50f5908a75",
-            partitionValues = Map("date" -> "2021-04-28"),
-            size = 573,
-            stats =
-              """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"maxValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"nullCount":{"eventTime":0}}"""
+        verifyTableFiles(tableFiles)
+        val refreshedTableFiles =
+          client.getFiles(
+            table = Table(name = "table2", schema = "default", share = "share2"),
+            predicates = Nil,
+            limit = None,
+            versionAsOf = None,
+            timestampAsOf = None,
+            jsonPredicateHints = None,
+            refreshToken = tableFiles.refreshToken
           )
-        )
-        assert(expectedFiles == tableFiles.files.toList)
-        assert(tableFiles.files(0).expirationTimestamp > System.currentTimeMillis())
+        verifyTableFiles(refreshedTableFiles)
       } finally {
         client.close()
       }
@@ -320,12 +338,14 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
     try {
       val tableFiles = client.getFiles(
-        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
-        Nil,
-        None,
-        Some(1L),
-        None,
-        None)
+        table = Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
+        predicates = Nil,
+        limit = None,
+        versionAsOf = Some(1L),
+        timestampAsOf = None,
+        jsonPredicateHints = None,
+        refreshToken = None
+      )
       assert(tableFiles.version == 1)
       assert(tableFiles.files.size == 3)
       val expectedFiles = Seq(
@@ -380,12 +400,13 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         try {
           val errorMessage = intercept[UnexpectedHttpStatus] {
             client.getFiles(
-              Table(name = "table1", schema = "default", share = "share1"),
-              Nil,
-              None,
-              Some(1L),
-              None,
-              None
+              table = Table(name = "table1", schema = "default", share = "share1"),
+              predicates = Nil,
+              limit = None,
+              versionAsOf = Some(1L),
+              timestampAsOf = None,
+              jsonPredicateHints = None,
+              refreshToken = None
             )
           }.getMessage
           assert(errorMessage.contains("Reading table by version or timestamp is not supported because history sharing is not enabled on table: share1.default.table1"))
@@ -412,12 +433,14 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
           // Because with undecided timezone, the timestamp string can be mapped to different versions
           val errorMessage = intercept[UnexpectedHttpStatus] {
             client.getFiles(
-              Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
-              Nil,
-              None,
-              None,
-              Some("2000-01-01T00:00:00Z"),
-              None)
+              table = Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
+              predicates = Nil,
+              limit = None,
+              versionAsOf = None,
+              timestampAsOf = Some("2000-01-01T00:00:00Z"),
+              jsonPredicateHints = None,
+              refreshToken = None
+            )
           }.getMessage
           assert(errorMessage.contains("The provided timestamp"))
         } finally {
@@ -439,12 +462,13 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         try {
           val errorMessage = intercept[UnexpectedHttpStatus] {
             client.getFiles(
-              Table(name = "table1", schema = "default", share = "share1"),
-              Nil,
-              None,
-              None,
-              Some("abc"),
-              None
+              table = Table(name = "table1", schema = "default", share = "share1"),
+              predicates = Nil,
+              limit = None,
+              versionAsOf = None,
+              timestampAsOf = Some("abc"),
+              jsonPredicateHints = None,
+              refreshToken = None
             )
           }.getMessage
           assert(errorMessage.contains("Reading table by version or timestamp is not supported because history sharing is not enabled on table: share1.default.table1"))

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -297,6 +297,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       assert(tableFiles.files(0).expirationTimestamp > System.currentTimeMillis())
       // Refresh token should be returned in latest snapshot query
       assert(tableFiles.refreshToken.nonEmpty)
+      assert(tableFiles.refreshToken.get.nonEmpty)
     }
 
     Seq(true, false).foreach { paginationEnabled =>

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -405,12 +405,12 @@ case class DeltaSharingSource(
       // If isStartingVersion is true, it means to fetch the snapshot at the fromVersion, which may
       // include table changes from previous versions.
       val tableFiles = deltaLog.client.getFiles(
-        deltaLog.table, Nil, None, Some(fromVersion), None, None
+        deltaLog.table, Nil, None, Some(fromVersion), None, None, None
       )
       latestRefreshFunc = () => {
         val queryTimestamp = System.currentTimeMillis()
         val files = deltaLog.client.getFiles(
-          deltaLog.table, Nil, None, Some(fromVersion), None, None
+          deltaLog.table, Nil, None, Some(fromVersion), None, None, None
         ).files
         var minUrlExpiration: Option[Long] = None
         val idToUrl = files.map { f =>

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -405,12 +405,24 @@ case class DeltaSharingSource(
       // If isStartingVersion is true, it means to fetch the snapshot at the fromVersion, which may
       // include table changes from previous versions.
       val tableFiles = deltaLog.client.getFiles(
-        deltaLog.table, Nil, None, Some(fromVersion), None, None, None
+        table = deltaLog.table,
+        predicates = Nil,
+        limit = None,
+        versionAsOf = Some(fromVersion),
+        timestampAsOf = None,
+        jsonPredicateHints = None,
+        refreshToken = None
       )
       latestRefreshFunc = () => {
         val queryTimestamp = System.currentTimeMillis()
         val files = deltaLog.client.getFiles(
-          deltaLog.table, Nil, None, Some(fromVersion), None, None, None
+          table = deltaLog.table,
+          predicates = Nil,
+          limit = None,
+          versionAsOf = Some(fromVersion),
+          timestampAsOf = None,
+          jsonPredicateHints = None,
+          refreshToken = None
         ).files
         var minUrlExpiration: Option[Long] = None
         val idToUrl = files.map { f =>

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -154,7 +154,7 @@ class RemoteSnapshot(
       metadata.size
     } else {
       log.warn("Getting table size from a full file scan for table: " + table)
-      val tableFiles = client.getFiles(table, Nil, None, versionAsOf, timestampAsOf, None)
+      val tableFiles = client.getFiles(table, Nil, None, versionAsOf, timestampAsOf, None, None)
       checkProtocolNotChange(tableFiles.protocol)
       checkSchemaNotChange(tableFiles.metadata)
       tableFiles.files.map(_.size).sum
@@ -208,7 +208,7 @@ class RemoteSnapshot(
       val implicits = spark.implicits
       import implicits._
       val tableFiles = client.getFiles(
-        table, predicates, limitHint, versionAsOf, timestampAsOf, jsonPredicateHints
+        table, predicates, limitHint, versionAsOf, timestampAsOf, jsonPredicateHints, None
       )
       var minUrlExpirationTimestamp: Option[Long] = None
       val idToUrl = tableFiles.files.map { file =>
@@ -229,8 +229,9 @@ class RemoteSnapshot(
           Seq(new WeakReference(fileIndex)),
           fileIndex.params.profileProvider,
           () => {
+            // TODO: use tableFiles.refreshToken
             val files = client.getFiles(
-              table, Nil, None, versionAsOf, timestampAsOf, jsonPredicateHints).files
+              table, Nil, None, versionAsOf, timestampAsOf, jsonPredicateHints, None).files
             var minUrlExpiration: Option[Long] = None
             val idToUrl = files.map { add =>
               if (add.expirationTimestamp != null) {

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -154,7 +154,15 @@ class RemoteSnapshot(
       metadata.size
     } else {
       log.warn("Getting table size from a full file scan for table: " + table)
-      val tableFiles = client.getFiles(table, Nil, None, versionAsOf, timestampAsOf, None, None)
+      val tableFiles = client.getFiles(
+        table = table,
+        predicates = Nil,
+        limit = None,
+        versionAsOf,
+        timestampAsOf,
+        jsonPredicateHints = None,
+        refreshToken = None
+      )
       checkProtocolNotChange(tableFiles.protocol)
       checkSchemaNotChange(tableFiles.metadata)
       tableFiles.files.map(_.size).sum

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -52,8 +52,12 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
 
     // sanity check for dummy client
     val client = new TestDeltaSharingClient()
-    client.getFiles(Table("fe", "fi", "fo"), Nil, Some(2L), None, None, Some("jsonPredicate1"))
-    client.getFiles(Table("fe", "fi", "fo"), Nil, Some(3L), None, None, Some("jsonPredicate2"))
+    client.getFiles(
+      Table("fe", "fi", "fo"), Nil, Some(2L), None, None, Some("jsonPredicate1"), None
+    )
+    client.getFiles(
+      Table("fe", "fi", "fo"), Nil, Some(3L), None, None, Some("jsonPredicate2"), None
+    )
     assert(TestDeltaSharingClient.limits === Seq(2L, 3L))
     assert(TestDeltaSharingClient.jsonPredicateHints === Seq("jsonPredicate1", "jsonPredicate2"))
     client.clear()

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -94,7 +94,8 @@ class TestDeltaSharingClient(
     limit: Option[Long],
     versionAsOf: Option[Long],
     timestampAsOf: Option[String],
-    jsonPredicateHints: Option[String]): DeltaTableFiles = {
+    jsonPredicateHints: Option[String],
+    refreshToken: Option[String]): DeltaTableFiles = {
     limit.foreach(lim => TestDeltaSharingClient.limits = TestDeltaSharingClient.limits :+ lim)
     jsonPredicateHints.foreach(p => {
       TestDeltaSharingClient.jsonPredicateHints = TestDeltaSharingClient.jsonPredicateHints :+ p


### PR DESCRIPTION
Use this [link](https://github.com/delta-io/delta-sharing/pull/386/files) to review incremental changes.

- [stack/refresh-token-server](https://github.com/delta-io/delta-sharing/pull/385)
  - [stack/refresh-token-client](https://github.com/delta-io/delta-sharing/pull/386)
    - [stack/refresh-token-spark](https://github.com/delta-io/delta-sharing/pull/387)

---

This pr adds refresh token support in delta sharing client:
- If the current query is for latest snapshot, set `includeRefreshToken=true` to retrieve the refresh token.
- Use `refreshToken` specified in `getFiles()` call for refresh query.
- Return refresh token to the caller as part of the `DeltaTableFiles` struct.

This is part 2 of https://github.com/delta-io/delta-sharing/issues/383.