### PR TITLE
CachedTableManager use refresh token to refresh urls

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingProfileProvider.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingProfileProvider.scala
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.apache.spark.delta.sharing.TableRefreshResult
 
 import io.delta.sharing.client.util.JsonUtils
 
@@ -50,8 +51,7 @@ trait DeltaSharingProfileProvider {
   // `refresher` takes an optional refreshToken, and returns
   // (idToUrlMap, minUrlExpirationTimestamp, refreshToken)
   def getCustomRefresher(
-      refresher: Option[String] => (Map[String, String], Option[Long], Option[String]))
-      : Option[String] => (Map[String, String], Option[Long], Option[String]) = {
+      refresher: Option[String] => TableRefreshResult): Option[String] => TableRefreshResult = {
     refresher
   }
 }

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingProfileProvider.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingProfileProvider.scala
@@ -47,10 +47,11 @@ trait DeltaSharingProfileProvider {
 
   def getCustomTablePath(tablePath: String): String = tablePath
 
-  // Map[String, String] is the id to url map.
-  // Long is the minimum url expiration time for all the urls.
-  def getCustomRefresher(refresher: () => (Map[String, String], Option[Long])): () =>
-    (Map[String, String], Option[Long]) = {
+  // `refresher` takes an optional refreshToken, and returns
+  // (idToUrlMap, minUrlExpirationTimestamp, refreshToken)
+  def getCustomRefresher(
+      refresher: Option[String] => (Map[String, String], Option[Long], Option[String]))
+      : Option[String] => (Map[String, String], Option[Long], Option[String]) = {
     refresher
   }
 }

--- a/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -35,15 +35,18 @@ import io.delta.sharing.client.DeltaSharingProfileProvider
  *             remove the cached table from our cache.
  * @param lastAccess When the table was accessed last time. We will remove old tables that are not
  *                   accessed after `expireAfterAccessMs` milliseconds.
- * @param refresher the function to generate a new file id to pre sign url map, as long as the new
- *                  expiration timestamp of the urls.
+ * @param refresher the function to generate a new file id to pre sign url map, with the new
+ *                  expiration timestamp of the urls and the new refresh token.
+ * @param refreshToken the optional refresh token that can be used by the refresher to retrieve
+ *                     the same set of files with refreshed urls.
  */
 class CachedTable(
     val expiration: Long,
     val idToUrl: Map[String, String],
     val refs: Seq[WeakReference[AnyRef]],
     @volatile var lastAccess: Long,
-    val refresher: () => (Map[String, String], Option[Long]))
+    val refresher: Option[String] => (Map[String, String], Option[Long], Option[String]),
+    val refreshToken: Option[String])
 
 class CachedTableManager(
     val preSignedUrlExpirationMs: Long,
@@ -96,7 +99,7 @@ class CachedTableManager(
         logInfo(s"Updating pre signed urls for $tablePath (expiration time: " +
           s"${new java.util.Date(cachedTable.expiration)})")
         try {
-          val (idToUrl, expOpt) = cachedTable.refresher()
+          val (idToUrl, expOpt, refreshToken) = cachedTable.refresher(cachedTable.refreshToken)
           val newTable = new CachedTable(
             if (isValidUrlExpirationTime(expOpt)) {
               expOpt.get
@@ -106,7 +109,8 @@ class CachedTableManager(
             idToUrl,
             cachedTable.refs,
             cachedTable.lastAccess,
-            cachedTable.refresher
+            cachedTable.refresher,
+            refreshToken
           )
           // Failing to replace the table is fine because if it did happen, we would retry after
           // `refreshCheckIntervalMs` milliseconds.
@@ -149,35 +153,38 @@ class CachedTableManager(
    * @param tablePath the table path. This is usually the profile file path.
    * @param idToUrl the pre signed url map. This will be refreshed when the pre signed urls is going
    *                to expire.
-   * @param refs    A list of weak references which can be used to determine whether the cache is
-   *                still needed. When all the weak references return null, we will remove the pre
-   *                signed url cache of this table form the cache.
+   * @param refs A list of weak references which can be used to determine whether the cache is
+   *             still needed. When all the weak references return null, we will remove the pre
+   *             signed url cache of this table form the cache.
    * @param profileProvider a profile Provider that can provide customized refresher function.
-   * @param refresher                 A function to re-generate pre signed urls for the table.
-   * @param expirationTimestamp   Optional, If set, it's a timestamp to indicate the expiration
-   *                              timestamp of the idToUrl.
+   * @param refresher A function to re-generate pre signed urls for the table.
+   * @param expirationTimestamp Optional, If set, it's a timestamp to indicate the expiration
+   *                            timestamp of the idToUrl.
+   * @param refreshToken an optional refresh token that can be used by the refresher to retrieve
+   *                     the same set of files with refreshed urls.
    */
   def register(
       tablePath: String,
       idToUrl: Map[String, String],
       refs: Seq[WeakReference[AnyRef]],
       profileProvider: DeltaSharingProfileProvider,
-      refresher: () => (Map[String, String], Option[Long]),
-      expirationTimestamp: Long = System.currentTimeMillis() + preSignedUrlExpirationMs
-  ): Unit = {
+      refresher: Option[String] => (Map[String, String], Option[Long], Option[String]),
+      expirationTimestamp: Long = System.currentTimeMillis() + preSignedUrlExpirationMs,
+      refreshToken: Option[String]
+    ): Unit = {
     val customTablePath = profileProvider.getCustomTablePath(tablePath)
     val customRefresher = profileProvider.getCustomRefresher(refresher)
 
-    val (resolvedIdToUrl, resolvedExpiration) =
+    val (resolvedIdToUrl, resolvedExpiration, resolvedRefreshToken) =
       if (expirationTimestamp - System.currentTimeMillis() < refreshThresholdMs) {
-        val (refreshedIdToUrl, expOpt) = customRefresher()
+        val (refreshedIdToUrl, expOpt, newRefreshToken) = customRefresher(refreshToken)
         if (isValidUrlExpirationTime(expOpt)) {
-          (refreshedIdToUrl, expOpt.get)
+          (refreshedIdToUrl, expOpt.get, newRefreshToken)
         } else {
-          (refreshedIdToUrl, System.currentTimeMillis() + preSignedUrlExpirationMs)
+          (refreshedIdToUrl, System.currentTimeMillis() + preSignedUrlExpirationMs, newRefreshToken)
         }
       } else {
-        (idToUrl, expirationTimestamp)
+        (idToUrl, expirationTimestamp, refreshToken)
       }
 
     val cachedTable = new CachedTable(
@@ -185,7 +192,8 @@ class CachedTableManager(
       idToUrl = resolvedIdToUrl,
       refs,
       System.currentTimeMillis(),
-      customRefresher
+      customRefresher,
+      resolvedRefreshToken
     )
     var oldTable = cache.putIfAbsent(customTablePath, cachedTable)
     if (oldTable == null) {
@@ -203,7 +211,8 @@ class CachedTableManager(
         // Try to avoid storing duplicate references
         refs.filterNot(ref => oldTable.refs.exists(_.get eq ref.get)) ++ oldTable.refs,
         lastAccess = System.currentTimeMillis(),
-        customRefresher
+        customRefresher,
+        cachedTable.refreshToken
       )
       if (cache.replace(customTablePath, oldTable, mergedTable)) {
         // Put the merged one to the cache

--- a/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
+++ b/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
@@ -47,9 +47,10 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
-          (Map("id1" -> "url1", "id2" -> "url2"), None)
-        })
+        _ => {
+          (Map("id1" -> "url1", "id2" -> "url2"), None, None)
+        },
+        refreshToken = None)
       assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path"),
         "id1")._1 == "url1")
       assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path"),
@@ -60,9 +61,10 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
-          (Map("id1" -> "url3", "id2" -> "url4"), None)
-        })
+        _ => {
+          (Map("id1" -> "url3", "id2" -> "url4"), None, None)
+        },
+        refreshToken = None)
       // We should get the new urls eventually
       eventually(timeout(10.seconds)) {
         assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path2"),
@@ -76,9 +78,10 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(new AnyRef)),
         provider,
-        () => {
-          (Map("id1" -> "url3", "id2" -> "url4"), None)
-        })
+        _ => {
+          (Map("id1" -> "url3", "id2" -> "url4"), None, None)
+        },
+        refreshToken = None)
       // We should remove the cached table eventually
       eventually(timeout(10.seconds)) {
         System.gc()
@@ -93,10 +96,11 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
-          (Map("id1" -> "url3", "id2" -> "url4"), None)
+        _ => {
+          (Map("id1" -> "url3", "id2" -> "url4"), None, None)
         },
-        -1
+        -1,
+        refreshToken = None
       )
       // We should get new urls immediately because it's refreshed upon register
       assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path4"),
@@ -124,14 +128,16 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
+        _ => {
           refreshTime += 1
           (
             Map("id1" -> ("url" + refreshTime.toString), "id2" -> "url4"),
-            Some(System.currentTimeMillis() + 1900)
+            Some(System.currentTimeMillis() + 1900),
+            None
           )
         },
-        System.currentTimeMillis() + 1900
+        System.currentTimeMillis() + 1900,
+        None
       )
       // We should refresh at least 5 times within 10 seconds based on
       // (System.currentTimeMillis() + 1900).
@@ -148,14 +154,16 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
+        _ => {
           refreshTime2 += 1
           (
             Map("id1" -> ("url" + refreshTime2.toString), "id2" -> "url4"),
-            Some(System.currentTimeMillis() + 4900)
+            Some(System.currentTimeMillis() + 4900),
+            None
           )
         },
-        System.currentTimeMillis() + 4900
+        System.currentTimeMillis() + 4900,
+        None
       )
       // We should refresh 2 times within 10 seconds based on (System.currentTimeMillis() + 4900).
       eventually(timeout(10.seconds)) {
@@ -171,14 +179,16 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
+        _ => {
           refreshTime3 += 1
           (
             Map("id1" -> ("url" + refreshTime3.toString), "id2" -> "url4"),
-            Some(System.currentTimeMillis() - 4900)
+            Some(System.currentTimeMillis() - 4900),
+            None
           )
         },
-        System.currentTimeMillis() + 6000
+        System.currentTimeMillis() + 6000,
+        None
       )
       // We should refresh 1 times within 10 seconds based on (preSignedUrlExpirationMs = 6000).
       try {
@@ -191,6 +201,44 @@ class CachedTableManagerSuite extends SparkFunSuite {
       } catch {
         case e: Throwable =>
           assert(e.getMessage.contains("did not equal"))
+      }
+    } finally {
+      manager.stop()
+    }
+  }
+
+  test("refresh using refresh token") {
+    val manager = new CachedTableManager(
+      preSignedUrlExpirationMs = 10,
+      refreshCheckIntervalMs = 10,
+      refreshThresholdMs = 10,
+      expireAfterAccessMs = 60000
+    )
+    try {
+      val ref = new AnyRef
+      val provider = new TestDeltaSharingProfileProvider
+      manager.register(
+        "test-table-path",
+        Map("id1" -> "url1", "id2" -> "url2"),
+        Seq(new WeakReference(ref)),
+        provider,
+        refreshToken => {
+          if (refreshToken.contains("refresh-token-1")) {
+            (Map("id1" -> "url3", "id2" -> "url4"), None, Some("refresh-token-2"))
+          } else if (refreshToken.contains("refresh-token-2")) {
+            (Map("id1" -> "url5", "id2" -> "url6"), None, Some("refresh-token-2"))
+          } else {
+            fail("Expecting to refresh with a refresh token")
+          }
+        },
+        refreshToken = Some("refresh-token-1")
+      )
+      // We should get url5 and url6 eventually.
+      eventually(timeout(10.seconds)) {
+        assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path"),
+          "id1")._1 == "url5")
+        assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path"),
+          "id2")._1 == "url6")
       }
     } finally {
       manager.stop()
@@ -213,9 +261,10 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
-          (Map("id1" -> "url1", "id2" -> "url2"), None)
-        })
+        _ => {
+          (Map("id1" -> "url1", "id2" -> "url2"), None, None)
+        },
+        refreshToken = None)
       Thread.sleep(1000)
       // We should remove the cached table when it's not accessed
       intercept[IllegalStateException](manager.getPreSignedUrl(

--- a/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
+++ b/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
@@ -48,7 +48,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(ref)),
         provider,
         _ => {
-          (Map("id1" -> "url1", "id2" -> "url2"), None, None)
+          TableRefreshResult(Map("id1" -> "url1", "id2" -> "url2"), None, None)
         },
         refreshToken = None)
       assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path"),
@@ -62,7 +62,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(ref)),
         provider,
         _ => {
-          (Map("id1" -> "url3", "id2" -> "url4"), None, None)
+          TableRefreshResult(Map("id1" -> "url3", "id2" -> "url4"), None, None)
         },
         refreshToken = None)
       // We should get the new urls eventually
@@ -79,7 +79,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(new AnyRef)),
         provider,
         _ => {
-          (Map("id1" -> "url3", "id2" -> "url4"), None, None)
+          TableRefreshResult(Map("id1" -> "url3", "id2" -> "url4"), None, None)
         },
         refreshToken = None)
       // We should remove the cached table eventually
@@ -97,7 +97,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(ref)),
         provider,
         _ => {
-          (Map("id1" -> "url3", "id2" -> "url4"), None, None)
+          TableRefreshResult(Map("id1" -> "url3", "id2" -> "url4"), None, None)
         },
         -1,
         refreshToken = None
@@ -130,7 +130,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         provider,
         _ => {
           refreshTime += 1
-          (
+          TableRefreshResult(
             Map("id1" -> ("url" + refreshTime.toString), "id2" -> "url4"),
             Some(System.currentTimeMillis() + 1900),
             None
@@ -156,7 +156,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         provider,
         _ => {
           refreshTime2 += 1
-          (
+          TableRefreshResult(
             Map("id1" -> ("url" + refreshTime2.toString), "id2" -> "url4"),
             Some(System.currentTimeMillis() + 4900),
             None
@@ -181,7 +181,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         provider,
         _ => {
           refreshTime3 += 1
-          (
+          TableRefreshResult(
             Map("id1" -> ("url" + refreshTime3.toString), "id2" -> "url4"),
             Some(System.currentTimeMillis() - 4900),
             None
@@ -224,9 +224,17 @@ class CachedTableManagerSuite extends SparkFunSuite {
         provider,
         refreshToken => {
           if (refreshToken.contains("refresh-token-1")) {
-            (Map("id1" -> "url3", "id2" -> "url4"), None, Some("refresh-token-2"))
+            TableRefreshResult(
+              Map("id1" -> "url3", "id2" -> "url4"),
+              None,
+              Some("refresh-token-2")
+            )
           } else if (refreshToken.contains("refresh-token-2")) {
-            (Map("id1" -> "url5", "id2" -> "url6"), None, Some("refresh-token-2"))
+            TableRefreshResult(
+              Map("id1" -> "url5", "id2" -> "url6"),
+              None,
+              Some("refresh-token-2")
+            )
           } else {
             fail("Expecting to refresh with a refresh token")
           }
@@ -262,7 +270,7 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Seq(new WeakReference(ref)),
         provider,
         _ => {
-          (Map("id1" -> "url1", "id2" -> "url2"), None, None)
+          TableRefreshResult(Map("id1" -> "url1", "id2" -> "url2"), None, None)
         },
         refreshToken = None)
       Thread.sleep(1000)

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
@@ -20,7 +20,7 @@ import java.lang.ref.WeakReference
 
 import scala.collection.mutable.ListBuffer
 
-import org.apache.spark.delta.sharing.CachedTableManager
+import org.apache.spark.delta.sharing.{CachedTableManager, TableRefreshResult}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, DeltaSharingScanUtils, Row, SparkSession, SQLContext}
 import org.apache.spark.sql.execution.LogicalRDD
@@ -58,7 +58,7 @@ case class RemoteDeltaCDFRelation(
       false,
       _ => {
         val d = client.getCDFFiles(table, cdfOptions, false)
-        (
+        TableRefreshResult(
           DeltaSharingCDFReader.getIdToUrl(d.addFiles, d.cdfFiles, d.removeFiles),
           DeltaSharingCDFReader.getMinUrlExpiration(d.addFiles, d.cdfFiles, d.removeFiles),
           None
@@ -83,7 +83,7 @@ object DeltaSharingCDFReader {
       removeFiles: Seq[RemoveFile],
       schema: StructType,
       isStreaming: Boolean,
-      refresher: Option[String] => (Map[String, String], Option[Long], Option[String]),
+      refresher: Option[String] => TableRefreshResult,
       lastQueryTableTimestamp: Long,
       expirationTimestamp: Option[Long]
   ): DataFrame = {

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
@@ -56,11 +56,12 @@ case class RemoteDeltaCDFRelation(
       deltaTabelFiles.removeFiles,
       DeltaTableUtils.addCdcSchema(deltaTabelFiles.metadata.schemaString),
       false,
-      () => {
+      _ => {
         val d = client.getCDFFiles(table, cdfOptions, false)
         (
           DeltaSharingCDFReader.getIdToUrl(d.addFiles, d.cdfFiles, d.removeFiles),
-          DeltaSharingCDFReader.getMinUrlExpiration(d.addFiles, d.cdfFiles, d.removeFiles)
+          DeltaSharingCDFReader.getMinUrlExpiration(d.addFiles, d.cdfFiles, d.removeFiles),
+          None
         )
       },
       System.currentTimeMillis(),
@@ -82,7 +83,7 @@ object DeltaSharingCDFReader {
       removeFiles: Seq[RemoveFile],
       schema: StructType,
       isStreaming: Boolean,
-      refresher: () => (Map[String, String], Option[Long]),
+      refresher: Option[String] => (Map[String, String], Option[Long], Option[String]),
       lastQueryTableTimestamp: Long,
       expirationTimestamp: Option[Long]
   ): DataFrame = {
@@ -111,7 +112,8 @@ object DeltaSharingCDFReader {
         expirationTimestamp.get
       } else {
         lastQueryTableTimestamp + CachedTableManager.INSTANCE.preSignedUrlExpirationMs
-      }
+      },
+      None
     )
 
     dfs.reduce((df1, df2) => df1.unionAll(df2))

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -20,7 +20,7 @@ import java.lang.ref.WeakReference
 
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkException
-import org.apache.spark.delta.sharing.CachedTableManager
+import org.apache.spark.delta.sharing.{CachedTableManager, TableRefreshResult}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Column, Encoder, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
@@ -32,15 +32,7 @@ import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 
 import io.delta.sharing.client.{DeltaSharingClient, DeltaSharingProfileProvider, DeltaSharingRestClient}
-import io.delta.sharing.client.model.{
-  AddFile,
-  CDFColumnInfo,
-  DeltaTableFiles,
-  FileAction,
-  Metadata,
-  Protocol,
-  Table => DeltaSharingTable
-}
+import io.delta.sharing.client.model.{AddFile, CDFColumnInfo, DeltaTableFiles, FileAction, Metadata, Protocol, Table => DeltaSharingTable}
 import io.delta.sharing.client.util.ConfUtils
 import io.delta.sharing.spark.perf.DeltaSharingLimitPushDown
 
@@ -252,7 +244,7 @@ class RemoteSnapshot(
               }
               add.id -> add.url
             }.toMap
-            (idToUrl, minUrlExpiration, tableFiles.refreshToken)
+            TableRefreshResult(idToUrl, minUrlExpiration, tableFiles.refreshToken)
           },
           if (CachedTableManager.INSTANCE.isValidUrlExpirationTime(minUrlExpirationTimestamp)) {
             minUrlExpirationTimestamp.get


### PR DESCRIPTION
Use this [link](https://github.com/delta-io/delta-sharing/pull/387/files) to review incremental changes.

- [stack/refresh-token-server](https://github.com/delta-io/delta-sharing/pull/385)
  - [stack/refresh-token-client](https://github.com/delta-io/delta-sharing/pull/386)
    - [stack/refresh-token-spark](https://github.com/delta-io/delta-sharing/pull/387)

---

This pr modifies `CachedTableManager` to support refresh token:
- Change `refresher` func to take `refreshToken: Option[String]`, and return `(idToUrlMap, minUrlExpiration, newRefreshToken)`
- The `refreshToken` will be stored in the `CachedTable`
- When refresh is needed for a cached table, call `cachedTable.refresher(cachedTable.refreshToken)` to update urls.

Note that the above change only applies to latest snapshot queries. For other types of queries, `refreshToken` will always be `None`.

This is part 3 of https://github.com/delta-io/delta-sharing/issues/383.