### PR TITLE
Refresh token branch-0.6 fix

### DIFF
--- a/server/src/main/protobuf/protocol.proto
+++ b/server/src/main/protobuf/protocol.proto
@@ -47,6 +47,15 @@ message QueryTableRequest {
     repeated string predicateHints = 1;
     optional string jsonPredicateHints = 6;
     optional int64 limitHint = 2;
+    // Whether or not to return a refresh token in the response. Only used in latest snapshot query
+    // AND first page query. For long running queries, delta sharing spark may make additional request
+    // to refresh pre-signed urls, and there might be table changes between the initial request and
+    // the refresh request. The refresh token will contain version information to make sure that
+    // the refresh request returns the same set of files.
+    optional bool includeRefreshToken = 8;
+    // The refresh token used to refresh pre-signed urls. Only used in latest snapshot query AND
+    // first page query.
+    optional string refreshToken = 9;
 
     // Only one of the three parameters can be supported in a single query.
     // If none of them is specified, the query is for the latest version.
@@ -97,4 +106,14 @@ message PageToken {
     optional string id = 1;
     optional string share = 2;
     optional string schema = 3;
+}
+
+// Define a special class to generate the refresh token for latest snapshot query.
+message RefreshToken {
+    // Id of the table being queried.
+    optional string id = 1;
+    // Only used in queryTable at snapshot, refers to the version being queried.
+    optional int64 version = 2;
+    // The expiration timestamp of the refresh token in milliseconds.
+    optional int64 expiration_timestamp = 3;
 }

--- a/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
+++ b/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
@@ -57,7 +57,9 @@ case class ServerConfig(
     // Whether to evaluate user provided `jsonPredicateHints`
     @BeanProperty var evaluateJsonPredicateHints: Boolean,
     // The timeout of an incoming web request in seconds. Set to 0 for no timeout
-    @BeanProperty var requestTimeoutSeconds: Long
+    @BeanProperty var requestTimeoutSeconds: Long,
+    // The TTL of the refresh token generated in queryTable API (in milliseconds).
+    @BeanProperty var refreshTokenTtlMs: Int
 ) extends ConfigItem {
   import ServerConfig._
 
@@ -76,7 +78,8 @@ case class ServerConfig(
       stalenessAcceptable = false,
       evaluatePredicateHints = false,
       evaluateJsonPredicateHints = false,
-      requestTimeoutSeconds = 30
+      requestTimeoutSeconds = 30,
+      refreshTokenTtlMs = 3600000 // 1 hour
     )
   }
 

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -25,7 +25,8 @@ case class SingleAction(
     cdf: AddCDCFile = null,
     remove: RemoveFile = null,
     metaData: Metadata = null,
-    protocol: Protocol = null) {
+    protocol: Protocol = null,
+    endStreamAction: EndStreamAction = null) {
 
   def unwrap: Action = {
     if (file != null) {
@@ -40,6 +41,8 @@ case class SingleAction(
       metaData
     } else if (protocol != null) {
       protocol
+    } else if (endStreamAction != null) {
+      endStreamAction
     } else {
       null
     }
@@ -122,6 +125,12 @@ case class RemoveFile(
     extends Action {
 
   override def wrap: SingleAction = SingleAction(remove = this)
+}
+
+case class EndStreamAction(
+    refreshToken: String
+) extends Action {
+  override def wrap: SingleAction = SingleAction(endStreamAction = this)
 }
 
 object Action {

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -19,6 +19,7 @@ package io.delta.standalone.internal
 
 import java.net.URI
 import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Base64
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
@@ -38,6 +39,7 @@ import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem
 import org.apache.hadoop.fs.s3a.S3AFileSystem
 import org.apache.spark.sql.types.{DataType, MetadataBuilder, StructType}
 import scala.collection.mutable.ListBuffer
+import scala.util.control.NonFatal
 
 import io.delta.sharing.server.{
   model,
@@ -51,6 +53,7 @@ import io.delta.sharing.server.{
   WasbFileSigner
 }
 import io.delta.sharing.server.config.{ServerConfig, TableConfig}
+import io.delta.sharing.server.protocol.RefreshToken
 
 /**
  * A class to load Delta tables from `TableConfig`. It also caches the loaded tables internally
@@ -72,7 +75,8 @@ class DeltaSharedTableLoader(serverConfig: ServerConfig) {
             tableConfig,
             serverConfig.preSignedUrlTimeoutSeconds,
             serverConfig.evaluatePredicateHints,
-            serverConfig.evaluateJsonPredicateHints)
+            serverConfig.evaluateJsonPredicateHints,
+            serverConfig.refreshTokenTtlMs)
         })
       if (!serverConfig.stalenessAcceptable) {
         deltaSharedTable.update()
@@ -93,7 +97,8 @@ class DeltaSharedTable(
     tableConfig: TableConfig,
     preSignedUrlTimeoutSeconds: Long,
     evaluatePredicateHints: Boolean,
-    evaluateJsonPredicateHints: Boolean) {
+    evaluateJsonPredicateHints: Boolean,
+    refreshTokenTtlMs: Int) {
 
   private val conf = withClassLoader {
     new Configuration()
@@ -188,7 +193,9 @@ class DeltaSharedTable(
       version: Option[Long],
       timestamp: Option[String],
       startingVersion: Option[Long],
-      endingVersion: Option[Long]
+      endingVersion: Option[Long],
+      includeRefreshToken: Boolean,
+      refreshToken: Option[String]
   ): (Long, Seq[model.SingleAction]) = withClassLoader {
     // TODO Support `limitHint`
     if (Seq(version, timestamp, startingVersion).filter(_.isDefined).size >= 2) {
@@ -196,8 +203,11 @@ class DeltaSharedTable(
         ErrorStrings.multipleParametersSetErrorMsg(Seq("version", "timestamp", "startingVersion"))
       )
     }
-    val snapshot = if (version.orElse(startingVersion).isDefined) {
-      deltaLog.getSnapshotForVersionAsOf(version.orElse(startingVersion).get)
+    // Validate refreshToken if it's specified
+    val refreshTokenOpt = refreshToken.map(decodeAndValidateRefreshToken)
+    val specifiedVersion = version.orElse(startingVersion).orElse(refreshTokenOpt.map(_.getVersion))
+    val snapshot = if (specifiedVersion.isDefined) {
+      deltaLog.getSnapshotForVersionAsOf(specifiedVersion.get)
     } else if (timestamp.isDefined) {
       val ts = DeltaSharingHistoryManager.getTimestamp("timestamp", timestamp.get)
       try {
@@ -268,7 +278,7 @@ class DeltaSharedTable(
           } else {
             filteredFiles
           }
-        filteredFiles.map { addFile =>
+        val signedFiles = filteredFiles.map { addFile =>
           val cloudPath = absolutePath(deltaLog.dataPath, addFile.path)
           val signedUrl = fileSigner.sign(cloudPath)
           val modelAddFile = model.AddFile(url = signedUrl,
@@ -280,6 +290,22 @@ class DeltaSharedTable(
             timestamp = if (isVersionQuery) { ts.get} else null
           )
           modelAddFile.wrap
+        }
+        signedFiles ++ {
+          // For backwards compatibility, return an `endStreamAction` object only when
+          // `includeRefreshToken` is true
+          if (includeRefreshToken) {
+            val refreshTokenStr = encodeRefreshToken(
+              RefreshToken(
+                id = Some(tableConfig.id),
+                version = Some(snapshot.version),
+                expirationTimestamp = Some(System.currentTimeMillis() + refreshTokenTtlMs)
+              )
+            )
+            Seq(model.EndStreamAction(refreshTokenStr).wrap)
+          } else {
+            Nil
+          }
         }
       } else {
         Nil
@@ -502,5 +528,31 @@ class DeltaSharedTable(
     } else {
       new Path(path, p)
     }
+  }
+
+  private def decodeAndValidateRefreshToken(tokenStr: String): RefreshToken = {
+    val token = try {
+      RefreshToken.parseFrom(Base64.getUrlDecoder.decode(tokenStr))
+    } catch {
+      case NonFatal(_) =>
+        throw new DeltaSharingIllegalArgumentException(
+          s"Error decoding refresh token: $tokenStr."
+        )
+    }
+    if (token.getExpirationTimestamp < System.currentTimeMillis()) {
+      throw new DeltaSharingIllegalArgumentException(
+        "The refresh token has expired. Please restart the query."
+      )
+    }
+    if (token.getId != tableConfig.id) {
+      throw new DeltaSharingIllegalArgumentException(
+        "The table specified in the refresh token does not match the table being queried."
+      )
+    }
+    token
+  }
+
+  private def encodeRefreshToken(token: RefreshToken): String = {
+    Base64.getUrlEncoder.encodeToString(token.toByteArray)
   }
 }

--- a/server/src/universal/conf/delta-sharing-server.yaml.template
+++ b/server/src/universal/conf/delta-sharing-server.yaml.template
@@ -49,3 +49,5 @@ stalenessAcceptable: false
 evaluatePredicateHints: false
 # Whether to evaluate user provided `jsonPredicateHints`
 evaluateJsonPredicateHints: false
+# The TTL of the refresh token generated in queryTable API (in milliseconds).
+refreshTokenTtlMs: 3600000

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -56,7 +56,8 @@ private[sharing] trait DeltaSharingClient {
     limit: Option[Long],
     versionAsOf: Option[Long],
     timestampAsOf: Option[String],
-    jsonPredicateHints: Option[String]): DeltaTableFiles
+    jsonPredicateHints: Option[String],
+    refreshToken: Option[String]): DeltaTableFiles
 
   def getFiles(table: Table, startingVersion: Long, endingVersion: Option[Long]): DeltaTableFiles
 
@@ -81,7 +82,9 @@ private[sharing] case class QueryTableRequest(
   timestamp: Option[String],
   startingVersion: Option[Long],
   endingVersion: Option[Long],
-  jsonPredicateHints: Option[String]
+  jsonPredicateHints: Option[String],
+  includeRefreshToken: Option[Boolean],
+  refreshToken: Option[String]
 )
 
 private[sharing] case class ListSharesResponse(
@@ -99,7 +102,8 @@ private[spark] class DeltaSharingRestClient(
     numRetries: Int = 10,
     maxRetryDuration: Long = Long.MaxValue,
     sslTrustAll: Boolean = false,
-    forStreaming: Boolean = false) extends DeltaSharingClient {
+    forStreaming: Boolean = false
+  ) extends DeltaSharingClient with Logging {
 
   @volatile private var created = false
 
@@ -228,7 +232,10 @@ private[spark] class DeltaSharingRestClient(
       limit: Option[Long],
       versionAsOf: Option[Long],
       timestampAsOf: Option[String],
-      jsonPredicateHints: Option[String]): DeltaTableFiles = {
+      jsonPredicateHints: Option[String],
+      refreshToken: Option[String]): DeltaTableFiles = {
+    // Retrieve refresh token when querying the latest snapshot.
+    val includeRefreshToken = versionAsOf.isEmpty && timestampAsOf.isEmpty
     val encodedShareName = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchemaName = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTableName = URLEncoder.encode(table.name, "UTF-8")
@@ -243,15 +250,26 @@ private[spark] class DeltaSharingRestClient(
         timestampAsOf,
         None,
         None,
-        jsonPredicateHints
+        jsonPredicateHints,
+        Some(includeRefreshToken),
+        refreshToken
       )
     )
+    val (filteredLines, endStreamAction) = maybeExtractEndStreamAction(lines)
+    val refreshTokenOpt = endStreamAction.flatMap { e =>
+      Option(e.refreshToken).flatMap { token =>
+        if (token.isEmpty) None else Some(token)
+      }
+    }
+    if (includeRefreshToken && refreshTokenOpt.isEmpty) {
+      logWarning("includeRefreshToken=true but refresh token is not returned.")
+    }
     require(versionAsOf.isEmpty || versionAsOf.get == version)
-    val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
+    val protocol = JsonUtils.fromJson[SingleAction](filteredLines(0)).protocol
     checkProtocol(protocol)
-    val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
-    val files = lines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).file)
-    DeltaTableFiles(version, protocol, metadata, files)
+    val metadata = JsonUtils.fromJson[SingleAction](filteredLines(1)).metaData
+    val files = filteredLines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).file)
+    DeltaTableFiles(version, protocol, metadata, files, refreshToken = refreshTokenOpt)
   }
 
   override def getFiles(
@@ -265,7 +283,19 @@ private[spark] class DeltaSharingRestClient(
     val target = getTargetUrl(
       s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query")
     val (version, lines) = getNDJson(
-      target, QueryTableRequest(Nil, None, None, None, Some(startingVersion), endingVersion, None))
+      target,
+      QueryTableRequest(
+        /* predicateHint */ Nil,
+        /* limitHint */ None,
+        /* version */ None,
+        /* timestamp */ None,
+        Some(startingVersion),
+        endingVersion,
+        /* jsonPredicateHints */ None,
+        /* includeRefreshToken */ None,
+        /* refreshToken */ None
+      )
+    )
     val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
     checkProtocol(protocol)
     val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
@@ -324,6 +354,17 @@ private[spark] class DeltaSharingRestClient(
       removeFiles = removeFiles,
       additionalMetadatas = additionalMetadatas
     )
+  }
+
+  // Check the last line and extract EndStreamAction if there is one.
+  private def maybeExtractEndStreamAction(
+      lines: Seq[String]): (Seq[String], Option[EndStreamAction]) = {
+    val endStreamAction = JsonUtils.fromJson[SingleAction](lines.last).endStreamAction
+    if (endStreamAction == null) {
+      (lines, None)
+    } else {
+      (lines.init, Some(endStreamAction))
+    }
   }
 
   private def getEncodedCDFParams(

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingProfileProvider.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingProfileProvider.scala
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.apache.spark.delta.sharing.TableRefreshResult
 
 import io.delta.sharing.spark.util.JsonUtils
 
@@ -47,7 +48,8 @@ trait DeltaSharingProfileProvider {
 
   def getCustomTablePath(tablePath: String): String = tablePath
 
-  def getCustomRefresher(refresher: () => Map[String, String]): () => Map[String, String] = {
+  def getCustomRefresher(
+      refresher: Option[String] => TableRefreshResult): Option[String] => TableRefreshResult = {
     refresher
   }
 }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -21,7 +21,7 @@ import java.lang.ref.WeakReference
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.delta.sharing.CachedTableManager
+import org.apache.spark.delta.sharing.{CachedTableManager, TableRefreshResult}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, DeltaSharingScanUtils, SparkSession}
 import org.apache.spark.sql.connector.read.streaming
@@ -155,7 +155,9 @@ case class DeltaSharingSource(
   // The latest function used to fetch presigned urls for the delta sharing table, record it in
   // a variable to be used by the CachedTableManager to refresh the presigned urls if the query
   // runs for a long time.
-  private var latestRefreshFunc = () => { Map.empty[String, String] }
+  private var latestRefreshFunc = (_: Option[String]) => {
+    TableRefreshResult(Map.empty[String, String], None)
+  }
   // The latest timestamp in millisecond, records the time of the last rpc sent to the server to
   // fetch the pre-signed urls.
   // This is used to track whether the pre-signed urls stored in sortedFetchedFiles are going to
@@ -280,14 +282,33 @@ case class DeltaSharingSource(
       // If isStartingVersion is true, it means to fetch the snapshot at the fromVersion, which may
       // include table changes from previous versions.
       val tableFiles = deltaLog.client.getFiles(
-        deltaLog.table, Nil, None, Some(fromVersion), None, None
+        table = deltaLog.table,
+        predicates = Nil,
+        limit = None,
+        versionAsOf = Some(fromVersion),
+        timestampAsOf = None,
+        jsonPredicateHints = None,
+        refreshToken = None
       )
-      latestRefreshFunc = () => {
-        deltaLog.client.getFiles(
-          deltaLog.table, Nil, None, Some(fromVersion), None, None
-        ).files.map { f =>
-          f.id -> f.url
-        }.toMap
+      latestRefreshFunc = (_: Option[String]) => {
+        TableRefreshResult(
+          deltaLog.client
+            .getFiles(
+              table = deltaLog.table,
+              predicates = Nil,
+              limit = None,
+              versionAsOf = Some(fromVersion),
+              timestampAsOf = None,
+              jsonPredicateHints = None,
+              refreshToken = None
+            )
+            .files
+            .map { f =>
+              f.id -> f.url
+            }
+            .toMap,
+          refreshToken = None
+        )
       }
 
       val numFiles = tableFiles.files.size
@@ -317,12 +338,21 @@ case class DeltaSharingSource(
       val tableFiles = deltaLog.client.getFiles(
         deltaLog.table, fromVersion, Some(endingVersionForQuery)
       )
-      latestRefreshFunc = () => {
-        deltaLog.client.getFiles(
-          deltaLog.table, fromVersion, Some(endingVersionForQuery)
-        ).addFiles.map { a =>
-          a.id -> a.url
-        }.toMap
+      latestRefreshFunc = (_: Option[String]) => {
+        TableRefreshResult(
+          deltaLog.client
+            .getFiles(
+              deltaLog.table,
+              fromVersion,
+              Some(endingVersionForQuery)
+            )
+            .addFiles
+            .map { a =>
+              a.id -> a.url
+            }
+            .toMap,
+          refreshToken = None
+        )
       }
       val allAddFiles = validateCommitAndFilterAddFiles(tableFiles).groupBy(a => a.version)
       for (v <- fromVersion to endingVersionForQuery) {
@@ -373,7 +403,7 @@ case class DeltaSharingSource(
       ),
       true
     )
-    latestRefreshFunc = () => {
+    latestRefreshFunc = (_: Option[String]) => {
       val d = deltaLog.client.getCDFFiles(
         deltaLog.table,
         Map(
@@ -382,7 +412,10 @@ case class DeltaSharingSource(
         ),
         true
       )
-      DeltaSharingCDFReader.getIdToUrl(d.addFiles, d.cdfFiles, d.removeFiles)
+      TableRefreshResult(
+        DeltaSharingCDFReader.getIdToUrl(d.addFiles, d.cdfFiles, d.removeFiles),
+        refreshToken = None
+      )
     }
 
     (Seq(tableFiles.metadata) ++ tableFiles.additionalMetadatas).foreach { m =>
@@ -543,7 +576,7 @@ case class DeltaSharingSource(
       )
       // force a refresh if needed.
       lastQueryTableTimestamp = System.currentTimeMillis()
-      val newIdToUrl = latestRefreshFunc()
+      val newIdToUrl = latestRefreshFunc(None).idToUrl
       sortedFetchedFiles = sortedFetchedFiles.map { indexedFile =>
         IndexedFile(
           version = indexedFile.version,
@@ -633,7 +666,8 @@ case class DeltaSharingSource(
       idToUrl,
       Seq(new WeakReference(fileIndex)),
       params.profileProvider,
-      latestRefreshFunc
+      latestRefreshFunc,
+      refreshToken = None
     )
 
     val relation = HadoopFsRelation(

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -293,12 +293,10 @@ class RemoteSnapshot(
             val tableFiles = client.getFiles(
               table, Nil, None, versionAsOf, timestampAsOf, jsonPredicateHints, refreshToken
             )
-            TableRefreshResult(
-              tableFiles.files.map { add =>
-                add.id -> add.url
-              }.toMap,
-              tableFiles.refreshToken
-            )
+            val idToUrl = tableFiles.files.map { add =>
+              add.id -> add.url
+            }.toMap
+            TableRefreshResult(idToUrl, tableFiles.refreshToken)
           },
           refreshToken = tableFiles.refreshToken
         )

--- a/spark/src/main/scala/io/delta/sharing/spark/model.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/model.scala
@@ -49,7 +49,8 @@ private[sharing] case class DeltaTableFiles(
     addFiles: Seq[AddFileForCDF] = Nil,
     cdfFiles: Seq[AddCDCFile] = Nil,
     removeFiles: Seq[RemoveFile] = Nil,
-    additionalMetadatas: Seq[Metadata] = Nil)
+    additionalMetadatas: Seq[Metadata] = Nil,
+    refreshToken: Option[String] = None)
 
 private[sharing] case class Share(name: String)
 
@@ -65,7 +66,8 @@ private[sharing] case class SingleAction(
     cdf: AddCDCFile = null,
     remove: RemoveFile = null,
     metaData: Metadata = null,
-    protocol: Protocol = null) {
+    protocol: Protocol = null,
+    endStreamAction: EndStreamAction = null) {
 
   def unwrap: Action = {
     if (file != null) {
@@ -80,6 +82,8 @@ private[sharing] case class SingleAction(
       metaData
     } else if (protocol != null) {
       protocol
+    } else if (endStreamAction != null) {
+      endStreamAction
     } else {
       null
     }
@@ -109,6 +113,12 @@ private[sharing] sealed trait Action {
 
 private[sharing] case class Protocol(minReaderVersion: Int) extends Action {
   override def wrap: SingleAction = SingleAction(protocol = this)
+}
+
+private[sharing] case class EndStreamAction(
+    refreshToken: String)
+  extends Action {
+  override def wrap: SingleAction = SingleAction(endStreamAction = this)
 }
 
 // A common base class for all file actions.

--- a/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/spark/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -41,7 +41,7 @@ case class TableRefreshResult(
  * @param lastAccess When the table was accessed last time. We will remove old tables that are not
  *                   accessed after `expireAfterAccessMs` milliseconds.
  * @param refresher the function to generate a new file id to pre sign url map, with the new
- *                  expiration timestamp of the urls and the new refresh token.
+ *                  refresh token.
  * @param refreshToken the optional refresh token that can be used by the refresher to retrieve
  *                     the same set of files with refreshed urls.
  */

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -25,6 +25,7 @@ import io.delta.sharing.spark.model.{
   AddCDCFile,
   AddFile,
   AddFileForCDF,
+  DeltaTableFiles,
   Format,
   Metadata,
   Protocol,
@@ -148,17 +149,16 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
   }
 
   integrationTest("getFiles") {
-    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
-    try {
-      val tableFiles =
-        client.getFiles(Table(name = "table2", schema = "default", share = "share2"), Nil, None, None, None, None)
+    def verifyTableFiles(tableFiles: DeltaTableFiles): Unit = {
       assert(tableFiles.version == 2)
       assert(Protocol(minReaderVersion = 1) == tableFiles.protocol)
       val expectedMetadata = Metadata(
         id = "f8d5c169-3d01-4ca3-ad9e-7dc3355aedb2",
         format = Format(),
-        schemaString = """{"type":"struct","fields":[{"name":"eventTime","type":"timestamp","nullable":true,"metadata":{}},{"name":"date","type":"date","nullable":true,"metadata":{}}]}""",
-        partitionColumns = Seq("date"))
+        schemaString =
+          """{"type":"struct","fields":[{"name":"eventTime","type":"timestamp","nullable":true,"metadata":{}},{"name":"date","type":"date","nullable":true,"metadata":{}}]}""",
+        partitionColumns = Seq("date")
+      )
       assert(expectedMetadata == tableFiles.metadata)
       assert(tableFiles.files.size == 2)
       val expectedFiles = Seq(
@@ -167,17 +167,47 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
           id = "9f1a49539c5cffe1ea7f9e055d5c003c",
           partitionValues = Map("date" -> "2021-04-28"),
           size = 573,
-          stats = """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:33:57.955Z"},"maxValues":{"eventTime":"2021-04-28T23:33:57.955Z"},"nullCount":{"eventTime":0}}"""
+          stats =
+            """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:33:57.955Z"},"maxValues":{"eventTime":"2021-04-28T23:33:57.955Z"},"nullCount":{"eventTime":0}}"""
         ),
         AddFile(
           url = tableFiles.files(1).url,
           id = "cd2209b32f5ed5305922dd50f5908a75",
           partitionValues = Map("date" -> "2021-04-28"),
           size = 573,
-          stats = """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"maxValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"nullCount":{"eventTime":0}}"""
+          stats =
+            """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"maxValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"nullCount":{"eventTime":0}}"""
         )
       )
       assert(expectedFiles == tableFiles.files.toList)
+      // Refresh token should be returned in latest snapshot query
+      assert(tableFiles.refreshToken.nonEmpty)
+      assert(tableFiles.refreshToken.get.nonEmpty)
+    }
+
+    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
+    val table = Table(name = "table2", schema = "default", share = "share2")
+    try {
+      val tableFiles = client.getFiles(
+        table,
+        predicates = Nil,
+        limit = None,
+        versionAsOf = None,
+        timestampAsOf = None,
+        jsonPredicateHints = None,
+        refreshToken = None
+      )
+      verifyTableFiles(tableFiles)
+      val refreshedTableFiles = client.getFiles(
+        table,
+        predicates = Nil,
+        limit = None,
+        versionAsOf = None,
+        timestampAsOf = None,
+        jsonPredicateHints = None,
+        refreshToken = tableFiles.refreshToken
+      )
+      verifyTableFiles(refreshedTableFiles)
     } finally {
       client.close()
     }
@@ -187,12 +217,14 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
     try {
       val tableFiles = client.getFiles(
-        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
-        Nil,
-        None,
-        Some(1L),
-        None,
-        None)
+        table = Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
+        predicates = Nil,
+        limit = None,
+        versionAsOf = Some(1L),
+        timestampAsOf = None,
+        jsonPredicateHints = None,
+        refreshToken = None
+      )
       assert(tableFiles.version == 1)
       assert(tableFiles.files.size == 3)
       val expectedFiles = Seq(
@@ -225,6 +257,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         )
       )
       assert(expectedFiles == tableFiles.files.toList)
+      // Refresh token shouldn't be returned in version query
+      assert(tableFiles.refreshToken.isEmpty)
     } finally {
       client.close()
     }
@@ -235,12 +269,13 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     try {
       val errorMessage = intercept[UnexpectedHttpStatus] {
         client.getFiles(
-          Table(name = "table1", schema = "default", share = "share1"),
-          Nil,
-          None,
-          Some(1L),
-          None,
-          None
+          table = Table(name = "table1", schema = "default", share = "share1"),
+          predicates = Nil,
+          limit = None,
+          versionAsOf = Some(1L),
+          timestampAsOf = None,
+          jsonPredicateHints = None,
+          refreshToken = None
         )
       }.getMessage
       assert(errorMessage.contains("Reading table by version or timestamp is not supported because change data feed is not enabled on table: share1.default.table1"))
@@ -258,12 +293,14 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       // Because with undecided timezone, the timestamp string can be mapped to different versions
       val errorMessage = intercept[UnexpectedHttpStatus] {
         client.getFiles(
-          Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
-          Nil,
-          None,
-          None,
-          Some("2000-01-01T00:00:00Z"),
-          None)
+          table = Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
+          predicates = Nil,
+          limit = None,
+          versionAsOf = None,
+          timestampAsOf = Some("2000-01-01T00:00:00Z"),
+          jsonPredicateHints = None,
+          refreshToken = None
+        )
       }.getMessage
       assert(errorMessage.contains("The provided timestamp"))
     } finally {
@@ -276,12 +313,13 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     try {
       val errorMessage = intercept[UnexpectedHttpStatus] {
         client.getFiles(
-          Table(name = "table1", schema = "default", share = "share1"),
-          Nil,
-          None,
-          None,
-          Some("abc"),
-          None
+          table = Table(name = "table1", schema = "default", share = "share1"),
+          predicates = Nil,
+          limit = None,
+          versionAsOf = None,
+          timestampAsOf = Some("abc"),
+          jsonPredicateHints = None,
+          refreshToken = None
         )
       }.getMessage
       assert(errorMessage.contains("Reading table by version or timestamp is not supported because change data feed is not enabled on table: share1.default.table1"))

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -70,8 +70,12 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
 
     // sanity check for dummy client
     val client = new TestDeltaSharingClient()
-    client.getFiles(Table("fe", "fi", "fo"), Nil, Some(2L), None, None, Some("jsonPredicate1"))
-    client.getFiles(Table("fe", "fi", "fo"), Nil, Some(3L), None, None, Some("jsonPredicate2"))
+    client.getFiles(
+      Table("fe", "fi", "fo"), Nil, Some(2L), None, None, Some("jsonPredicate1"), None
+    )
+    client.getFiles(
+      Table("fe", "fi", "fo"), Nil, Some(3L), None, None, Some("jsonPredicate2"), None
+    )
     assert(TestDeltaSharingClient.limits === Seq(2L, 3L))
     assert(TestDeltaSharingClient.jsonPredicateHints === Seq("jsonPredicate1", "jsonPredicate2"))
     client.clear()

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -62,7 +62,8 @@ class TestDeltaSharingClient(
     limit: Option[Long],
     versionAsOf: Option[Long],
     timestampAsOf: Option[String],
-    jsonPredicateHints: Option[String]): DeltaTableFiles = {
+    jsonPredicateHints: Option[String],
+    refreshToken: Option[String]): DeltaTableFiles = {
     limit.foreach(lim => TestDeltaSharingClient.limits = TestDeltaSharingClient.limits :+ lim)
     jsonPredicateHints.foreach(p => {
       TestDeltaSharingClient.jsonPredicateHints = TestDeltaSharingClient.jsonPredicateHints :+ p


### PR DESCRIPTION
This pr adds refresh token fix to delta-sharing-spark branch-0.6:

- In `DeltaSharingClient`, if the query is for latest snapshot, set `includeRefreshToken=true` to retrieve the refresh token.
- In `CachedTableManager`, when refreshing a cached table, use `refreshToken` to update urls.
- Added tests for client side changes, also added refresh token changes in the reference server to support integration test.

