### PR TITLE
Refresh token branch-0.7 fix

### DIFF
--- a/server/src/main/protobuf/protocol.proto
+++ b/server/src/main/protobuf/protocol.proto
@@ -47,6 +47,15 @@ message QueryTableRequest {
     repeated string predicateHints = 1;
     optional string jsonPredicateHints = 6;
     optional int64 limitHint = 2;
+    // Whether or not to return a refresh token in the response. Only used in latest snapshot query
+    // AND first page query. For long running queries, delta sharing spark may make additional request
+    // to refresh pre-signed urls, and there might be table changes between the initial request and
+    // the refresh request. The refresh token will contain version information to make sure that
+    // the refresh request returns the same set of files.
+    optional bool includeRefreshToken = 8;
+    // The refresh token used to refresh pre-signed urls. Only used in latest snapshot query AND
+    // first page query.
+    optional string refreshToken = 9;
 
     // Only one of the three parameters can be supported in a single query.
     // If none of them is specified, the query is for the latest version.
@@ -97,4 +106,14 @@ message PageToken {
     optional string id = 1;
     optional string share = 2;
     optional string schema = 3;
+}
+
+// Define a special class to generate the refresh token for latest snapshot query.
+message RefreshToken {
+    // Id of the table being queried.
+    optional string id = 1;
+    // Only used in queryTable at snapshot, refers to the version being queried.
+    optional int64 version = 2;
+    // The expiration timestamp of the refresh token in milliseconds.
+    optional int64 expiration_timestamp = 3;
 }

--- a/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
+++ b/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
@@ -57,7 +57,9 @@ case class ServerConfig(
     // Whether to evaluate user provided `jsonPredicateHints`
     @BeanProperty var evaluateJsonPredicateHints: Boolean,
     // The timeout of an incoming web request in seconds. Set to 0 for no timeout
-    @BeanProperty var requestTimeoutSeconds: Long
+    @BeanProperty var requestTimeoutSeconds: Long,
+    // The TTL of the refresh token generated in queryTable API (in milliseconds).
+    @BeanProperty var refreshTokenTtlMs: Int
 ) extends ConfigItem {
   import ServerConfig._
 
@@ -76,7 +78,8 @@ case class ServerConfig(
       stalenessAcceptable = false,
       evaluatePredicateHints = false,
       evaluateJsonPredicateHints = false,
-      requestTimeoutSeconds = 30
+      requestTimeoutSeconds = 30,
+      refreshTokenTtlMs = 3600000 // 1 hour
     )
   }
 

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -25,7 +25,8 @@ case class SingleAction(
     cdf: AddCDCFile = null,
     remove: RemoveFile = null,
     metaData: Metadata = null,
-    protocol: Protocol = null) {
+    protocol: Protocol = null,
+    endStreamAction: EndStreamAction = null) {
 
   def unwrap: Action = {
     if (file != null) {
@@ -40,6 +41,8 @@ case class SingleAction(
       metaData
     } else if (protocol != null) {
       protocol
+    } else if (endStreamAction != null) {
+      endStreamAction
     } else {
       null
     }
@@ -126,6 +129,12 @@ case class RemoveFile(
     extends Action {
 
   override def wrap: SingleAction = SingleAction(remove = this)
+}
+
+case class EndStreamAction(
+    refreshToken: String
+) extends Action {
+  override def wrap: SingleAction = SingleAction(endStreamAction = this)
 }
 
 object Action {

--- a/server/src/universal/conf/delta-sharing-server.yaml.template
+++ b/server/src/universal/conf/delta-sharing-server.yaml.template
@@ -57,3 +57,5 @@ stalenessAcceptable: false
 evaluatePredicateHints: false
 # Whether to evaluate user provided `jsonPredicateHints`
 evaluateJsonPredicateHints: false
+# The TTL of the refresh token generated in queryTable API (in milliseconds).
+refreshTokenTtlMs: 3600000

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -56,7 +56,8 @@ private[sharing] trait DeltaSharingClient {
     limit: Option[Long],
     versionAsOf: Option[Long],
     timestampAsOf: Option[String],
-    jsonPredicateHints: Option[String]): DeltaTableFiles
+    jsonPredicateHints: Option[String],
+    refreshToken: Option[String]): DeltaTableFiles
 
   def getFiles(table: Table, startingVersion: Long, endingVersion: Option[Long]): DeltaTableFiles
 
@@ -81,7 +82,9 @@ private[sharing] case class QueryTableRequest(
   timestamp: Option[String],
   startingVersion: Option[Long],
   endingVersion: Option[Long],
-  jsonPredicateHints: Option[String]
+  jsonPredicateHints: Option[String],
+  includeRefreshToken: Option[Boolean],
+  refreshToken: Option[String]
 )
 
 private[sharing] case class ListSharesResponse(
@@ -99,7 +102,8 @@ private[spark] class DeltaSharingRestClient(
     numRetries: Int = 10,
     maxRetryDuration: Long = Long.MaxValue,
     sslTrustAll: Boolean = false,
-    forStreaming: Boolean = false) extends DeltaSharingClient {
+    forStreaming: Boolean = false
+  ) extends DeltaSharingClient with Logging {
 
   @volatile private var created = false
 
@@ -228,7 +232,10 @@ private[spark] class DeltaSharingRestClient(
       limit: Option[Long],
       versionAsOf: Option[Long],
       timestampAsOf: Option[String],
-      jsonPredicateHints: Option[String]): DeltaTableFiles = {
+      jsonPredicateHints: Option[String],
+      refreshToken: Option[String]): DeltaTableFiles = {
+    // Retrieve refresh token when querying the latest snapshot.
+    val includeRefreshToken = versionAsOf.isEmpty && timestampAsOf.isEmpty
     val encodedShareName = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchemaName = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTableName = URLEncoder.encode(table.name, "UTF-8")
@@ -243,15 +250,26 @@ private[spark] class DeltaSharingRestClient(
         timestampAsOf,
         None,
         None,
-        jsonPredicateHints
+        jsonPredicateHints,
+        Some(includeRefreshToken),
+        refreshToken
       )
     )
+    val (filteredLines, endStreamAction) = maybeExtractEndStreamAction(lines)
+    val refreshTokenOpt = endStreamAction.flatMap { e =>
+      Option(e.refreshToken).flatMap { token =>
+        if (token.isEmpty) None else Some(token)
+      }
+    }
+    if (includeRefreshToken && refreshTokenOpt.isEmpty) {
+      logWarning("includeRefreshToken=true but refresh token is not returned.")
+    }
     require(versionAsOf.isEmpty || versionAsOf.get == version)
-    val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
+    val protocol = JsonUtils.fromJson[SingleAction](filteredLines(0)).protocol
     checkProtocol(protocol)
-    val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
-    val files = lines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).file)
-    DeltaTableFiles(version, protocol, metadata, files)
+    val metadata = JsonUtils.fromJson[SingleAction](filteredLines(1)).metaData
+    val files = filteredLines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).file)
+    DeltaTableFiles(version, protocol, metadata, files, refreshToken = refreshTokenOpt)
   }
 
   override def getFiles(
@@ -265,7 +283,19 @@ private[spark] class DeltaSharingRestClient(
     val target = getTargetUrl(
       s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query")
     val (version, lines) = getNDJson(
-      target, QueryTableRequest(Nil, None, None, None, Some(startingVersion), endingVersion, None))
+      target,
+      QueryTableRequest(
+        /* predicateHint */ Nil,
+        /* limitHint */ None,
+        /* version */ None,
+        /* timestamp */ None,
+        Some(startingVersion),
+        endingVersion,
+        /* jsonPredicateHints */ None,
+        /* includeRefreshToken */ None,
+        /* refreshToken */ None
+      )
+    )
     val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
     checkProtocol(protocol)
     val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
@@ -324,6 +354,17 @@ private[spark] class DeltaSharingRestClient(
       removeFiles = removeFiles,
       additionalMetadatas = additionalMetadatas
     )
+  }
+
+  // Check the last line and extract EndStreamAction if there is one.
+  private def maybeExtractEndStreamAction(
+      lines: Seq[String]): (Seq[String], Option[EndStreamAction]) = {
+    val endStreamAction = JsonUtils.fromJson[SingleAction](lines.last).endStreamAction
+    if (endStreamAction == null) {
+      (lines, None)
+    } else {
+      (lines.init, Some(endStreamAction))
+    }
   }
 
   private def getEncodedCDFParams(

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingProfileProvider.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingProfileProvider.scala
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.apache.spark.delta.sharing.TableRefreshResult
 
 import io.delta.sharing.spark.util.JsonUtils
 
@@ -47,10 +48,10 @@ trait DeltaSharingProfileProvider {
 
   def getCustomTablePath(tablePath: String): String = tablePath
 
-  // Map[String, String] is the id to url map.
-  // Long is the minimum url expiration time for all the urls.
-  def getCustomRefresher(refresher: () => (Map[String, String], Option[Long])): () =>
-    (Map[String, String], Option[Long]) = {
+  // `refresher` takes an optional refreshToken, and returns
+  // (idToUrlMap, minUrlExpirationTimestamp, refreshToken)
+  def getCustomRefresher(
+      refresher: Option[String] => TableRefreshResult): Option[String] => TableRefreshResult = {
     refresher
   }
 }

--- a/spark/src/main/scala/io/delta/sharing/spark/model.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/model.scala
@@ -49,7 +49,8 @@ private[sharing] case class DeltaTableFiles(
     addFiles: Seq[AddFileForCDF] = Nil,
     cdfFiles: Seq[AddCDCFile] = Nil,
     removeFiles: Seq[RemoveFile] = Nil,
-    additionalMetadatas: Seq[Metadata] = Nil)
+    additionalMetadatas: Seq[Metadata] = Nil,
+    refreshToken: Option[String] = None)
 
 private[sharing] case class Share(name: String)
 
@@ -65,7 +66,8 @@ private[sharing] case class SingleAction(
     cdf: AddCDCFile = null,
     remove: RemoveFile = null,
     metaData: Metadata = null,
-    protocol: Protocol = null) {
+    protocol: Protocol = null,
+    endStreamAction: EndStreamAction = null) {
 
   def unwrap: Action = {
     if (file != null) {
@@ -80,6 +82,8 @@ private[sharing] case class SingleAction(
       metaData
     } else if (protocol != null) {
       protocol
+    } else if (endStreamAction != null) {
+      endStreamAction
     } else {
       null
     }
@@ -109,6 +113,12 @@ private[sharing] sealed trait Action {
 
 private[sharing] case class Protocol(minReaderVersion: Int) extends Action {
   override def wrap: SingleAction = SingleAction(protocol = this)
+}
+
+private[sharing] case class EndStreamAction(
+    refreshToken: String)
+  extends Action {
+  override def wrap: SingleAction = SingleAction(endStreamAction = this)
 }
 
 // A common base class for all file actions.

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -25,6 +25,7 @@ import io.delta.sharing.spark.model.{
   AddCDCFile,
   AddFile,
   AddFileForCDF,
+  DeltaTableFiles,
   Format,
   Metadata,
   Protocol,
@@ -148,17 +149,16 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
   }
 
   integrationTest("getFiles") {
-    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
-    try {
-      val tableFiles =
-        client.getFiles(Table(name = "table2", schema = "default", share = "share2"), Nil, None, None, None, None)
+    def verifyTableFiles(tableFiles: DeltaTableFiles): Unit = {
       assert(tableFiles.version == 2)
       assert(Protocol(minReaderVersion = 1) == tableFiles.protocol)
       val expectedMetadata = Metadata(
         id = "f8d5c169-3d01-4ca3-ad9e-7dc3355aedb2",
         format = Format(),
-        schemaString = """{"type":"struct","fields":[{"name":"eventTime","type":"timestamp","nullable":true,"metadata":{}},{"name":"date","type":"date","nullable":true,"metadata":{}}]}""",
-        partitionColumns = Seq("date"))
+        schemaString =
+          """{"type":"struct","fields":[{"name":"eventTime","type":"timestamp","nullable":true,"metadata":{}},{"name":"date","type":"date","nullable":true,"metadata":{}}]}""",
+        partitionColumns = Seq("date")
+      )
       assert(expectedMetadata == tableFiles.metadata)
       assert(tableFiles.files.size == 2)
       val expectedFiles = Seq(
@@ -168,7 +168,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
           id = "9f1a49539c5cffe1ea7f9e055d5c003c",
           partitionValues = Map("date" -> "2021-04-28"),
           size = 573,
-          stats = """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:33:57.955Z"},"maxValues":{"eventTime":"2021-04-28T23:33:57.955Z"},"nullCount":{"eventTime":0}}"""
+          stats =
+            """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:33:57.955Z"},"maxValues":{"eventTime":"2021-04-28T23:33:57.955Z"},"nullCount":{"eventTime":0}}"""
         ),
         AddFile(
           url = tableFiles.files(1).url,
@@ -176,11 +177,40 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
           id = "cd2209b32f5ed5305922dd50f5908a75",
           partitionValues = Map("date" -> "2021-04-28"),
           size = 573,
-          stats = """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"maxValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"nullCount":{"eventTime":0}}"""
+          stats =
+            """{"numRecords":1,"minValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"maxValues":{"eventTime":"2021-04-28T23:33:48.719Z"},"nullCount":{"eventTime":0}}"""
         )
       )
       assert(expectedFiles == tableFiles.files.toList)
       assert(tableFiles.files(0).expirationTimestamp > System.currentTimeMillis())
+      // Refresh token should be returned in latest snapshot query
+      assert(tableFiles.refreshToken.nonEmpty)
+      assert(tableFiles.refreshToken.get.nonEmpty)
+    }
+
+    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
+    val table = Table(name = "table2", schema = "default", share = "share2")
+    try {
+      val tableFiles = client.getFiles(
+        table,
+        predicates = Nil,
+        limit = None,
+        versionAsOf = None,
+        timestampAsOf = None,
+        jsonPredicateHints = None,
+        refreshToken = None
+      )
+      verifyTableFiles(tableFiles)
+      val refreshedTableFiles = client.getFiles(
+        table,
+        predicates = Nil,
+        limit = None,
+        versionAsOf = None,
+        timestampAsOf = None,
+        jsonPredicateHints = None,
+        refreshToken = tableFiles.refreshToken
+      )
+      verifyTableFiles(refreshedTableFiles)
     } finally {
       client.close()
     }
@@ -190,12 +220,14 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
     try {
       val tableFiles = client.getFiles(
-        Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
-        Nil,
-        None,
-        Some(1L),
-        None,
-        None)
+        table = Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
+        predicates = Nil,
+        limit = None,
+        versionAsOf = Some(1L),
+        timestampAsOf = None,
+        jsonPredicateHints = None,
+        refreshToken = None
+      )
       assert(tableFiles.version == 1)
       assert(tableFiles.files.size == 3)
       val expectedFiles = Seq(
@@ -232,6 +264,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       )
       assert(expectedFiles == tableFiles.files.toList)
       assert(tableFiles.files(0).expirationTimestamp > System.currentTimeMillis())
+      // Refresh token shouldn't be returned in version query
+      assert(tableFiles.refreshToken.isEmpty)
     } finally {
       client.close()
     }
@@ -242,12 +276,13 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     try {
       val errorMessage = intercept[UnexpectedHttpStatus] {
         client.getFiles(
-          Table(name = "table1", schema = "default", share = "share1"),
-          Nil,
-          None,
-          Some(1L),
-          None,
-          None
+          table = Table(name = "table1", schema = "default", share = "share1"),
+          predicates = Nil,
+          limit = None,
+          versionAsOf = Some(1L),
+          timestampAsOf = None,
+          jsonPredicateHints = None,
+          refreshToken = None
         )
       }.getMessage
       assert(errorMessage.contains("Reading table by version or timestamp is not supported because change data feed is not enabled on table: share1.default.table1"))
@@ -265,12 +300,14 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       // Because with undecided timezone, the timestamp string can be mapped to different versions
       val errorMessage = intercept[UnexpectedHttpStatus] {
         client.getFiles(
-          Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
-          Nil,
-          None,
-          None,
-          Some("2000-01-01T00:00:00Z"),
-          None)
+          table = Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
+          predicates = Nil,
+          limit = None,
+          versionAsOf = None,
+          timestampAsOf = Some("2000-01-01T00:00:00Z"),
+          jsonPredicateHints = None,
+          refreshToken = None
+        )
       }.getMessage
       assert(errorMessage.contains("The provided timestamp"))
     } finally {
@@ -283,12 +320,13 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     try {
       val errorMessage = intercept[UnexpectedHttpStatus] {
         client.getFiles(
-          Table(name = "table1", schema = "default", share = "share1"),
-          Nil,
-          None,
-          None,
-          Some("abc"),
-          None
+          table = Table(name = "table1", schema = "default", share = "share1"),
+          predicates = Nil,
+          limit = None,
+          versionAsOf = None,
+          timestampAsOf = Some("abc"),
+          jsonPredicateHints = None,
+          refreshToken = None
         )
       }.getMessage
       assert(errorMessage.contains("Reading table by version or timestamp is not supported because change data feed is not enabled on table: share1.default.table1"))

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -70,8 +70,12 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
 
     // sanity check for dummy client
     val client = new TestDeltaSharingClient()
-    client.getFiles(Table("fe", "fi", "fo"), Nil, Some(2L), None, None, Some("jsonPredicate1"))
-    client.getFiles(Table("fe", "fi", "fo"), Nil, Some(3L), None, None, Some("jsonPredicate2"))
+    client.getFiles(
+      Table("fe", "fi", "fo"), Nil, Some(2L), None, None, Some("jsonPredicate1"), None
+    )
+    client.getFiles(
+      Table("fe", "fi", "fo"), Nil, Some(3L), None, None, Some("jsonPredicate2"), None
+    )
     assert(TestDeltaSharingClient.limits === Seq(2L, 3L))
     assert(TestDeltaSharingClient.jsonPredicateHints === Seq("jsonPredicate1", "jsonPredicate2"))
     client.clear()

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -62,7 +62,8 @@ class TestDeltaSharingClient(
     limit: Option[Long],
     versionAsOf: Option[Long],
     timestampAsOf: Option[String],
-    jsonPredicateHints: Option[String]): DeltaTableFiles = {
+    jsonPredicateHints: Option[String],
+    refreshToken: Option[String]): DeltaTableFiles = {
     limit.foreach(lim => TestDeltaSharingClient.limits = TestDeltaSharingClient.limits :+ lim)
     jsonPredicateHints.foreach(p => {
       TestDeltaSharingClient.jsonPredicateHints = TestDeltaSharingClient.jsonPredicateHints :+ p

--- a/spark/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
@@ -41,9 +41,10 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
-          (Map("id1" -> "url1", "id2" -> "url2"), None)
-        })
+        _ => {
+          TableRefreshResult(Map("id1" -> "url1", "id2" -> "url2"), None, None)
+        },
+        refreshToken = None)
       assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path"),
         "id1")._1 == "url1")
       assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path"),
@@ -54,9 +55,10 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
-          (Map("id1" -> "url3", "id2" -> "url4"), None)
-        })
+        _ => {
+          TableRefreshResult(Map("id1" -> "url3", "id2" -> "url4"), None, None)
+        },
+        refreshToken = None)
       // We should get the new urls eventually
       eventually(timeout(10.seconds)) {
         assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path2"),
@@ -70,9 +72,10 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(new AnyRef)),
         provider,
-        () => {
-          (Map("id1" -> "url3", "id2" -> "url4"), None)
-        })
+        _ => {
+          TableRefreshResult(Map("id1" -> "url3", "id2" -> "url4"), None, None)
+        },
+        refreshToken = None)
       // We should remove the cached table eventually
       eventually(timeout(10.seconds)) {
         System.gc()
@@ -87,10 +90,11 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
-          (Map("id1" -> "url3", "id2" -> "url4"), None)
+        _ => {
+          TableRefreshResult(Map("id1" -> "url3", "id2" -> "url4"), None, None)
         },
-        -1
+        -1,
+        refreshToken = None
       )
       // We should get new urls immediately because it's refreshed upon register
       assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path4"),
@@ -118,14 +122,16 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
+        _ => {
           refreshTime += 1
-          (
+          TableRefreshResult(
             Map("id1" -> ("url" + refreshTime.toString), "id2" -> "url4"),
-            Some(System.currentTimeMillis() + 1900)
+            Some(System.currentTimeMillis() + 1900),
+            None
           )
         },
-        System.currentTimeMillis() + 1900
+        System.currentTimeMillis() + 1900,
+        None
       )
       // We should refresh at least 5 times within 10 seconds based on
       // (System.currentTimeMillis() + 1900).
@@ -142,14 +148,16 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
+        _ => {
           refreshTime2 += 1
-          (
+          TableRefreshResult(
             Map("id1" -> ("url" + refreshTime2.toString), "id2" -> "url4"),
-            Some(System.currentTimeMillis() + 4900)
+            Some(System.currentTimeMillis() + 4900),
+            None
           )
         },
-        System.currentTimeMillis() + 4900
+        System.currentTimeMillis() + 4900,
+        None
       )
       // We should refresh 2 times within 10 seconds based on (System.currentTimeMillis() + 4900).
       eventually(timeout(10.seconds)) {
@@ -165,14 +173,16 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
+        _ => {
           refreshTime3 += 1
-          (
+          TableRefreshResult(
             Map("id1" -> ("url" + refreshTime3.toString), "id2" -> "url4"),
-            Some(System.currentTimeMillis() - 4900)
+            Some(System.currentTimeMillis() - 4900),
+            None
           )
         },
-        System.currentTimeMillis() + 6000
+        System.currentTimeMillis() + 6000,
+        None
       )
       // We should refresh 1 times within 10 seconds based on (preSignedUrlExpirationMs = 6000).
       try {
@@ -185,6 +195,52 @@ class CachedTableManagerSuite extends SparkFunSuite {
       } catch {
         case e: Throwable =>
           assert(e.getMessage.contains("did not equal"))
+      }
+    } finally {
+      manager.stop()
+    }
+  }
+
+  test("refresh using refresh token") {
+    val manager = new CachedTableManager(
+      preSignedUrlExpirationMs = 10,
+      refreshCheckIntervalMs = 10,
+      refreshThresholdMs = 10,
+      expireAfterAccessMs = 60000
+    )
+    try {
+      val ref = new AnyRef
+      val provider = new TestDeltaSharingProfileProvider
+      manager.register(
+        "test-table-path",
+        Map("id1" -> "url1", "id2" -> "url2"),
+        Seq(new WeakReference(ref)),
+        provider,
+        refreshToken => {
+          if (refreshToken.contains("refresh-token-1")) {
+            TableRefreshResult(
+              Map("id1" -> "url3", "id2" -> "url4"),
+              None,
+              Some("refresh-token-2")
+            )
+          } else if (refreshToken.contains("refresh-token-2")) {
+            TableRefreshResult(
+              Map("id1" -> "url5", "id2" -> "url6"),
+              None,
+              Some("refresh-token-2")
+            )
+          } else {
+            fail("Expecting to refresh with a refresh token")
+          }
+        },
+        refreshToken = Some("refresh-token-1")
+      )
+      // We should get url5 and url6 eventually.
+      eventually(timeout(10.seconds)) {
+        assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path"),
+          "id1")._1 == "url5")
+        assert(manager.getPreSignedUrl(provider.getCustomTablePath("test-table-path"),
+          "id2")._1 == "url6")
       }
     } finally {
       manager.stop()
@@ -207,9 +263,10 @@ class CachedTableManagerSuite extends SparkFunSuite {
         Map("id1" -> "url1", "id2" -> "url2"),
         Seq(new WeakReference(ref)),
         provider,
-        () => {
-          (Map("id1" -> "url1", "id2" -> "url2"), None)
-        })
+        _ => {
+          TableRefreshResult(Map("id1" -> "url1", "id2" -> "url2"), None, None)
+        },
+        refreshToken = None)
       Thread.sleep(1000)
       // We should remove the cached table when it's not accessed
       intercept[IllegalStateException](manager.getPreSignedUrl(


### PR DESCRIPTION
This pr adds refresh token fix to delta-sharing-spark branch-0.7:

- In `DeltaSharingClient`, if the query is for latest snapshot, set `includeRefreshToken=true` to retrieve the refresh token.
- In `CachedTableManager`, when refreshing a cached table, use `refreshToken` to update urls.
- Added tests for client side changes, also added refresh token changes in the reference server to support integration test.