### PR TITLE
Throw error when respondedFormat doesn't match requested responseFormat

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -239,8 +239,12 @@ class DeltaSharingRestClient(
     if (responseFormat != respondedFormat) {
       // This could only happen when the asked format is delta and the server doesn't support
       // the requested format.
-      logWarning(s"RespondedFormat($respondedFormat) is different from requested responseFormat(" +
+      logError(s"RespondedFormat($respondedFormat) is different from requested responseFormat(" +
         s"$responseFormat) for getMetadata.${table.share}.${table.schema}.${table.name}.")
+      throw new IllegalArgumentException("The responseFormat returned from the delta sharing " +
+        s"server doesn't match the requested responseFormat: respondedFormat($respondedFormat)" +
+        s" != requestedFormat($responseFormat)." +
+        s"This is likely because the server is not upgraded to support delta format sharing.")
     }
     // To ensure that it works with delta sharing server that doesn't support the requested format.
     if (respondedFormat == RESPONSE_FORMAT_DELTA) {
@@ -313,9 +317,13 @@ class DeltaSharingRestClient(
     }
 
     if (responseFormat != respondedFormat) {
-      logWarning(s"RespondedFormat($respondedFormat) is different from requested responseFormat(" +
+      logError(s"RespondedFormat($respondedFormat) is different from requested responseFormat(" +
         s"$responseFormat) for getFiles(versionAsOf-$versionAsOf, timestampAsOf-$timestampAsOf " +
         s"for table ${table.share}.${table.schema}.${table.name}.")
+      throw new IllegalArgumentException("The responseFormat returned from the delta sharing " +
+        s"server doesn't match the requested responseFormat: respondedFormat($respondedFormat)" +
+        s" != requestedFormat($responseFormat)." +
+        s"This is likely because the server is not upgraded to support delta format sharing.")
     }
     // To ensure that it works with delta sharing server that doesn't support the requested format.
     if (respondedFormat == RESPONSE_FORMAT_DELTA) {
@@ -363,9 +371,13 @@ class DeltaSharingRestClient(
       getNDJson(target, request)
     }
     if (responseFormat != respondedFormat) {
-      logWarning(s"RespondedFormat($respondedFormat) is different from requested responseFormat(" +
+      logError(s"RespondedFormat($respondedFormat) is different from requested responseFormat(" +
         s"$responseFormat) for getFiles(startingVersion-$startingVersion, endingVersion-" +
         s"$endingVersion) for table ${table.share}.${table.schema}.${table.name}.")
+      throw new IllegalArgumentException("The responseFormat returned from the delta sharing " +
+        s"server doesn't match the requested responseFormat: respondedFormat($respondedFormat)" +
+        s" != requestedFormat($responseFormat)." +
+        s"This is likely because the server is not upgraded to support delta format sharing.")
     }
     // To ensure that it works with delta sharing server that doesn't support the requested format.
     if (respondedFormat == RESPONSE_FORMAT_DELTA) {
@@ -481,9 +493,13 @@ class DeltaSharingRestClient(
       getNDJson(target, requireVersion = false)
     }
     if (responseFormat != respondedFormat) {
-      logWarning(s"RespondedFormat($respondedFormat) is different from requested responseFormat(" +
+      logError(s"RespondedFormat($respondedFormat) is different from requested responseFormat(" +
         s"$responseFormat) for getCDFFiles(cdfOptions-$cdfOptions) for table " +
         s"${table.share}.${table.schema}.${table.name}.")
+      throw new IllegalArgumentException("The responseFormat returned from the delta sharing " +
+        s"server doesn't match the requested responseFormat: respondedFormat($respondedFormat)" +
+        s" != requestedFormat($responseFormat)." +
+        s"This is likely because the server is not upgraded to support delta format sharing.")
     }
     // To ensure that it works with delta sharing server that doesn't support the requested format.
     if (respondedFormat == RESPONSE_FORMAT_DELTA) {

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -273,14 +273,12 @@ class DeltaSharingService(serverConfig: ServerConfig) {
     if (headerString == null) {
       return Map.empty[String, String]
     }
-    headerString.toLowerCase().split(",").map { capability =>
-      val splits = capability.split("=")
-      if (splits.size == 2) {
+    headerString.toLowerCase().split(";")
+      .map(_.split("="))
+      .filter(_.size == 2)
+      .map { splits =>
         (splits(0), splits(1))
-      } else {
-        ("", "")
-      }
-    }.toMap
+      }.toMap
   }
 
   @Get("/shares/{share}/schemas/{schema}/tables/{table}/metadata")


### PR DESCRIPTION
1. Throw error when respondedFormat != requested responseFormat. This is to alert when an advanced client is querying an old server, to let the client query the files with parquet format sharing.
2. fix the parsing of delta-sharing-capabilities header in server.

Tests:
1. As in integration test we are using the oss server which always return the correct responseFormat, I tested this change by manually disable the responseFormat in server and verified the error below:
```
[info] - getMetadata with configuration *** FAILED ***
[info]   java.lang.IllegalArgumentException: The responseFormat returned from the delta sharing server doesn't match the requested responseFormat: respondedFormat(parquet) != requestedFormat(delta).This is likely because the server is not upgraded to support delta format sharing.
[info]   at io.delta.sharing.client.DeltaSharingRestClient.getMetadata(DeltaSharingClient.scala:247)
[info]   at io.delta.sharing.client.DeltaSharingRestClientDeltaSuite.$anonfun$new$3(DeltaSharingRestClientDeltaSuite.scala:74)
[info]   at io.delta.sharing.client.DeltaSharingIntegrationTest.$anonfun$integrationTest$1(DeltaSharingIntegrationTest.scala:133)
[info]   at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike$$anon$1.apply(AnyFunSuiteLike.scala:190)
```

2. Also manually tested the parsing of the header at the server with the following output:
`map:Map(responseformat -> delta, readerfeatures -> deletionvectors,columnmapping,timestampntz)`