### PR TITLE
Move JsonPredicates, OpConverter and RetryUtilsSuite from spark to client

### DIFF
--- a/client/src/main/scala/io/delta/sharing/filters/JsonPredicates.scala
+++ b/client/src/main/scala/io/delta/sharing/filters/JsonPredicates.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.delta.sharing.spark.filters
+package io.delta.sharing.filters
 
 import scala.collection.mutable.ListBuffer
 

--- a/client/src/main/scala/io/delta/sharing/filters/OpConverter.scala
+++ b/client/src/main/scala/io/delta/sharing/filters/OpConverter.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.delta.sharing.spark.filters
+package io.delta.sharing.filters
 
 import scala.collection.mutable.ListBuffer
 

--- a/client/src/test/scala/io/delta/sharing/client/util/RetryUtilsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/RetryUtilsSuite.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.delta.sharing.spark.util
+package io.delta.sharing.client.util
 
 import java.io.{InterruptedIOException, IOException}
 

--- a/client/src/test/scala/io/delta/sharing/filters/JsonPredicateSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/filters/JsonPredicateSuite.scala
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-// scalastyle:off println
-
-package io.delta.sharing.spark.filters
+package io.delta.sharing.filters
 
 import org.apache.spark.SparkFunSuite
 
@@ -423,6 +421,8 @@ class JsonPredicateSuite extends SparkFunSuite {
       evalExpectBoolean(op, EvalContext(Map("date" -> dates(i % dates.size))))
     }
     val t = System.currentTimeMillis() - start
+
+    // scalastyle:off println
     println("Stress test took " + t + " millis")
   }
 }

--- a/client/src/test/scala/io/delta/sharing/filters/OpConverterSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/filters/OpConverterSuite.scala
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-// scalastyle:off println
-
-package io.delta.sharing.spark.filters
+package io.delta.sharing.filters
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.expressions.{

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -38,7 +38,7 @@ import io.delta.sharing.client.model.{
   RemoveFile
 }
 import io.delta.sharing.client.util.{ConfUtils, JsonUtils}
-import io.delta.sharing.spark.filters.{AndOp, BaseOp, OpConverter}
+import io.delta.sharing.filters.{AndOp, BaseOp, OpConverter}
 
 private[sharing] case class RemoteDeltaFileIndexParams(
     val spark: SparkSession,

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.types.{
 import io.delta.sharing.client.DeltaSharingClient
 import io.delta.sharing.client.model.Table
 import io.delta.sharing.client.util.JsonUtils
-import io.delta.sharing.spark.filters.{BaseOp, OpConverter}
+import io.delta.sharing.filters.{BaseOp, OpConverter}
 
 class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
 


### PR DESCRIPTION
Move JsonPredicates and OpConverter and RetryUtilsSuite from spark to client, as they are of delta sharing core logic.