### PR TITLE
Fix build errors: use a static Cast init function in all places under spark/

### DIFF
--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -16,8 +16,7 @@
 
 package io.delta.sharing.server.model
 
-import com.fasterxml.jackson.annotation.JsonInclude
-import org.codehaus.jackson.annotate.JsonRawValue
+import com.fasterxml.jackson.annotation.{JsonInclude, JsonRawValue}
 
 case class SingleAction(
     file: AddFile = null,

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -16,7 +16,8 @@
 
 package io.delta.sharing.server.model
 
-import com.fasterxml.jackson.annotation.{JsonInclude, JsonRawValue}
+import com.fasterxml.jackson.annotation.JsonInclude
+import org.codehaus.jackson.annotate.JsonRawValue
 
 case class SingleAction(
     file: AddFile = null,

--- a/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -16,16 +16,12 @@
 
 package io.delta.sharing.spark
 
-import java.lang.ref.WeakReference
-
 import org.apache.hadoop.fs.{FileStatus, Path}
-import org.apache.spark.delta.sharing.CachedTableManager
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Column, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Cast, Expression, GenericInternalRow, Literal, SubqueryExpression}
-import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, HadoopFsRelation, PartitionDirectory}
+import org.apache.spark.sql.catalyst.expressions.{And, Cast, Expression, GenericInternalRow, Literal}
+import org.apache.spark.sql.execution.datasources.{FileIndex, PartitionDirectory}
 import org.apache.spark.sql.types.{DataType, StructType}
 
 import io.delta.sharing.client.{DeltaSharingFileSystem, DeltaSharingProfileProvider}
@@ -71,7 +67,7 @@ private[sharing] abstract class RemoteDeltaFileIndexBase(
     actions.groupBy(_.getPartitionValuesInDF()).map {
       case (partitionValues, files) =>
         val rowValues: Array[Any] = partitionSchema.map { p =>
-          Cast(Literal(partitionValues(p.name)), p.dataType, Option(timeZone)).eval()
+          new Cast(Literal(partitionValues(p.name)), p.dataType, Option(timeZone)).eval()
         }.toArray
 
         val fileStats = files.map { f =>
@@ -102,7 +98,8 @@ private[sharing] abstract class RemoteDeltaFileIndexBase(
     val rewrittenFilters = DeltaTableUtils.rewritePartitionFilters(
       params.snapshotAtAnalysis.partitionSchema,
       params.spark.sessionState.conf.resolver,
-      partitionFilters)
+      partitionFilters,
+      params.spark.sessionState.conf.sessionLocalTimeZone)
     new Column(rewrittenFilters.reduceLeftOption(And).getOrElse(Literal(true)))
   }
 


### PR DESCRIPTION
Fix build errors: use a static Cast init function in all places under spark/, and clean up some imports.
A similar change to https://github.com/delta-io/delta-sharing/pull/371