### PR TITLE
Improve error message on unrecognized file from server, and add two configs in 0.6

### DIFF
--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -178,7 +178,7 @@ class DeltaSharingReader:
 
         if for_cdf:
             # Add the change type col name to non cdc actions.
-            if type(action) != AddCdcFile:
+            if not isinstance(action, AddCdcFile):
                 pdf[DeltaSharingReader._change_type_col_name()] = action.get_change_type_col_value()
 
             # If available, add timestamp and version columns from the action.

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -272,11 +272,14 @@ private[spark] class DeltaSharingRestClient(
     val addFiles = ArrayBuffer[AddFileForCDF]()
     val removeFiles = ArrayBuffer[RemoveFile]()
     val additionalMetadatas = ArrayBuffer[Metadata]()
-    lines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).unwrap).foreach{
-      case a: AddFileForCDF => addFiles.append(a)
-      case r: RemoveFile => removeFiles.append(r)
-      case m: Metadata => additionalMetadatas.append(m)
-      case f => throw new IllegalStateException(s"Unexpected File:${f}")
+    lines.drop(2).foreach { line =>
+      val action = JsonUtils.fromJson[SingleAction](line).unwrap
+      action match {
+        case a: AddFileForCDF => addFiles.append(a)
+        case r: RemoveFile => removeFiles.append(r)
+        case m: Metadata => additionalMetadatas.append(m)
+        case _ => throw new IllegalStateException(s"Unexpected Line:${line}")
+      }
     }
     DeltaTableFiles(
       version,
@@ -308,12 +311,15 @@ private[spark] class DeltaSharingRestClient(
     val cdfFiles = ArrayBuffer[AddCDCFile]()
     val removeFiles = ArrayBuffer[RemoveFile]()
     val additionalMetadatas = ArrayBuffer[Metadata]()
-    lines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).unwrap).foreach{
-      case c: AddCDCFile => cdfFiles.append(c)
-      case a: AddFileForCDF => addFiles.append(a)
-      case r: RemoveFile => removeFiles.append(r)
-      case m: Metadata => additionalMetadatas.append(m)
-      case f => throw new IllegalStateException(s"Unexpected File:${f}")
+    lines.drop(2).foreach { line =>
+      val action = JsonUtils.fromJson[SingleAction](line).unwrap
+      action match {
+        case c: AddCDCFile => cdfFiles.append(c)
+        case a: AddFileForCDF => addFiles.append(a)
+        case r: RemoveFile => removeFiles.append(r)
+        case m: Metadata => additionalMetadatas.append(m)
+        case _ => throw new IllegalStateException(s"Unexpected Line:${line}")
+      }
     }
     DeltaTableFiles(
       version,

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -40,7 +40,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 
 import io.delta.sharing.spark.model._
-import io.delta.sharing.spark.util.{ConfUtils, JsonUtils, RetryUtils, UnexpectedHttpStatus}
+import io.delta.sharing.spark.util.{JsonUtils, RetryUtils, UnexpectedHttpStatus}
 
 /** An interface to fetch Delta metadata from remote server. */
 private[sharing] trait DeltaSharingClient {
@@ -273,10 +273,8 @@ private[spark] class DeltaSharingRestClient(
       val action = JsonUtils.fromJson[SingleAction](line)
       if (action.file != null) {
         files.append(action.file)
-      } else if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
-        throw new IllegalStateException(s"Unexpected Line:${line}")
       } else {
-        logWarning(s"Unexpected Line:${line}.")
+        throw new IllegalStateException(s"Unexpected Line:${line}")
       }
     }
     DeltaTableFiles(version, protocol, metadata, files, refreshToken = refreshTokenOpt)
@@ -318,11 +316,7 @@ private[spark] class DeltaSharingRestClient(
         case a: AddFileForCDF => addFiles.append(a)
         case r: RemoveFile => removeFiles.append(r)
         case m: Metadata => additionalMetadatas.append(m)
-        case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
-          throw new IllegalStateException(s"Unexpected Line:${line}")
-        } else {
-          logWarning(s"Unexpected Line:${line}.")
-        }
+        case _ => throw new IllegalStateException(s"Unexpected Line:${line}")
       }
     }
     DeltaTableFiles(
@@ -362,11 +356,7 @@ private[spark] class DeltaSharingRestClient(
         case a: AddFileForCDF => addFiles.append(a)
         case r: RemoveFile => removeFiles.append(r)
         case m: Metadata => additionalMetadatas.append(m)
-        case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
-          throw new IllegalStateException(s"Unexpected Line:${line}")
-        } else {
-          logWarning(s"Unexpected Line:${line}.")
-        }
+        case _ => throw new IllegalStateException(s"Unexpected Line:${line}")
       }
     }
     DeltaTableFiles(

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -250,7 +250,14 @@ private[spark] class DeltaSharingRestClient(
     val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
     checkProtocol(protocol)
     val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
-    val files = lines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).file)
+    val files = lines.drop(2).map{ line =>
+      val action = JsonUtils.fromJson[SingleAction](line)
+      if (action.file != null) {
+        action.file
+      } else {
+        throw new IllegalStateException(s"Unexpected Line:${line}")
+      }
+    }
     DeltaTableFiles(version, protocol, metadata, files)
   }
 

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -275,6 +275,8 @@ private[spark] class DeltaSharingRestClient(
         files.append(action.file)
       } else if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
         throw new IllegalStateException(s"Unexpected Line:${line}")
+      } else {
+        logWarning(s"Unexpected Line:${line}.")
       }
     }
     DeltaTableFiles(version, protocol, metadata, files, refreshToken = refreshTokenOpt)
@@ -318,6 +320,8 @@ private[spark] class DeltaSharingRestClient(
         case m: Metadata => additionalMetadatas.append(m)
         case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
           throw new IllegalStateException(s"Unexpected Line:${line}")
+        } else {
+          logWarning(s"Unexpected Line:${line}.")
         }
       }
     }
@@ -360,6 +364,8 @@ private[spark] class DeltaSharingRestClient(
         case m: Metadata => additionalMetadatas.append(m)
         case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
           throw new IllegalStateException(s"Unexpected Line:${line}")
+        } else {
+          logWarning(s"Unexpected Line:${line}.")
         }
       }
     }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -658,8 +658,6 @@ case class DeltaSharingSource(
       // add won't be null at this step as addFile is the only interested file when
       // options.readChangeFeed is false, which is when this function is called.
       assert(indexedFile.add != null, "add file cannot be null.")
-      logWarning(s"----[linzhou]----addFile, version:${indexedFile.version}, " +
-        s"index:${indexedFile.index}, id:${indexedFile.add.id}, url:${indexedFile.add.url}")
       val add = indexedFile.add
       AddFile(add.url, add.id, add.partitionValues, add.size, add.stats)
     }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -658,6 +658,8 @@ case class DeltaSharingSource(
       // add won't be null at this step as addFile is the only interested file when
       // options.readChangeFeed is false, which is when this function is called.
       assert(indexedFile.add != null, "add file cannot be null.")
+      logWarning(s"----[linzhou]----addFile, version:${indexedFile.version}, " +
+        s"index:${indexedFile.index}, id:${indexedFile.add.id}, url:${indexedFile.add.url}")
       val add = indexedFile.add
       AddFile(add.url, add.id, add.partitionValues, add.size, add.stats)
     }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -148,9 +148,16 @@ case class DeltaSharingSource(
   private var lastGetVersionTimestamp: Long = -1
   private var latestTableVersion: Long = -1
   // minimum 30 seconds
-  private val QUERY_TABLE_VERSION_INTERVAL_MILLIS = 30000.max(
-    ConfUtils.streamingQueryTableVersionIntervalSeconds(spark.sessionState.conf)
-  )
+  private val QUERY_TABLE_VERSION_INTERVAL_MILLIS = {
+    val interval = 30000.max(
+      ConfUtils.streamingQueryTableVersionIntervalSeconds(spark.sessionState.conf) * 1000
+    )
+    if (interval < 30000) {
+      throw new IllegalArgumentException(s"QUERY_TABLE_VERSION_INTERVAL_MILLIS($interval) must " +
+        "not be less than 30 seconds.")
+    }
+    interval
+  }
 
   private val maxVersionsPerRpc: Int = options.maxVersionsPerRpc.getOrElse(
     DeltaSharingOptions.MAX_VERSIONS_PER_RPC_DEFAULT

--- a/spark/src/main/scala/io/delta/sharing/spark/RandomAccessHttpInputStream.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RandomAccessHttpInputStream.scala
@@ -167,7 +167,7 @@ private[sharing] class RandomAccessHttpInputStream(
             }
           }
           throw new UnexpectedHttpStatus(
-            s"HTTP request failed with status: $status $errorBody. While accessing [$uri]",
+            s"HTTP request failed with status: $status $errorBody, while accessing [$uri]",
             statusCode)
         }
         entity

--- a/spark/src/main/scala/io/delta/sharing/spark/RandomAccessHttpInputStream.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RandomAccessHttpInputStream.scala
@@ -167,7 +167,7 @@ private[sharing] class RandomAccessHttpInputStream(
             }
           }
           throw new UnexpectedHttpStatus(
-            s"HTTP request failed with status: $status $errorBody",
+            s"HTTP request failed with status: $status $errorBody. While accessing [$uri]",
             statusCode)
         }
         entity

--- a/spark/src/main/scala/io/delta/sharing/spark/util/ConfUtils.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/util/ConfUtils.scala
@@ -36,9 +36,6 @@ object ConfUtils {
   val MAX_CONNECTION_CONF = "spark.delta.sharing.network.maxConnections"
   val MAX_CONNECTION_DEFAULT = 64
 
-  val IGNORE_UNPARSED_ACTIONS = "spark.delta.sharing.ignoreUnparsedActions"
-  val IGNORE_UNPARSED_ACTIONS_DEFAULT = false
-
   val QUERY_TABLE_VERSION_INTERVAL_SECONDS =
     "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds"
   val QUERY_TABLE_VERSION_INTERVAL_SECONDS_DEFAULT = "30s"
@@ -82,10 +79,6 @@ object ConfUtils {
     val maxConn = conf.getInt(MAX_CONNECTION_CONF, MAX_CONNECTION_DEFAULT)
     validateNonNeg(maxConn, MAX_CONNECTION_CONF)
     maxConn
-  }
-
-  def ignoreUnparsedActions(conf: SQLConf): Boolean = {
-    conf.getConfString(IGNORE_UNPARSED_ACTIONS, IGNORE_UNPARSED_ACTIONS_DEFAULT.toString).toBoolean
   }
 
   def streamingQueryTableVersionIntervalSeconds(conf: SQLConf): Int = {

--- a/spark/src/main/scala/io/delta/sharing/spark/util/ConfUtils.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/util/ConfUtils.scala
@@ -96,11 +96,14 @@ object ConfUtils {
     toTimeInSeconds(intervalStr, QUERY_TABLE_VERSION_INTERVAL_SECONDS)
   }
 
-  private def toTimeInSeconds(timeStr: String, arg: String): Int = {
+  private def toTimeInSeconds(timeStr: String, conf: String): Int = {
     val timeInSeconds = JavaUtils.timeStringAs(timeStr, TimeUnit.SECONDS)
-    validateNonNeg(timeInSeconds, arg)
+    validateNonNeg(timeInSeconds, conf)
+    if (conf == QUERY_TABLE_VERSION_INTERVAL_SECONDS && timeInSeconds < 30) {
+      throw new IllegalArgumentException(conf + " must not be less than 30 seconds.")
+    }
     if (timeInSeconds > Int.MaxValue) {
-      throw new IllegalArgumentException(arg + " is too big: " +  timeStr)
+      throw new IllegalArgumentException(conf + " is too big: " +  timeStr)
     }
     timeInSeconds.toInt
   }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -273,7 +273,7 @@ class DeltaSharingSourceSuite extends QueryTest
       "30"
     )
   }
-  
+
   /**
    * Test basic streaming functionality
    */

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -255,6 +255,26 @@ class DeltaSharingSourceSuite extends QueryTest
   }
 
   /**
+   * Test spark config of query table version interval
+   */
+  integrationTest("query table version interval cannot be less than 30 seconds") {
+    spark.sessionState.conf.setConfString(
+      "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds",
+      "29"
+    )
+    val message = intercept[Exception] {
+      val query = spark.readStream.format("deltaSharing").load(tablePath)
+        .writeStream.format("console").start()
+      query.processAllAvailable()
+    }.getMessage
+    assert(message.contains("must not be less than 30 seconds."))
+    spark.sessionState.conf.setConfString(
+      "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds",
+      "30"
+    )
+  }
+  
+  /**
    * Test basic streaming functionality
    */
   integrationTest("basic - success") {


### PR DESCRIPTION
Improve error message when seeing unrecognized file from server: output the line instead of file.
And add two configs:

- "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds", cannot be less than 30 seconds
- "spark.delta.sharing.ignoreUnparsedActions"
