### PR TITLE
Improve error message on unrecognized file from server, and add two configs in 0.7

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -40,7 +40,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 
 import io.delta.sharing.spark.model._
-import io.delta.sharing.spark.util.{ConfUtils, JsonUtils, RetryUtils, UnexpectedHttpStatus}
+import io.delta.sharing.spark.util.{JsonUtils, RetryUtils, UnexpectedHttpStatus}
 
 /** An interface to fetch Delta metadata from remote server. */
 private[sharing] trait DeltaSharingClient {
@@ -273,10 +273,8 @@ private[spark] class DeltaSharingRestClient(
       val action = JsonUtils.fromJson[SingleAction](line)
       if (action.file != null) {
         files.append(action.file)
-      } else if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
-        throw new IllegalStateException(s"Unexpected Line:${line}")
       } else {
-        logWarning(s"Unexpected Line:${line}")
+        throw new IllegalStateException(s"Unexpected Line:${line}")
       }
     }
     DeltaTableFiles(version, protocol, metadata, files, refreshToken = refreshTokenOpt)
@@ -318,11 +316,7 @@ private[spark] class DeltaSharingRestClient(
         case a: AddFileForCDF => addFiles.append(a)
         case r: RemoveFile => removeFiles.append(r)
         case m: Metadata => additionalMetadatas.append(m)
-        case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
-          throw new IllegalStateException(s"Unexpected Line:${line}")
-        } else {
-          logWarning(s"Unexpected Line:${line}")
-        }
+        case _ => throw new IllegalStateException(s"Unexpected Line:${line}")
       }
     }
     DeltaTableFiles(
@@ -362,11 +356,7 @@ private[spark] class DeltaSharingRestClient(
         case a: AddFileForCDF => addFiles.append(a)
         case r: RemoveFile => removeFiles.append(r)
         case m: Metadata => additionalMetadatas.append(m)
-        case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
-          throw new IllegalStateException(s"Unexpected Line:${line}")
-        } else {
-          logWarning(s"Unexpected Line:${line}")
-        }
+        case _ => throw new IllegalStateException(s"Unexpected Line:${line}")
       }
     }
     DeltaTableFiles(

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingClient.scala
@@ -275,6 +275,8 @@ private[spark] class DeltaSharingRestClient(
         files.append(action.file)
       } else if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
         throw new IllegalStateException(s"Unexpected Line:${line}")
+      } else {
+        logWarning(s"Unexpected Line:${line}")
       }
     }
     DeltaTableFiles(version, protocol, metadata, files, refreshToken = refreshTokenOpt)
@@ -318,6 +320,8 @@ private[spark] class DeltaSharingRestClient(
         case m: Metadata => additionalMetadatas.append(m)
         case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
           throw new IllegalStateException(s"Unexpected Line:${line}")
+        } else {
+          logWarning(s"Unexpected Line:${line}")
         }
       }
     }
@@ -360,6 +364,8 @@ private[spark] class DeltaSharingRestClient(
         case m: Metadata => additionalMetadatas.append(m)
         case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
           throw new IllegalStateException(s"Unexpected Line:${line}")
+        } else {
+          logWarning(s"Unexpected Line:${line}")
         }
       }
     }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -43,7 +43,7 @@ import io.delta.sharing.spark.model.{
   FileAction,
   RemoveFile
 }
-import io.delta.sharing.spark.util.SchemaUtils
+import io.delta.sharing.spark.util.{ConfUtils, SchemaUtils}
 
 /**
  * A case class to help with `Dataset` operations regarding Offset indexing, representing a
@@ -154,7 +154,10 @@ case class DeltaSharingSource(
 
   private var lastGetVersionTimestamp: Long = -1
   private var latestTableVersion: Long = -1
-  private val QUERY_TABLE_VERSION_INTERVAL_MILLIS = 30000 // 30 seconds
+  // minimum 30 seconds
+  private val QUERY_TABLE_VERSION_INTERVAL_MILLIS = 30000.max(
+    ConfUtils.streamingQueryTableVersionIntervalSeconds(spark.sessionState.conf)
+  )
   private val maxVersionsPerRpc: Int = options.maxVersionsPerRpc.getOrElse(
     DeltaSharingOptions.MAX_VERSIONS_PER_RPC_DEFAULT
   )

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -155,9 +155,16 @@ case class DeltaSharingSource(
   private var lastGetVersionTimestamp: Long = -1
   private var latestTableVersion: Long = -1
   // minimum 30 seconds
-  private val QUERY_TABLE_VERSION_INTERVAL_MILLIS = 30000.max(
-    ConfUtils.streamingQueryTableVersionIntervalSeconds(spark.sessionState.conf)
-  )
+  private val QUERY_TABLE_VERSION_INTERVAL_MILLIS = {
+    val interval = 30000.max(
+      ConfUtils.streamingQueryTableVersionIntervalSeconds(spark.sessionState.conf) * 1000
+    )
+    if (interval < 30000) {
+      throw new IllegalArgumentException("QUERY_TABLE_VERSION_INTERVAL_MILLIS must not be less " +
+        "than 30 seconds.")
+    }
+    interval
+  }
   private val maxVersionsPerRpc: Int = options.maxVersionsPerRpc.getOrElse(
     DeltaSharingOptions.MAX_VERSIONS_PER_RPC_DEFAULT
   )

--- a/spark/src/main/scala/io/delta/sharing/spark/RandomAccessHttpInputStream.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/RandomAccessHttpInputStream.scala
@@ -167,7 +167,7 @@ private[sharing] class RandomAccessHttpInputStream(
             }
           }
           throw new UnexpectedHttpStatus(
-            s"HTTP request failed with status: $status $errorBody",
+            s"HTTP request failed with status: $status $errorBody, while accessing [$uri]",
             statusCode)
         }
         entity

--- a/spark/src/main/scala/io/delta/sharing/spark/util/ConfUtils.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/util/ConfUtils.scala
@@ -36,9 +36,6 @@ object ConfUtils {
   val MAX_CONNECTION_CONF = "spark.delta.sharing.network.maxConnections"
   val MAX_CONNECTION_DEFAULT = 64
 
-  val IGNORE_UNPARSED_ACTIONS = "spark.delta.sharing.ignoreUnparsedActions"
-  val IGNORE_UNPARSED_ACTIONS_DEFAULT = false
-
   val QUERY_TABLE_VERSION_INTERVAL_SECONDS =
     "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds"
   val QUERY_TABLE_VERSION_INTERVAL_SECONDS_DEFAULT = "30s"
@@ -82,10 +79,6 @@ object ConfUtils {
     val maxConn = conf.getInt(MAX_CONNECTION_CONF, MAX_CONNECTION_DEFAULT)
     validateNonNeg(maxConn, MAX_CONNECTION_CONF)
     maxConn
-  }
-
-  def ignoreUnparsedActions(conf: SQLConf): Boolean = {
-    conf.getConfString(IGNORE_UNPARSED_ACTIONS, IGNORE_UNPARSED_ACTIONS_DEFAULT.toString).toBoolean
   }
 
   def streamingQueryTableVersionIntervalSeconds(conf: SQLConf): Int = {

--- a/spark/src/main/scala/io/delta/sharing/spark/util/ConfUtils.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/util/ConfUtils.scala
@@ -93,7 +93,10 @@ object ConfUtils {
       QUERY_TABLE_VERSION_INTERVAL_SECONDS,
       QUERY_TABLE_VERSION_INTERVAL_SECONDS_DEFAULT
     )
-    toTimeInSeconds(intervalStr, QUERY_TABLE_VERSION_INTERVAL_SECONDS)
+    val a = toTimeInSeconds(intervalStr, QUERY_TABLE_VERSION_INTERVAL_SECONDS)
+    // scalastyle:off println
+    Console.println(s"----[linzhou]----a:$a")
+    a
   }
 
   private def toTimeInSeconds(timeStr: String, conf: String): Int = {

--- a/spark/src/main/scala/io/delta/sharing/spark/util/ConfUtils.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/util/ConfUtils.scala
@@ -93,10 +93,7 @@ object ConfUtils {
       QUERY_TABLE_VERSION_INTERVAL_SECONDS,
       QUERY_TABLE_VERSION_INTERVAL_SECONDS_DEFAULT
     )
-    val a = toTimeInSeconds(intervalStr, QUERY_TABLE_VERSION_INTERVAL_SECONDS)
-    // scalastyle:off println
-    Console.println(s"----[linzhou]----a:$a")
-    a
+    toTimeInSeconds(intervalStr, QUERY_TABLE_VERSION_INTERVAL_SECONDS)
   }
 
   private def toTimeInSeconds(timeStr: String, conf: String): Int = {

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -268,6 +268,10 @@ class DeltaSharingSourceSuite extends QueryTest
       query.processAllAvailable()
     }.getMessage
     assert(message.contains("must not be less than 30 seconds."))
+    spark.sessionState.conf.setConfString(
+      "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds",
+      "30"
+    )
   }
 
   /**

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -262,8 +262,10 @@ class DeltaSharingSourceSuite extends QueryTest
       "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds",
       "29"
     )
-    val message = intercept[IllegalArgumentException] {
-      spark.readStream.format("deltaSharing").load(tablePath)
+    val message = intercept[Exception] {
+      val query = spark.readStream.format("deltaSharing").load(tablePath)
+        .writeStream.format("console").start()
+      query.processAllAvailable()
     }.getMessage
     assert(message.contains("must not be less than 30 seconds."))
   }


### PR DESCRIPTION
Improve error message when seeing unrecognized file from server: output the line instead of file.
And add two configs:

- "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds", cannot be less than 30 seconds
- "spark.delta.sharing.ignoreUnparsedActions"