### PR TITLE
Improve error message on unrecognized file from server, and add two configs

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -334,7 +334,7 @@ class DeltaSharingRestClient(
     checkProtocol(protocol)
     val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
     val files = ArrayBuffer[AddFile]()
-    files.drop(2).foreach { line =>
+    lines.drop(2).foreach { line =>
       val action = JsonUtils.fromJson[SingleAction](line)
       if (action.file != null) {
         files.append(action.file)

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -338,10 +338,8 @@ class DeltaSharingRestClient(
       val action = JsonUtils.fromJson[SingleAction](line)
       if (action.file != null) {
         files.append(action.file)
-      } else if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
-        throw new IllegalStateException(s"Unexpected Line:${line}")
       } else {
-        logWarning(s"Unexpected Line:${line}.")
+        throw new IllegalStateException(s"Unexpected Line:${line}")
       }
     }
     DeltaTableFiles(version, protocol, metadata, files, refreshToken = refreshTokenOpt)
@@ -405,11 +403,7 @@ class DeltaSharingRestClient(
         case a: AddFileForCDF => addFiles.append(a)
         case r: RemoveFile => removeFiles.append(r)
         case m: Metadata => additionalMetadatas.append(m)
-        case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
-          throw new IllegalStateException(s"Unexpected Line:${line}")
-        } else {
-          logWarning(s"Unexpected Line:${line}.")
-        }
+        case _ => throw new IllegalStateException(s"Unexpected Line:${line}")
       }
     }
     DeltaTableFiles(
@@ -537,11 +531,7 @@ class DeltaSharingRestClient(
         case a: AddFileForCDF => addFiles.append(a)
         case r: RemoveFile => removeFiles.append(r)
         case m: Metadata => additionalMetadatas.append(m)
-        case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
-          throw new IllegalStateException(s"Unexpected Line:${line}")
-        } else {
-          logWarning(s"Unexpected Line:${line}.")
-        }
+        case _ => throw new IllegalStateException(s"Unexpected Line:${line}")
       }
     }
     DeltaTableFiles(

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -340,6 +340,8 @@ class DeltaSharingRestClient(
         files.append(action.file)
       } else if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
         throw new IllegalStateException(s"Unexpected Line:${line}")
+      } else {
+        logWarning(s"Unexpected Line:${line}.")
       }
     }
     DeltaTableFiles(version, protocol, metadata, files, refreshToken = refreshTokenOpt)
@@ -405,6 +407,8 @@ class DeltaSharingRestClient(
         case m: Metadata => additionalMetadatas.append(m)
         case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
           throw new IllegalStateException(s"Unexpected Line:${line}")
+        } else {
+          logWarning(s"Unexpected Line:${line}.")
         }
       }
     }
@@ -535,6 +539,8 @@ class DeltaSharingRestClient(
         case m: Metadata => additionalMetadatas.append(m)
         case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
           throw new IllegalStateException(s"Unexpected Line:${line}")
+        } else {
+          logWarning(s"Unexpected Line:${line}.")
         }
       }
     }

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -333,7 +333,15 @@ class DeltaSharingRestClient(
     val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
     checkProtocol(protocol)
     val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
-    val files = lines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).file)
+    val files = ArrayBuffer[AddFile]()
+    files.drop(2).foreach { line =>
+      val action = JsonUtils.fromJson[SingleAction](line)
+      if (action.file != null) {
+        files.append(action.file)
+      } else if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
+        throw new IllegalStateException(s"Unexpected Line:${line}")
+      }
+    }
     DeltaTableFiles(version, protocol, metadata, files, refreshToken = refreshTokenOpt)
   }
 
@@ -389,11 +397,16 @@ class DeltaSharingRestClient(
     val addFiles = ArrayBuffer[AddFileForCDF]()
     val removeFiles = ArrayBuffer[RemoveFile]()
     val additionalMetadatas = ArrayBuffer[Metadata]()
-    lines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).unwrap).foreach{
-      case a: AddFileForCDF => addFiles.append(a)
-      case r: RemoveFile => removeFiles.append(r)
-      case m: Metadata => additionalMetadatas.append(m)
-      case f => throw new IllegalStateException(s"Unexpected File:${f}")
+    lines.drop(2).foreach { line =>
+      val action = JsonUtils.fromJson[SingleAction](line).unwrap
+      action match {
+        case a: AddFileForCDF => addFiles.append(a)
+        case r: RemoveFile => removeFiles.append(r)
+        case m: Metadata => additionalMetadatas.append(m)
+        case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
+          throw new IllegalStateException(s"Unexpected Line:${line}")
+        }
+      }
     }
     DeltaTableFiles(
       version,
@@ -513,13 +526,17 @@ class DeltaSharingRestClient(
     val cdfFiles = ArrayBuffer[AddCDCFile]()
     val removeFiles = ArrayBuffer[RemoveFile]()
     val additionalMetadatas = ArrayBuffer[Metadata]()
-    lines.drop(2).map(line => JsonUtils.fromJson[SingleAction](line).unwrap).foreach{
-      case c: AddCDCFile => cdfFiles.append(c)
-      case a: AddFileForCDF => addFiles.append(a)
-      case r: RemoveFile => removeFiles.append(r)
-      case m: Metadata => additionalMetadatas.append(m)
-      case f => throw new IllegalStateException(s"Unexpected File:${f}")
-    }
+    lines.drop(2).foreach { line =>
+      val action = JsonUtils.fromJson[SingleAction](line).unwrap
+      action match {
+        case c: AddCDCFile => cdfFiles.append(c)
+        case a: AddFileForCDF => addFiles.append(a)
+        case r: RemoveFile => removeFiles.append(r)
+        case m: Metadata => additionalMetadatas.append(m)
+        case _ => if (!ConfUtils.ignoreUnparsedActions(SparkSession.active.sessionState.conf)) {
+          throw new IllegalStateException(s"Unexpected Line:${line}")
+        }
+      }
     DeltaTableFiles(
       version,
       protocol,

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -537,6 +537,7 @@ class DeltaSharingRestClient(
           throw new IllegalStateException(s"Unexpected Line:${line}")
         }
       }
+    }
     DeltaTableFiles(
       version,
       protocol,

--- a/client/src/main/scala/io/delta/sharing/client/RandomAccessHttpInputStream.scala
+++ b/client/src/main/scala/io/delta/sharing/client/RandomAccessHttpInputStream.scala
@@ -167,7 +167,7 @@ private[sharing] class RandomAccessHttpInputStream(
             }
           }
           throw new UnexpectedHttpStatus(
-            s"HTTP request failed with status: $status $errorBody",
+            s"HTTP request failed with status: $status $errorBody, while accessing [$uri]",
             statusCode)
         }
         entity

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -57,6 +57,13 @@ object ConfUtils {
   val MAX_FILES_CONF = "spark.delta.sharing.maxFilesPerQueryRequest"
   val MAX_FILES_DEFAULT = 100000
 
+  val IGNORE_UNPARSED_ACTIONS = "spark.delta.sharing.ignoreUnparsedActions"
+  val IGNORE_UNPARSED_ACTIONS_DEFAULT = false
+
+  val QUERY_TABLE_VERSION_INTERVAL_SECONDS =
+    "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds"
+  val QUERY_TABLE_VERSION_INTERVAL_SECONDS_DEFAULT = "30s"
+
   def numRetries(conf: Configuration): Int = {
     val numRetries = conf.getInt(NUM_RETRIES_CONF, NUM_RETRIES_DEFAULT)
     validateNonNeg(numRetries, NUM_RETRIES_CONF)
@@ -84,12 +91,12 @@ object ConfUtils {
 
   def timeoutInSeconds(conf: Configuration): Int = {
     val timeoutStr = conf.get(TIMEOUT_CONF, TIMEOUT_DEFAULT)
-    toTimeout(timeoutStr)
+    toTimeInSeconds(timeoutStr, TIMEOUT_CONF)
   }
 
   def timeoutInSeconds(conf: SQLConf): Int = {
     val timeoutStr = conf.getConfString(TIMEOUT_CONF, TIMEOUT_DEFAULT)
-    toTimeout(timeoutStr)
+    toTimeInSeconds(timeoutStr, TIMEOUT_CONF)
   }
 
   def maxConnections(conf: Configuration): Int = {
@@ -128,13 +135,28 @@ object ConfUtils {
     maxFiles
   }
 
-  private def toTimeout(timeoutStr: String): Int = {
-    val timeoutInSeconds = JavaUtils.timeStringAs(timeoutStr, TimeUnit.SECONDS)
-    validateNonNeg(timeoutInSeconds, TIMEOUT_CONF)
-    if (timeoutInSeconds > Int.MaxValue) {
-      throw new IllegalArgumentException(TIMEOUT_CONF + " is too big: " +  timeoutStr)
+  def ignoreUnparsedActions(conf: SQLConf): Boolean = {
+    conf.getConfString(IGNORE_UNPARSED_ACTIONS, IGNORE_UNPARSED_ACTIONS_DEFAULT.toString).toBoolean
+  }
+
+  def streamingQueryTableVersionIntervalSeconds(conf: SQLConf): Int = {
+    val intervalStr = conf.getConfString(
+      QUERY_TABLE_VERSION_INTERVAL_SECONDS,
+      QUERY_TABLE_VERSION_INTERVAL_SECONDS_DEFAULT
+    )
+    toTimeInSeconds(intervalStr, QUERY_TABLE_VERSION_INTERVAL_SECONDS)
+  }
+
+  private def toTimeInSeconds(timeStr: String, conf: String): Int = {
+    val timeInSeconds = JavaUtils.timeStringAs(timeStr, TimeUnit.SECONDS)
+    validateNonNeg(timeInSeconds, conf)
+    if (conf == QUERY_TABLE_VERSION_INTERVAL_SECONDS && timeInSeconds < 30) {
+      throw new IllegalArgumentException(conf + " must not be less than 30 seconds.")
     }
-    timeoutInSeconds.toInt
+    if (timeInSeconds > Int.MaxValue) {
+      throw new IllegalArgumentException(conf + " is too big: " + timeStr)
+    }
+    timeInSeconds.toInt
   }
 
   private def validateNonNeg(value: Long, conf: String): Unit = {

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -57,9 +57,6 @@ object ConfUtils {
   val MAX_FILES_CONF = "spark.delta.sharing.maxFilesPerQueryRequest"
   val MAX_FILES_DEFAULT = 100000
 
-  val IGNORE_UNPARSED_ACTIONS = "spark.delta.sharing.ignoreUnparsedActions"
-  val IGNORE_UNPARSED_ACTIONS_DEFAULT = false
-
   val QUERY_TABLE_VERSION_INTERVAL_SECONDS =
     "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds"
   val QUERY_TABLE_VERSION_INTERVAL_SECONDS_DEFAULT = "30s"
@@ -133,10 +130,6 @@ object ConfUtils {
     val maxFiles = conf.getConfString(MAX_FILES_CONF, MAX_FILES_DEFAULT.toString).toInt
     validatePositive(maxFiles, MAX_FILES_CONF)
     maxFiles
-  }
-
-  def ignoreUnparsedActions(conf: SQLConf): Boolean = {
-    conf.getConfString(IGNORE_UNPARSED_ACTIONS, IGNORE_UNPARSED_ACTIONS_DEFAULT.toString).toBoolean
   }
 
   def streamingQueryTableVersionIntervalSeconds(conf: SQLConf): Int = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.0"
+version in ThisBuild := "1.0.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.1-SNAPSHOT"
+version in ThisBuild := "1.0.0"


### PR DESCRIPTION
Improve error message when seeing unrecognized file from server: output the line instead of file.
And add two configs:

- "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds", cannot be less than 30 seconds
- "spark.delta.sharing.ignoreUnparsedActions"