### PR TITLE
Fix Tests with a copy of DeltaMetadata

### DIFF
--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTableLoader.scala
@@ -224,7 +224,7 @@ class DeltaSharedTable(
         } else {
           null
         },
-        deltaMetadata = m
+        deltaMetadata = DeltaMetadataCopy(m)
       ).wrap
     } else {
       model.Metadata(

--- a/server/src/main/scala/io/delta/standalone/internal/model.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/model.scala
@@ -16,12 +16,40 @@
 
 package io.delta.standalone.internal
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.delta.standalone.internal.actions.{
+  Format => DeltaFormat,
   Metadata => DeltaMetadata,
   Protocol => DeltaProtocol,
   SingleAction => DeltaSingleAction
 }
 
+case class DeltaMetadataCopy(
+    id: String,
+    name: String,
+    description: String,
+    format: DeltaFormat,
+    schemaString: String,
+    partitionColumns: Seq[String],
+    configuration: Map[String, String],
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    createdTime: Option[Long]
+)
+
+object DeltaMetadataCopy {
+  def apply(metadata: DeltaMetadata): DeltaMetadataCopy = {
+    DeltaMetadataCopy(
+      id = metadata.id,
+      name = metadata.name,
+      description = metadata.description,
+      format = metadata.format,
+      schemaString = metadata.schemaString,
+      partitionColumns = metadata.partitionColumns,
+      configuration = metadata.configuration,
+      createdTime = metadata.createdTime
+    )
+  }
+}
 /**
  * Actions defined to use in the response for delta format sharing.
  */
@@ -64,7 +92,7 @@ case class DeltaResponseFileAction(
  */
 case class DeltaResponseMetadata(
     version: java.lang.Long = null,
-    deltaMetadata: DeltaMetadata) extends DeltaResponseAction {
+    deltaMetadata: DeltaMetadataCopy) extends DeltaResponseAction {
   override def wrap: DeltaResponseSingleAction = DeltaResponseSingleAction(metaData = this)
 }
 

--- a/server/src/main/scala/io/delta/standalone/internal/model.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/model.scala
@@ -24,6 +24,10 @@ import io.delta.standalone.internal.actions.{
   SingleAction => DeltaSingleAction
 }
 
+/**
+ * A copy of delta Metadata class, removed schema/dataSchema/partitionSchema, is serialized as
+ * json response for a delta sharing rpc.
+ */
 case class DeltaMetadataCopy(
     id: String,
     name: String,


### PR DESCRIPTION
Fix the test failures in: https://github.com/delta-io/delta-sharing/actions/runs/6255145774/job/17116036562, as this is reference server purely for demonstration purpose, this should be ok.

The reason is the unexpected serialization of fields of Metadata in the json string, which in theory should not appear. 
schema/dataSchema/partitionSchema which should be ignored: https://github.com/delta-io/connectors/blob/master/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala#L195

```
{"metaData":{"deltaMetadata":{"id":"ed96aa41-1d81-4b7f-8fb5-846878b4b0cf","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"eventTime\",\"type\":\"timestamp\",\"nullable\":true,\"metadata\":{}},{\"name\":\"date\",\"type\":\"date\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1619591469476,"schema":{"fields":[{"name":"eventTime","dataType":{"simpleString":"timestamp","catalogString":"timestamp","typeName":"timestamp"},"nullable":true,"metadata":{"entries":{}}},{"name":"date","dataType":{"simpleString":"date","catalogString":"date","typeName":"date"},"nullable":true,"metadata":{"entries":{}}}],"fieldNames":["eventTime","date"],"treeString":"root\n |-- eventTime: timestamp (nullable = true) (metadata ={})\n |-- date: date (nullable = true) (metadata ={})\n","simpleString":"struct","catalogString":"struct","typeName":"struct"},"dataSchema":{"fields":[{"name":"eventTime","dataType":{"simpleString":"timestamp","catalogString":"timestamp","typeName":"timestamp"},"nullable":true,"metadata":{"entries":{}}},{"name":"date","dataType":{"simpleString":"date","catalogString":"date","typeName":"date"},"nullable":true,"metadata":{"entries":{}}}],"fieldNames":["eventTime","date"],"treeString":"root\n |-- eventTime: timestamp (nullable = true) (metadata ={})\n |-- date: date (nullable = true) (metadata ={})\n","simpleString":"struct","catalogString":"struct","typeName":"struct"},"partitionSchema":{"fields":[],"fieldNames":[],"treeString":"root\n","simpleString":"struct","catalogString":"struct","typeName":"struct"}}}}
```