### PR TITLE
RemoteDeltaLog accept input Metadata

### DIFF
--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 
 import io.delta.sharing.client.{DeltaSharingClient, DeltaSharingRestClient}
-import io.delta.sharing.client.model.{AddFile, CDFColumnInfo, Metadata, Protocol, Table => DeltaSharingTable}
+import io.delta.sharing.client.model.{AddFile, CDFColumnInfo, DeltaTableMetadata, Metadata, Protocol, Table => DeltaSharingTable}
 import io.delta.sharing.client.util.ConfUtils
 import io.delta.sharing.spark.perf.DeltaSharingLimitPushDown
 
@@ -41,7 +41,8 @@ import io.delta.sharing.spark.perf.DeltaSharingLimitPushDown
 private[sharing] class RemoteDeltaLog(
   val table: DeltaSharingTable,
   val path: Path,
-  val client: DeltaSharingClient) {
+  val client: DeltaSharingClient,
+  inputDeltaTableMetadata: Option[DeltaTableMetadata] = None) {
 
   @volatile private var currentSnapshot: RemoteSnapshot = new RemoteSnapshot(path, client, table)
 
@@ -51,7 +52,7 @@ private[sharing] class RemoteDeltaLog(
     if (versionAsOf.isEmpty && timestampAsOf.isEmpty) {
       currentSnapshot
     } else {
-      new RemoteSnapshot(path, client, table, versionAsOf, timestampAsOf)
+      new RemoteSnapshot(path, client, table, versionAsOf, timestampAsOf, inputDeltaTableMetadata)
     }
   }
 
@@ -103,7 +104,8 @@ private[sharing] object RemoteDeltaLog {
   def apply(
       path: String,
       forStreaming: Boolean = false,
-      responseFormat: String = DeltaSharingOptions.RESPONSE_FORMAT_PARQUET): RemoteDeltaLog = {
+      responseFormat: String = DeltaSharingOptions.RESPONSE_FORMAT_PARQUET,
+      inputDeltaTableMetadata: Option[DeltaTableMetadata] = None): RemoteDeltaLog = {
     val parsedPath = DeltaSharingRestClient.parsePath(path)
     val client = DeltaSharingRestClient(parsedPath.profileFile, forStreaming, responseFormat)
     val deltaSharingTable = DeltaSharingTable(
@@ -111,7 +113,7 @@ private[sharing] object RemoteDeltaLog {
       schema = parsedPath.schema,
       share = parsedPath.share
     )
-    new RemoteDeltaLog(deltaSharingTable, new Path(path), client)
+    new RemoteDeltaLog(deltaSharingTable, new Path(path), client, inputDeltaTableMetadata)
   }
 }
 
@@ -121,7 +123,8 @@ class RemoteSnapshot(
     client: DeltaSharingClient,
     table: DeltaSharingTable,
     versionAsOf: Option[Long] = None,
-    timestampAsOf: Option[String] = None) extends Logging {
+    timestampAsOf: Option[String] = None,
+    inputDeltaTableMetadata: Option[DeltaTableMetadata] = None) extends Logging {
 
   protected def spark = SparkSession.active
 
@@ -165,7 +168,9 @@ class RemoteSnapshot(
   }
 
   private def getTableMetadata: (Metadata, Protocol, Long) = {
-    val tableMetadata = client.getMetadata(table, versionAsOf, timestampAsOf)
+    val tableMetadata = inputDeltaTableMetadata.getOrElse(
+      client.getMetadata(table, versionAsOf, timestampAsOf)
+    )
     (tableMetadata.metadata, tableMetadata.protocol, tableMetadata.version)
   }
 

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -156,11 +156,13 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
   test("snapshot file index test") {
     val spark = SparkSession.active
     val client = new TestDeltaSharingClient()
+    client.clear()
     val snapshot = new RemoteSnapshot(new Path("test"), client, Table("fe", "fi", "fo"))
     assert(snapshot.sizeInBytes == 100)
     assert(snapshot.metadata.numFiles == 2)
     assert(snapshot.schema("col1").nullable)
     assert(snapshot.schema("col2").nullable)
+    assert(TestDeltaSharingClient.numMetadataCalled == 1)
 
     // Create an index without limits.
     val fileIndex = {
@@ -225,6 +227,7 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     // files with additional field returned from server.
     val spark = SparkSession.active
     val client = new TestDeltaSharingClient()
+    client.clear()
     val snapshot = new RemoteSnapshot(
       new Path("test"),
       client,
@@ -235,6 +238,7 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     assert(snapshot.metadata.numFiles == 2)
     assert(!snapshot.schema("col1").nullable)
     assert(!snapshot.schema("col2").nullable)
+    assert(TestDeltaSharingClient.numMetadataCalled == 1)
 
     // Create an index without limits.
     val fileIndex = {
@@ -299,6 +303,7 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     // files with additional field returned from server.
     val spark = SparkSession.active
     val client = new TestDeltaSharingClient()
+    client.clear()
     val snapshot = new RemoteSnapshot(
       new Path("test"),
       client,
@@ -310,6 +315,7 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     assert(snapshot.metadata.numFiles == 2)
     assert(snapshot.schema("col1").nullable)
     assert(!snapshot.schema("col2").nullable)
+    assert(TestDeltaSharingClient.numMetadataCalled == 1)
 
     // Create an index without limits.
     val fileIndex = {

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -18,19 +18,17 @@ package io.delta.sharing.spark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
-import java.util.Base64
+
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference => SqlAttributeReference, EqualTo => SqlEqualTo, Literal => SqlLiteral}
+import org.apache.spark.sql.execution.datasources.HadoopFsRelation
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{FloatType, IntegerType, LongType, StringType, StructField, StructType}
-import io.delta.sharing.client.DeltaSharingClient
+
 import io.delta.sharing.client.model.Table
-import io.delta.sharing.client.util.JsonUtils
-import io.delta.sharing.filters.{BaseOp, OpConverter}
-import org.apache.spark.sql.execution.datasources.HadoopFsRelation
 
 class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
 
@@ -498,6 +496,7 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     val path = new Path("profileFile")
     val table = Table(share = "share", schema = "schema", name = "table")
     val client = new TestDeltaSharingClient()
+    client.clear()
 
     def checkGetMetadataCalledOnce(versionAsOf: Option[Long] = None, nullable: Boolean): Unit = {
       var deltaTableMetadata = client.getMetadata(table, versionAsOf, None)

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -80,6 +80,7 @@ class TestDeltaSharingClient(
       table: Table,
       versionAsOf: Option[Long] = None,
       timestampAsOf: Option[String] = None): DeltaTableMetadata = {
+    TestDeltaSharingClient.numMetadataCalled += 1
     // Different metadata are returned for rpcs with different parameters to test the parameters
     // are set properly.
     if (versionAsOf.exists(_ == 1)) {
@@ -183,6 +184,7 @@ class TestDeltaSharingClient(
   def clear(): Unit = {
     TestDeltaSharingClient.limits = Nil
     TestDeltaSharingClient.jsonPredicateHints = Nil
+    TestDeltaSharingClient.numMetadataCalled = 0
   }
 }
 
@@ -195,6 +197,8 @@ class TestDeltaSharingProfileProvider extends DeltaSharingProfileProvider {
 object TestDeltaSharingClient {
   var limits = Seq.empty[Long]
   var jsonPredicateHints = Seq.empty[String]
+
+  var numMetadataCalled = 0
 
   val TESTING_TIMESTAMP = "2022-01-01 00:00:00.0"
 }


### PR DESCRIPTION
RemoteDeltaLog can be initialized with `initDeltaTableMetadata`.