### PR TITLE
RemoteDeltaLog accept input Metadata in branch 1.0

### DIFF
--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -32,18 +32,28 @@ import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 
 import io.delta.sharing.client.{DeltaSharingClient, DeltaSharingRestClient}
-import io.delta.sharing.client.model.{AddFile, CDFColumnInfo, Metadata, Protocol, Table => DeltaSharingTable}
+import io.delta.sharing.client.model.{AddFile, CDFColumnInfo, DeltaTableMetadata, Metadata, Protocol, Table => DeltaSharingTable}
 import io.delta.sharing.client.util.ConfUtils
 import io.delta.sharing.spark.perf.DeltaSharingLimitPushDown
 
 
-/** Used to query the current state of the transaction logs of a remote shared Delta table. */
+/**
+ * Used to query the current state of the transaction logs of a remote shared Delta table.
+ *
+ * @param initDeltaTableMetadata Used to initialize RemoteSnapshot, and is always preferred to use
+ *                               if set, to avoid an unnecessary call with additional delay.
+ *                               It's because we'd like to fetch the table metadata for a pre-check
+ *                               to decide whether to use parquet format sharing or delta format
+ *                               sharing before initializing RemoteDeltaLog.
+ */
 private[sharing] class RemoteDeltaLog(
   val table: DeltaSharingTable,
   val path: Path,
-  val client: DeltaSharingClient) {
+  val client: DeltaSharingClient,
+  initDeltaTableMetadata: Option[DeltaTableMetadata] = None) {
 
-  @volatile private var currentSnapshot: RemoteSnapshot = new RemoteSnapshot(path, client, table)
+  @volatile private var currentSnapshot: RemoteSnapshot = new RemoteSnapshot(
+    path, client, table, initDeltaTableMetadata = initDeltaTableMetadata)
 
   def snapshot(
       versionAsOf: Option[Long] = None,
@@ -51,7 +61,7 @@ private[sharing] class RemoteDeltaLog(
     if (versionAsOf.isEmpty && timestampAsOf.isEmpty) {
       currentSnapshot
     } else {
-      new RemoteSnapshot(path, client, table, versionAsOf, timestampAsOf)
+      new RemoteSnapshot(path, client, table, versionAsOf, timestampAsOf, initDeltaTableMetadata)
     }
   }
 
@@ -103,7 +113,8 @@ private[sharing] object RemoteDeltaLog {
   def apply(
       path: String,
       forStreaming: Boolean = false,
-      responseFormat: String = DeltaSharingOptions.RESPONSE_FORMAT_PARQUET): RemoteDeltaLog = {
+      responseFormat: String = DeltaSharingOptions.RESPONSE_FORMAT_PARQUET,
+      initDeltaTableMetadata: Option[DeltaTableMetadata] = None): RemoteDeltaLog = {
     val parsedPath = DeltaSharingRestClient.parsePath(path)
     val client = DeltaSharingRestClient(parsedPath.profileFile, forStreaming, responseFormat)
     val deltaSharingTable = DeltaSharingTable(
@@ -111,7 +122,7 @@ private[sharing] object RemoteDeltaLog {
       schema = parsedPath.schema,
       share = parsedPath.share
     )
-    new RemoteDeltaLog(deltaSharingTable, new Path(path), client)
+    new RemoteDeltaLog(deltaSharingTable, new Path(path), client, initDeltaTableMetadata)
   }
 }
 
@@ -121,11 +132,22 @@ class RemoteSnapshot(
     client: DeltaSharingClient,
     table: DeltaSharingTable,
     versionAsOf: Option[Long] = None,
-    timestampAsOf: Option[String] = None) extends Logging {
+    timestampAsOf: Option[String] = None,
+    initDeltaTableMetadata: Option[DeltaTableMetadata] = None) extends Logging {
 
   protected def spark = SparkSession.active
 
-  lazy val (metadata, protocol, version) = getTableMetadata
+  // initDeltaTableMetadata is from the initialization of RemoteDeltaLog and RemoteSnapshot.
+  // It's always preferred to use if set, to avoid an unnecessary call with additional delay.
+  // The reason is we'd like to fetch the table metadata for a pre-check to decide whether to
+  // use parquet format sharing or delta format sharing.
+  private lazy val tableMetadata = initDeltaTableMetadata.getOrElse(
+    client.getMetadata(table, versionAsOf, timestampAsOf)
+  )
+
+  lazy val (metadata, protocol, version) = {
+    (tableMetadata.metadata, tableMetadata.protocol, tableMetadata.version)
+  }
 
   lazy val schema: StructType = DeltaTableUtils.toSchema(metadata.schemaString)
 
@@ -162,11 +184,6 @@ class RemoteSnapshot(
       checkSchemaNotChange(tableFiles.metadata)
       tableFiles.files.map(_.size).sum
     }
-  }
-
-  private def getTableMetadata: (Metadata, Protocol, Long) = {
-    val tableMetadata = client.getMetadata(table, versionAsOf, timestampAsOf)
-    (tableMetadata.metadata, tableMetadata.protocol, tableMetadata.version)
   }
 
   private def checkProtocolNotChange(newProtocol: Protocol): Unit = {

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -505,8 +505,9 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     client.clear()
 
     def checkGetMetadataCalledOnce(versionAsOf: Option[Long] = None, nullable: Boolean): Unit = {
-      var deltaTableMetadata = client.getMetadata(table, versionAsOf, None)
+      val deltaTableMetadata = client.getMetadata(table, versionAsOf, None)
       assert(TestDeltaSharingClient.numMetadataCalled == 1)
+
       val remoteDeltaLog = new RemoteDeltaLog(table, path, client, Some(deltaTableMetadata))
       val relation = remoteDeltaLog.createRelation(versionAsOf, None, Map.empty[String, String])
       val hadoopFsRelation = relation.asInstanceOf[HadoopFsRelation]

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -182,6 +182,6 @@ object TestDeltaSharingClient {
   var jsonPredicateHints = Seq.empty[String]
 
   var numMetadataCalled = 0
-  
+
   val TESTING_TIMESTAMP = "2022-01-01 00:00:00.0"
 }

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -78,6 +78,7 @@ class TestDeltaSharingClient(
       table: Table,
       versionAsOf: Option[Long] = None,
       timestampAsOf: Option[String] = None): DeltaTableMetadata = {
+    TestDeltaSharingClient.numMetadataCalled += 1
     // Different metadata are returned for rpcs with different parameters to test the parameters
     // are set properly.
     if (versionAsOf.exists(_ == 1)) {
@@ -166,6 +167,7 @@ class TestDeltaSharingClient(
   def clear(): Unit = {
     TestDeltaSharingClient.limits = Nil
     TestDeltaSharingClient.jsonPredicateHints = Nil
+    TestDeltaSharingClient.numMetadataCalled = 0
   }
 }
 
@@ -179,5 +181,7 @@ object TestDeltaSharingClient {
   var limits = Seq.empty[Long]
   var jsonPredicateHints = Seq.empty[String]
 
+  var numMetadataCalled = 0
+  
   val TESTING_TIMESTAMP = "2022-01-01 00:00:00.0"
 }


### PR DESCRIPTION
RemoteDeltaLog can be initialized with `initDeltaTableMetadata`, same change as https://github.com/delta-io/delta-sharing/pull/421