### PR TITLE
Allow list of resopnseFormat in branch-1.0

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2442,9 +2442,11 @@ This header can be used in the request for [Query Table Metadata](#query-table-m
 </td>
 <td>The header is processed properly by the server.
 
-The server may choose to respond in parquet format if the table does not have any advanced features.
+If there's only one responseFormat specified, the server must respect and return in the requested format.
 
-The server must respond in delta format if the table has advanced features which are not compatible with the parquet format.</td>
+If there's a list of responseFormat specified, such as `responseFormat=delta,parquet`. The server
+may choose to respond in parquet format if the table does not have any advanced features. The server
+must respond in delta format if the table has advanced features which are not compatible with the parquet format.
 </tr>
 </table>
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2447,6 +2447,7 @@ If there's only one responseFormat specified, the server must respect and return
 If there's a list of responseFormat specified, such as `responseFormat=delta,parquet`. The server
 may choose to respond in parquet format if the table does not have any advanced features. The server
 must respond in delta format if the table has advanced features which are not compatible with the parquet format.
+</td>
 </tr>
 </table>
 

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -127,6 +127,9 @@ class DeltaSharingRestClient(
 
   @volatile private var created = false
 
+  // Convert the responseFormat to a Seq to be used later.
+  private val responseFormatSet = responseFormat.split(",").toSet
+
   private lazy val client = {
     val clientBuilder: HttpClientBuilder = if (sslTrustAll) {
       val sslBuilder = new SSLContextBuilder()
@@ -224,24 +227,17 @@ class DeltaSharingRestClient(
   }
 
   /**
-   * Compare requestedFormat and respondedFormat, only error out when requested parquet but got
-   * delta in response. The client allows backward compatibility: requested delta but got parquet
-   * in response.
+   * Compare responseFormatSet and respondedFormat, error out when responseFormatSet doesn't contain
+   * respondedFormat. The client allows backward compatibility by specifying
+   * responseFormat=parquet,delta in the request header.
    */
-  private def checkRespondedFormat(
-      requestedFormat: String, respondedFormat: String, rpc: String, table: String): Unit = {
-    if (requestedFormat == respondedFormat) {
-      return
-    }
-    if (responseFormat == RESPONSE_FORMAT_PARQUET && respondedFormat == RESPONSE_FORMAT_DELTA) {
+  private def checkRespondedFormat(respondedFormat: String, rpc: String, table: String): Unit = {
+    if (!responseFormatSet.contains(respondedFormat)) {
       logError(s"RespondedFormat($respondedFormat) is different from requested " +
         s"responseFormat($responseFormat) for $rpc for table $table.")
       throw new IllegalArgumentException("The responseFormat returned from the delta sharing " +
         s"server doesn't match the requested responseFormat: respondedFormat($respondedFormat)" +
         s" != requestedFormat($responseFormat).")
-    } else {
-      logWarning(s"RespondedFormat($respondedFormat) is different from requested " +
-        s"responseFormat($responseFormat) for $rpc for table $table.")
     }
   }
 
@@ -260,7 +256,6 @@ class DeltaSharingRestClient(
     val (version, respondedFormat, lines) = getNDJson(target)
 
     checkRespondedFormat(
-      responseFormat,
       respondedFormat,
       rpc = "getMetadata",
       table = s"${table.share}.${table.schema}.${table.name}"
@@ -336,7 +331,6 @@ class DeltaSharingRestClient(
     }
 
     checkRespondedFormat(
-      responseFormat,
       respondedFormat,
       rpc = s"getFiles(versionAsOf-$versionAsOf, timestampAsOf-$timestampAsOf)",
       table = s"${table.share}.${table.schema}.${table.name}"
@@ -408,7 +402,6 @@ class DeltaSharingRestClient(
     }
 
     checkRespondedFormat(
-      responseFormat,
       respondedFormat,
       rpc = s"getFiles(startingVersion:$startingVersion, endingVersion:$endingVersion)",
       table = s"${table.share}.${table.schema}.${table.name}"
@@ -532,7 +525,6 @@ class DeltaSharingRestClient(
     }
 
     checkRespondedFormat(
-      responseFormat,
       respondedFormat,
       rpc = s"getCDFFiles(cdfOptions:$cdfOptions)",
       table = s"${table.share}.${table.schema}.${table.name}."
@@ -894,7 +886,7 @@ class DeltaSharingRestClient(
   // Example: "capability1=value1;capability2=value3,value4,value5"
   private def getDeltaSharingCapabilities(): String = {
     var capabilities = Seq[String](s"${RESPONSE_FORMAT}=$responseFormat")
-    if (responseFormat == RESPONSE_FORMAT_DELTA && readerFeatures.nonEmpty) {
+    if (responseFormatSet.contains(RESPONSE_FORMAT_DELTA) && readerFeatures.nonEmpty) {
       capabilities = capabilities :+ s"$READER_FEATURES=$readerFeatures"
     }
     capabilities.mkString(DELTA_SHARING_CAPABILITIES_DELIMITER)

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
@@ -95,7 +95,15 @@ trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
 
   val timestampAsOf = options.get(TIME_TRAVEL_TIMESTAMP).map(getFormattedTimestamp(_))
 
-  val responseFormat = options.get(RESPONSE_FORMAT).getOrElse(RESPONSE_FORMAT_PARQUET)
+  val responseFormat = options.get(RESPONSE_FORMAT).map { str =>
+    if (!(str == RESPONSE_FORMAT_PARQUET || str == RESPONSE_FORMAT_DELTA)) {
+      throw DeltaSharingErrors.illegalDeltaSharingOptionException(
+        RESPONSE_FORMAT, str,
+        s"The user input must be one of:{$RESPONSE_FORMAT_PARQUET, $RESPONSE_FORMAT_DELTA}."
+      )
+    }
+    str
+  }.getOrElse(RESPONSE_FORMAT_PARQUET)
 
   def isTimeTravel: Boolean = versionAsOf.isDefined || timestampAsOf.isDefined
 

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -94,6 +94,16 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     checkDeltaSharingCapabilities(
       httpRequestBase, s"responseformat=delta;readerfeatures=$readerFeatures"
     )
+
+    httpRequestBase = new DeltaSharingRestClient(
+      testProfileProvider,
+      forStreaming = true,
+      responseFormat = s"$RESPONSE_FORMAT_DELTA,$RESPONSE_FORMAT_PARQUET",
+      readerFeatures = readerFeatures).prepareHeaders(httpRequest)
+    checkUserAgent(httpRequestBase, true)
+    checkDeltaSharingCapabilities(
+      httpRequestBase, s"responseformat=delta,parquet;readerfeatures=$readerFeatures"
+    )
   }
 
   integrationTest("listAllTables") {
@@ -170,19 +180,31 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
   }
 
   integrationTest("getMetadata") {
-    val client = new DeltaSharingRestClient(testProfileProvider, sslTrustAll = true)
-    try {
-      val tableMatadata =
-        client.getMetadata(Table(name = "table2", schema = "default", share = "share2"))
-      assert(Protocol(minReaderVersion = 1) == tableMatadata.protocol)
-      val expectedMetadata = Metadata(
-        id = "f8d5c169-3d01-4ca3-ad9e-7dc3355aedb2",
-        format = Format(),
-        schemaString = """{"type":"struct","fields":[{"name":"eventTime","type":"timestamp","nullable":true,"metadata":{}},{"name":"date","type":"date","nullable":true,"metadata":{}}]}""",
-        partitionColumns = Seq("date"))
-      assert(expectedMetadata == tableMatadata.metadata)
-    } finally {
-      client.close()
+    // The response is always in parquet format, because the client allows parquet and the
+    // table is a basic table.
+    Seq(
+      RESPONSE_FORMAT_PARQUET,
+      s"${RESPONSE_FORMAT_DELTA},${RESPONSE_FORMAT_PARQUET}",
+      s"${RESPONSE_FORMAT_PARQUET},${RESPONSE_FORMAT_DELTA}"
+    ).foreach { responseFormat =>
+      val client = new DeltaSharingRestClient(
+        testProfileProvider,
+        sslTrustAll = true,
+        responseFormat = responseFormat
+      )
+      try {
+        val tableMatadata =
+          client.getMetadata(Table(name = "table2", schema = "default", share = "share2"))
+        assert(Protocol(minReaderVersion = 1) == tableMatadata.protocol)
+        val expectedMetadata = Metadata(
+          id = "f8d5c169-3d01-4ca3-ad9e-7dc3355aedb2",
+          format = Format(),
+          schemaString = """{"type":"struct","fields":[{"name":"eventTime","type":"timestamp","nullable":true,"metadata":{}},{"name":"date","type":"date","nullable":true,"metadata":{}}]}""",
+          partitionColumns = Seq("date"))
+        assert(expectedMetadata == tableMatadata.metadata)
+      } finally {
+        client.close()
+      }
     }
   }
 
@@ -301,39 +323,48 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       assert(tableFiles.refreshToken.get.nonEmpty)
     }
 
-    Seq(true, false).foreach { paginationEnabled =>
-      val client = new DeltaSharingRestClient(
-        testProfileProvider,
-        sslTrustAll = true,
-        queryTablePaginationEnabled = paginationEnabled,
-        maxFilesPerReq = 1
-      )
-      val table = Table(name = "table2", schema = "default", share = "share2")
-      try {
-        val tableFiles =
-          client.getFiles(
-            table,
-            predicates = Nil,
-            limit = None,
-            versionAsOf = None,
-            timestampAsOf = None,
-            jsonPredicateHints = None,
-            refreshToken = None
-          )
-        verifyTableFiles(tableFiles)
-        val refreshedTableFiles =
-          client.getFiles(
-            table,
-            predicates = Nil,
-            limit = None,
-            versionAsOf = None,
-            timestampAsOf = None,
-            jsonPredicateHints = None,
-            refreshToken = tableFiles.refreshToken
-          )
-        verifyTableFiles(refreshedTableFiles)
-      } finally {
-        client.close()
+    // The response is always in parquet format, because the client allows parquet and the
+    // table is a basic table.
+    Seq(
+      RESPONSE_FORMAT_PARQUET,
+      s"${RESPONSE_FORMAT_DELTA},${RESPONSE_FORMAT_PARQUET}",
+      s"${RESPONSE_FORMAT_PARQUET},${RESPONSE_FORMAT_DELTA}"
+    ).foreach { responseFormat =>
+      Seq(true, false).foreach { paginationEnabled =>
+        val client = new DeltaSharingRestClient(
+          testProfileProvider,
+          sslTrustAll = true,
+          queryTablePaginationEnabled = paginationEnabled,
+          maxFilesPerReq = 1,
+          responseFormat = responseFormat
+        )
+        val table = Table(name = "table2", schema = "default", share = "share2")
+        try {
+          val tableFiles =
+            client.getFiles(
+              table,
+              predicates = Nil,
+              limit = None,
+              versionAsOf = None,
+              timestampAsOf = None,
+              jsonPredicateHints = None,
+              refreshToken = None
+            )
+          verifyTableFiles(tableFiles)
+          val refreshedTableFiles =
+            client.getFiles(
+              table,
+              predicates = Nil,
+              limit = None,
+              versionAsOf = None,
+              timestampAsOf = None,
+              jsonPredicateHints = None,
+              refreshToken = tableFiles.refreshToken
+            )
+          verifyTableFiles(refreshedTableFiles)
+        } finally {
+          client.close()
+        }
       }
     }
   }
@@ -760,96 +791,104 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
   }
 
   integrationTest("getCDFFiles") {
-    Seq(true, false).foreach { paginationEnabled =>
-      val client = new DeltaSharingRestClient(
-        testProfileProvider,
-        sslTrustAll = true,
-        queryTablePaginationEnabled = paginationEnabled,
-        maxFilesPerReq = 1
-      )
-      try {
-        val cdfOptions = Map("startingVersion" -> "0", "endingVersion" -> "3")
-        val tableFiles = client.getCDFFiles(
-          Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
-          cdfOptions,
-          false
+    // The response is always in parquet format, because the client allows parquet and the
+    // table is a basic table.
+    Seq(
+      RESPONSE_FORMAT_PARQUET,
+      s"${RESPONSE_FORMAT_DELTA},${RESPONSE_FORMAT_PARQUET}",
+      s"${RESPONSE_FORMAT_PARQUET},${RESPONSE_FORMAT_DELTA}"
+    ).foreach { responseFormat =>
+      Seq(true, false).foreach { paginationEnabled =>
+        val client = new DeltaSharingRestClient(
+          testProfileProvider,
+          sslTrustAll = true,
+          queryTablePaginationEnabled = paginationEnabled,
+          maxFilesPerReq = 1
         )
-        assert(tableFiles.version == 0)
-        assert(Protocol(minReaderVersion = 1) == tableFiles.protocol)
-        val expectedMetadata = Metadata(
-          id = "16736144-3306-4577-807a-d3f899b77670",
-          format = Format(),
-          schemaString =
-            """{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}},{"name":"age","type":"integer","nullable":true,"metadata":{}},{"name":"birthday","type":"date","nullable":true,"metadata":{}}]}""",
-          configuration = Map("enableChangeDataFeed" -> "true"),
-          partitionColumns = Nil,
-          version = 5
-        )
-        assert(expectedMetadata == tableFiles.metadata)
-        assert(tableFiles.cdfFiles.size == 2)
-        val expectedCdfFiles = Seq(
-          AddCDCFile(
-            url = tableFiles.cdfFiles(0).url,
-            expirationTimestamp = tableFiles.cdfFiles(0).expirationTimestamp,
-            id = "6521ba910108d4b54d27beaa9fc2373f",
-            partitionValues = Map.empty,
-            size = 1301,
-            version = 2,
-            timestamp = 1651272655000L
-          ),
-          AddCDCFile(
-            url = tableFiles.cdfFiles(1).url,
-            expirationTimestamp = tableFiles.cdfFiles(1).expirationTimestamp,
-            id = "2508998dce55bd726369e53761c4bc3f",
-            partitionValues = Map.empty,
-            size = 1416,
-            version = 3,
-            timestamp = 1651272660000L
+        try {
+          val cdfOptions = Map("startingVersion" -> "0", "endingVersion" -> "3")
+          val tableFiles = client.getCDFFiles(
+            Table(name = "cdf_table_cdf_enabled", schema = "default", share = "share8"),
+            cdfOptions,
+            false
           )
-        )
-        assert(expectedCdfFiles == tableFiles.cdfFiles.toList)
-        assert(tableFiles.cdfFiles(1).expirationTimestamp > System.currentTimeMillis())
+          assert(tableFiles.version == 0)
+          assert(Protocol(minReaderVersion = 1) == tableFiles.protocol)
+          val expectedMetadata = Metadata(
+            id = "16736144-3306-4577-807a-d3f899b77670",
+            format = Format(),
+            schemaString =
+              """{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}},{"name":"age","type":"integer","nullable":true,"metadata":{}},{"name":"birthday","type":"date","nullable":true,"metadata":{}}]}""",
+            configuration = Map("enableChangeDataFeed" -> "true"),
+            partitionColumns = Nil,
+            version = 5
+          )
+          assert(expectedMetadata == tableFiles.metadata)
+          assert(tableFiles.cdfFiles.size == 2)
+          val expectedCdfFiles = Seq(
+            AddCDCFile(
+              url = tableFiles.cdfFiles(0).url,
+              expirationTimestamp = tableFiles.cdfFiles(0).expirationTimestamp,
+              id = "6521ba910108d4b54d27beaa9fc2373f",
+              partitionValues = Map.empty,
+              size = 1301,
+              version = 2,
+              timestamp = 1651272655000L
+            ),
+            AddCDCFile(
+              url = tableFiles.cdfFiles(1).url,
+              expirationTimestamp = tableFiles.cdfFiles(1).expirationTimestamp,
+              id = "2508998dce55bd726369e53761c4bc3f",
+              partitionValues = Map.empty,
+              size = 1416,
+              version = 3,
+              timestamp = 1651272660000L
+            )
+          )
+          assert(expectedCdfFiles == tableFiles.cdfFiles.toList)
+          assert(tableFiles.cdfFiles(1).expirationTimestamp > System.currentTimeMillis())
 
-        assert(tableFiles.addFiles.size == 3)
-        val expectedAddFiles = Seq(
-          AddFileForCDF(
-            url = tableFiles.addFiles(0).url,
-            expirationTimestamp = tableFiles.addFiles(0).expirationTimestamp,
-            id = "60d0cf57f3e4367db154aa2c36152a1f",
-            partitionValues = Map.empty,
-            size = 1030,
-            stats =
-              """{"numRecords":1,"minValues":{"name":"1","age":1,"birthday":"2020-01-01"},"maxValues":{"name":"1","age":1,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
-            version = 1,
-            timestamp = 1651272635000L
-          ),
-          AddFileForCDF(
-            url = tableFiles.addFiles(1).url,
-            expirationTimestamp = tableFiles.addFiles(1).expirationTimestamp,
-            id = "a6dc5694a4ebcc9a067b19c348526ad6",
-            partitionValues = Map.empty,
-            size = 1030,
-            stats =
-              """{"numRecords":1,"minValues":{"name":"2","age":2,"birthday":"2020-01-01"},"maxValues":{"name":"2","age":2,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
-            version = 1,
-            timestamp = 1651272635000L
-          ),
-          AddFileForCDF(
-            url = tableFiles.addFiles(2).url,
-            expirationTimestamp = tableFiles.addFiles(2).expirationTimestamp,
-            id = "d7ed708546dd70fdff9191b3e3d6448b",
-            partitionValues = Map.empty,
-            size = 1030,
-            stats =
-              """{"numRecords":1,"minValues":{"name":"3","age":3,"birthday":"2020-01-01"},"maxValues":{"name":"3","age":3,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
-            version = 1,
-            timestamp = 1651272635000L
+          assert(tableFiles.addFiles.size == 3)
+          val expectedAddFiles = Seq(
+            AddFileForCDF(
+              url = tableFiles.addFiles(0).url,
+              expirationTimestamp = tableFiles.addFiles(0).expirationTimestamp,
+              id = "60d0cf57f3e4367db154aa2c36152a1f",
+              partitionValues = Map.empty,
+              size = 1030,
+              stats =
+                """{"numRecords":1,"minValues":{"name":"1","age":1,"birthday":"2020-01-01"},"maxValues":{"name":"1","age":1,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
+              version = 1,
+              timestamp = 1651272635000L
+            ),
+            AddFileForCDF(
+              url = tableFiles.addFiles(1).url,
+              expirationTimestamp = tableFiles.addFiles(1).expirationTimestamp,
+              id = "a6dc5694a4ebcc9a067b19c348526ad6",
+              partitionValues = Map.empty,
+              size = 1030,
+              stats =
+                """{"numRecords":1,"minValues":{"name":"2","age":2,"birthday":"2020-01-01"},"maxValues":{"name":"2","age":2,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
+              version = 1,
+              timestamp = 1651272635000L
+            ),
+            AddFileForCDF(
+              url = tableFiles.addFiles(2).url,
+              expirationTimestamp = tableFiles.addFiles(2).expirationTimestamp,
+              id = "d7ed708546dd70fdff9191b3e3d6448b",
+              partitionValues = Map.empty,
+              size = 1030,
+              stats =
+                """{"numRecords":1,"minValues":{"name":"3","age":3,"birthday":"2020-01-01"},"maxValues":{"name":"3","age":3,"birthday":"2020-01-01"},"nullCount":{"name":0,"age":0,"birthday":0}}""",
+              version = 1,
+              timestamp = 1651272635000L
+            )
           )
-        )
-        assert(expectedAddFiles == tableFiles.addFiles.toList)
-        assert(tableFiles.addFiles(0).expirationTimestamp > System.currentTimeMillis())
-      } finally {
-        client.close()
+          assert(expectedAddFiles == tableFiles.addFiles.toList)
+          assert(tableFiles.addFiles(0).expirationTimestamp > System.currentTimeMillis())
+        } finally {
+          client.close()
+        }
       }
     }
   }

--- a/client/src/test/scala/io/delta/sharing/spark/DeltaSharingOptionsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/spark/DeltaSharingOptionsSuite.scala
@@ -214,5 +214,10 @@ class DeltaSharingOptionsSuite extends SparkFunSuite {
       new DeltaSharingOptions(Map("versionAsOf" -> "1", "timestampAsOf" -> "2020"))
     }.getMessage
     assert(errorMessage.contains("Please either provide 'versionAsOf' or 'timestampAsOf'"))
+
+    errorMessage = intercept[IllegalArgumentException] {
+      new DeltaSharingOptions(Map("responseFormat" -> "abc"))
+    }.getMessage
+    assert(errorMessage.contains("The user input must be one of:{parquet, delta}."))
   }
 }

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -508,8 +508,18 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   integrationTest("table1 - non partitioned - /shares/{share}/schemas/{schema}/tables/{table}/metadata") {
-    Seq(RESPONSE_FORMAT_PARQUET, RESPONSE_FORMAT_DELTA).foreach { responseFormat =>
-      val response = readNDJson(requestPath(s"/shares/share1/schemas/default/tables/table1/metadata"), responseFormat = responseFormat, expectedTableVersion = Some(2))
+    Seq(
+      RESPONSE_FORMAT_PARQUET,
+      RESPONSE_FORMAT_DELTA,
+      s"$RESPONSE_FORMAT_DELTA,$RESPONSE_FORMAT_PARQUET",
+      s"$RESPONSE_FORMAT_PARQUET,$RESPONSE_FORMAT_DELTA"
+    ).foreach { responseFormat =>
+      val respondedFormat = if (responseFormat == RESPONSE_FORMAT_DELTA) {
+        RESPONSE_FORMAT_DELTA
+      } else {
+        RESPONSE_FORMAT_PARQUET
+      }
+      val response = readNDJson(requestPath(s"/shares/share1/schemas/default/tables/table1/metadata"), responseFormat = respondedFormat, expectedTableVersion = Some(2))
       val Array(protocol, metadata) = response.split("\n")
       if (responseFormat == RESPONSE_FORMAT_DELTA) {
         val responseProtocol = JsonUtils.fromJson[DeltaResponseSingleAction](protocol).protocol
@@ -531,7 +541,17 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   integrationTest("table1 - non partitioned - /shares/{share}/schemas/{schema}/tables/{table}/query") {
-    Seq(RESPONSE_FORMAT_PARQUET, RESPONSE_FORMAT_DELTA).foreach { responseFormat =>
+    Seq(
+      RESPONSE_FORMAT_PARQUET,
+      RESPONSE_FORMAT_DELTA,
+      s"$RESPONSE_FORMAT_DELTA,$RESPONSE_FORMAT_PARQUET",
+      s"$RESPONSE_FORMAT_PARQUET,$RESPONSE_FORMAT_DELTA"
+    ).foreach { responseFormat =>
+      val respondedFormat = if (responseFormat == RESPONSE_FORMAT_DELTA) {
+        RESPONSE_FORMAT_DELTA
+      } else {
+        RESPONSE_FORMAT_PARQUET
+      }
       val p =
         s"""
           |{
@@ -540,7 +560,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
           |  ]
           |}
           |""".stripMargin
-      val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/table1/query"), Some("POST"), Some(p), Some(2), responseFormat)
+      val response = readNDJson(requestPath("/shares/share1/schemas/default/tables/table1/query"), Some("POST"), Some(p), Some(2), respondedFormat)
       val lines = response.split("\n")
       val protocol = lines(0)
       val metadata = lines(1)
@@ -2232,8 +2252,18 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   integrationTest("cdf_table_cdf_enabled_changes - query table changes") {
-    Seq(RESPONSE_FORMAT_PARQUET, RESPONSE_FORMAT_DELTA).foreach { responseFormat =>
-      val response = readNDJson(requestPath(s"/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=0&endingVersion=3"), Some("GET"), None, Some(0), responseFormat)
+    Seq(
+      RESPONSE_FORMAT_PARQUET,
+      RESPONSE_FORMAT_DELTA,
+      s"$RESPONSE_FORMAT_DELTA,$RESPONSE_FORMAT_PARQUET",
+      s"$RESPONSE_FORMAT_PARQUET,$RESPONSE_FORMAT_DELTA"
+    ).foreach { responseFormat =>
+      val respondedFormat = if (responseFormat == RESPONSE_FORMAT_DELTA) {
+        RESPONSE_FORMAT_DELTA
+      } else {
+        RESPONSE_FORMAT_PARQUET
+      }
+      val response = readNDJson(requestPath(s"/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=0&endingVersion=3"), Some("GET"), None, Some(0), respondedFormat)
       val lines = response.split("\n")
       val protocol = lines(0)
       val metadata = lines(1)

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
@@ -24,8 +24,6 @@ import scala.collection.mutable
 import org.apache.spark.SparkEnv
 import org.apache.spark.delta.sharing.PreSignedUrlCache
 import org.apache.spark.sql.{SparkSession, SQLContext}
-import org.apache.spark.sql.connector.catalog.{Table, TableCapability, TableProvider}
-import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.execution.streaming.Source
 import org.apache.spark.sql.sources.{
   BaseRelation,
@@ -34,7 +32,6 @@ import org.apache.spark.sql.sources.{
   StreamSourceProvider
 }
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /** A DataSource V1 for integrating Delta into Spark SQL batch APIs. */
 private[sharing] class DeltaSharingDataSource

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.sources.{
 }
 import org.apache.spark.sql.types.StructType
 
+
 /** A DataSource V1 for integrating Delta into Spark SQL batch APIs. */
 private[sharing] class DeltaSharingDataSource
   extends RelationProvider


### PR DESCRIPTION
The same change as in https://github.com/delta-io/delta-sharing/pull/426

Allow list of responseFormat in the request http header, separated by comma(`responseFormat=parquet,delta`), but require only one decided responseformat in the response.
And throw error if the respondedFormat is not in the list of the request.