### PR TITLE
Improve error handling and logging in DeltaSharingSource in branch 0.7

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -183,15 +183,15 @@ case class DeltaSharingSource(
     val currentTimeMillis = System.currentTimeMillis()
     if (lastGetVersionTimestamp == -1 ||
       (currentTimeMillis - lastGetVersionTimestamp) >= QUERY_TABLE_VERSION_INTERVAL_MILLIS) {
-      val tmpVersion = deltaLog.client.getTableVersion(deltaLog.table)
-      if (tmpVersion < 0) {
+      val serverVersion = deltaLog.client.getTableVersion(deltaLog.table)
+      if (serverVersion < 0) {
         throw new IllegalStateException(s"Delta Sharing Server returning negative table version:" +
-          s"$tmpVersion.")
-      } else if (tmpVersion < latestTableVersion) {
-        logWarning(s"Delta Sharing Server returning smaller table version:$tmpVersion < " +
+          s"$serverVersion.")
+      } else if (serverVersion < latestTableVersion) {
+        logWarning(s"Delta Sharing Server returning smaller table version:$serverVersion < " +
           s"$latestTableVersion.")
       }
-      latestTableVersion = tmpVersion
+      latestTableVersion = serverVersion
       lastGetVersionTimestamp = currentTimeMillis
     }
     latestTableVersion

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -183,7 +183,15 @@ case class DeltaSharingSource(
     val currentTimeMillis = System.currentTimeMillis()
     if (lastGetVersionTimestamp == -1 ||
       (currentTimeMillis - lastGetVersionTimestamp) >= QUERY_TABLE_VERSION_INTERVAL_MILLIS) {
-      latestTableVersion = deltaLog.client.getTableVersion(deltaLog.table)
+      val tmpVersion = deltaLog.client.getTableVersion(deltaLog.table)
+      if (tmpVersion < 0) {
+        throw new IllegalStateException(s"Delta Sharing Server returning negative table version:" +
+          s"$tmpVersion.")
+      } else if (tmpVersion < latestTableVersion) {
+        logWarning(s"Delta Sharing Server returning smaller table version:$tmpVersion < " +
+          s"$latestTableVersion.")
+      }
+      latestTableVersion = tmpVersion
       lastGetVersionTimestamp = currentTimeMillis
     }
     latestTableVersion
@@ -455,6 +463,10 @@ case class DeltaSharingSource(
       }
 
       val numFiles = tableFiles.files.size
+      logInfo(
+        s"Fetched ${numFiles} files for table version ${tableFiles.version} from" +
+          " delta sharing server."
+      )
       tableFiles.files.sortWith(fileActionCompareFunc).zipWithIndex.foreach {
         case (file, index) if (index > fromIndex) =>
           appendToSortedFetchedFiles(
@@ -508,6 +520,11 @@ case class DeltaSharingSource(
         TableRefreshResult(idToUrl, minUrlExpiration, None)
       }
       val allAddFiles = validateCommitAndFilterAddFiles(tableFiles).groupBy(a => a.version)
+      logInfo(
+        s"Fetched and filtered ${allAddFiles.size} files from startingVersion " +
+          s"${fromVersion} to endingVersion ${endingVersionForQuery} from " +
+          "delta sharing server."
+      )
       for (v <- fromVersion to endingVersionForQuery) {
         val vAddFiles = allAddFiles.getOrElse(v, ArrayBuffer[AddFileForCDF]())
         val numFiles = vAddFiles.size


### PR DESCRIPTION
- Throw error when latest table version from the server is smaller than previous version.
- Add logging on number of files fetched from the server.