### PR TITLE
[DTS-2474] Introduce Timestamp and UUID as suffix to table path in RemoteDeltaLog

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -321,6 +321,10 @@ case class DeltaSharingSource(
       }
 
       val numFiles = tableFiles.files.size
+      logInfo(
+        s"Fetched ${numFiles} files for table version ${tableFiles.version} from" +
+          " delta sharing server."
+      )
       tableFiles.files.sortWith(fileActionCompareFunc).zipWithIndex.foreach {
         case (file, index) if (index > fromIndex) =>
           appendToSortedFetchedFiles(
@@ -362,6 +366,11 @@ case class DeltaSharingSource(
         TableRefreshResult(idToUrl, None)
       }
       val allAddFiles = validateCommitAndFilterAddFiles(tableFiles).groupBy(a => a.version)
+      logInfo(
+        s"Fetched and filtered ${allAddFiles.size} files from startingVersion " +
+          s"${fromVersion} to endingVersion ${endingVersionForQuery} from " +
+          "delta sharing server."
+      )
       for (v <- fromVersion to endingVersionForQuery) {
 
         val vAddFiles = allAddFiles.getOrElse(v, ArrayBuffer[AddFileForCDF]())

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -129,6 +129,8 @@ class DeltaSharingSourceSuite extends QueryTest
       "ignoreDeletes" -> "true",
       "startingVersion" -> "latest"
     ))
+    // #share8.default.cdf_table_cdf_enabled_<yyyyMMdd_HHmmss>_<UUID>
+    assert(source.deltaLog.path.toString.split("_").size == 7)
     val latestOffset = source.latestOffset(null, source.getDefaultReadLimit)
     assert(latestOffset == null)
   }


### PR DESCRIPTION
Introduce Timestamp and UUID as suffix to table path in RemoteDeltaLog, to avoid two queries on the same table override the CachedTableManager entry for each other. 