### PR TITLE
[DTS-2474] Introduce Timestamp and UUID as suffix to table path in RemoteDeltaLog in branch 0.7

### DIFF
--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -129,6 +129,8 @@ class DeltaSharingSourceSuite extends QueryTest
       "ignoreDeletes" -> "true",
       "startingVersion" -> "latest"
     ))
+    // #share8.default.cdf_table_cdf_enabled_<yyyyMMdd_HHmmss>_<UUID>
+    assert(source.deltaLog.path.toString.split("_").size == 7)
     val latestOffset = source.latestOffset(null, source.getDefaultReadLimit)
     assert(latestOffset == null)
   }


### PR DESCRIPTION
Introduce Timestamp and UUID as suffix to table path in RemoteDeltaLog, to avoid two queries on the same table override the CachedTableManager entry for each other.