### PR TITLE
[DTS-2474] Introduce Timestamp and UUID as suffix to table path in RemoteDeltaLog in branch 1.0

### DIFF
--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -17,6 +17,8 @@
 package io.delta.sharing.spark
 
 import java.lang.ref.WeakReference
+import java.text.SimpleDateFormat
+import java.util.{TimeZone, UUID}
 
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkException
@@ -110,6 +112,18 @@ private[sharing] object RemoteDeltaLog {
     _addFileEncoder.copy()
   }
 
+  // Get a unique string composed of a formatted timestamp and an uuid.
+  // Used as a suffix for the table name and its delta log path of a delta sharing table in a
+  // streaming job, to avoid overwriting the delta log from multiple references of the same delta
+  // sharing table in one streaming job.
+  private[sharing] def getFormattedTimestampWithUUID(): String = {
+    val dateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss")
+    dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"))
+    val formattedDateTime = dateFormat.format(System.currentTimeMillis())
+    val uuid = UUID.randomUUID().toString().split('-').head
+    s"_${formattedDateTime}_${uuid}"
+  }
+
   def apply(
       path: String,
       forStreaming: Boolean = false,
@@ -122,7 +136,12 @@ private[sharing] object RemoteDeltaLog {
       schema = parsedPath.schema,
       share = parsedPath.share
     )
-    new RemoteDeltaLog(deltaSharingTable, new Path(path), client, initDeltaTableMetadata)
+    new RemoteDeltaLog(
+      deltaSharingTable,
+      new Path(path + getFormattedTimestampWithUUID),
+      client,
+      initDeltaTableMetadata
+    )
   }
 }
 

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -121,6 +121,8 @@ class DeltaSharingSourceSuite extends QueryTest
       "ignoreDeletes" -> "true",
       "startingVersion" -> "latest"
     ))
+    // #share8.default.cdf_table_cdf_enabled_<yyyyMMdd_HHmmss>_<UUID>
+    assert(source.deltaLog.path.toString.split("_").size == 7)
     val latestOffset = source.latestOffset(null, source.getDefaultReadLimit)
     assert(latestOffset == null)
   }


### PR DESCRIPTION
Introduce Timestamp and UUID as suffix to table path in RemoteDeltaLog, to avoid two queries on the same table override the CachedTableManager entry for each other.