### PR TITLE
Add support for http proxy

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystem.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystem.scala
@@ -77,7 +77,7 @@ private[sharing] class DeltaSharingFileSystem extends FileSystem {
               new HttpRoute(target)
             } else {
               // Route via proxy
-              new HttpRoute(target, null, proxy, true)
+              new HttpRoute(target, proxy)
             }
           }
         }

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystem.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystem.scala
@@ -43,11 +43,10 @@ private[sharing] class DeltaSharingFileSystem extends FileSystem {
   lazy private val numRetries = ConfUtils.numRetries(getConf)
   lazy private val maxRetryDurationMillis = ConfUtils.maxRetryDurationMillis(getConf)
   lazy private val timeoutInSeconds = ConfUtils.timeoutInSeconds(getConf)
-  lazy private val proxyConfigOpt = ConfUtils.getProxyConfig(getConf)
-
   lazy private val httpClient = createHttpClient()
 
-  private def createHttpClient() = {
+  private[sharing] def createHttpClient() = {
+    val proxyConfigOpt = ConfUtils.getProxyConfig(getConf)
     val maxConnections = ConfUtils.maxConnections(getConf)
     val config = RequestConfig.custom()
       .setConnectTimeout(timeoutInSeconds * 1000)
@@ -62,8 +61,9 @@ private[sharing] class DeltaSharingFileSystem extends FileSystem {
       // See `RetryUtils.runWithExponentialBackoff`.
       .disableAutomaticRetries()
 
-    // Set proxy if provided
+    // Set proxy if provided.
     proxyConfigOpt.foreach { proxyConfig =>
+
       val proxy = new HttpHost(proxyConfig.host, proxyConfig.port)
       clientBuilder.setProxy(proxy)
 

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystem.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystem.scala
@@ -22,37 +22,78 @@ import java.util.concurrent.TimeUnit
 import org.apache.hadoop.fs._
 import org.apache.hadoop.fs.permission.FsPermission
 import org.apache.hadoop.util.Progressable
+import org.apache.http.{HttpHost, HttpRequest}
+import org.apache.http.auth.{AuthScope, UsernamePasswordCredentials}
 import org.apache.http.client.config.RequestConfig
-import org.apache.http.impl.client.HttpClientBuilder
+import org.apache.http.conn.routing.HttpRoute
+import org.apache.http.impl.client.{BasicCredentialsProvider, HttpClientBuilder}
+import org.apache.http.impl.conn.{DefaultRoutePlanner, DefaultSchemePortResolver}
+import org.apache.http.protocol.HttpContext
 import org.apache.spark.SparkEnv
 import org.apache.spark.delta.sharing.{PreSignedUrlCache, PreSignedUrlFetcher}
-import org.apache.spark.network.util.JavaUtils
 
 import io.delta.sharing.client.model.FileAction
-import io.delta.sharing.client.util.{ConfUtils, RetryUtils}
+import io.delta.sharing.client.util.ConfUtils
 
 /** Read-only file system for delta paths. */
 private[sharing] class DeltaSharingFileSystem extends FileSystem {
+
   import DeltaSharingFileSystem._
 
   lazy private val numRetries = ConfUtils.numRetries(getConf)
   lazy private val maxRetryDurationMillis = ConfUtils.maxRetryDurationMillis(getConf)
   lazy private val timeoutInSeconds = ConfUtils.timeoutInSeconds(getConf)
+  lazy private val proxyConfigOpt = ConfUtils.getProxyConfig(getConf)
 
   lazy private val httpClient = {
+
     val maxConnections = ConfUtils.maxConnections(getConf)
     val config = RequestConfig.custom()
       .setConnectTimeout(timeoutInSeconds * 1000)
       .setConnectionRequestTimeout(timeoutInSeconds * 1000)
       .setSocketTimeout(timeoutInSeconds * 1000).build()
-    HttpClientBuilder.create()
+
+    val clientBuilder = HttpClientBuilder.create()
       .setMaxConnTotal(maxConnections)
       .setMaxConnPerRoute(maxConnections)
       .setDefaultRequestConfig(config)
       // Disable the default retry behavior because we have our own retry logic.
       // See `RetryUtils.runWithExponentialBackoff`.
       .disableAutomaticRetries()
-      .build()
+
+    // Set proxy if provided
+    proxyConfigOpt.foreach { proxyConfig =>
+      val proxy = new HttpHost(proxyConfig.host, proxyConfig.port)
+      clientBuilder.setProxy(proxy)
+
+      // Set credentials if provided
+      if (proxyConfig.username.isDefined && proxyConfig.password.isDefined) {
+        val credsProvider = new BasicCredentialsProvider()
+        credsProvider.setCredentials(
+          new AuthScope(proxy),
+          new UsernamePasswordCredentials(proxyConfig.username.get, proxyConfig.password.get)
+        )
+        clientBuilder.setDefaultCredentialsProvider(credsProvider)
+      }
+
+      if (proxyConfig.noProxyHosts.nonEmpty) {
+        val routePlanner = new DefaultRoutePlanner(DefaultSchemePortResolver.INSTANCE) {
+          override def determineRoute(target: HttpHost,
+                                      request: HttpRequest,
+                                      context: HttpContext): HttpRoute = {
+            if (proxyConfig.noProxyHosts.contains(target.getHostName)) {
+              // Direct route (no proxy)
+              new HttpRoute(target)
+            } else {
+              // Route via proxy
+              new HttpRoute(target, null, proxy, true)
+            }
+          }
+        }
+        clientBuilder.setRoutePlanner(routePlanner)
+      }
+    }
+    clientBuilder.build()
   }
 
   private lazy val refreshThresholdMs = getConf.getLong(

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -70,12 +70,14 @@ object ConfUtils {
 
   def getProxyConfig(conf: Configuration): Option[ProxyConfig] = {
     val proxyHost = conf.get(PROXY_HOST, null)
-    if (proxyHost == null) {
+    val proxyPortAsString = conf.get(PROXY_PORT, null)
+
+    if (proxyHost == null && proxyPortAsString == null) {
       return None
     }
 
-    val proxyPortAsString = conf.get(PROXY_PORT, null)
-    validateNonNull(proxyPortAsString, PROXY_PORT)
+    validateNonEmpty(proxyHost, PROXY_HOST)
+    validateNonEmpty(proxyPortAsString, PROXY_PORT)
     val proxyPort = proxyPortAsString.toInt
     validatePortNumber(proxyPort, PROXY_PORT)
 
@@ -190,8 +192,8 @@ object ConfUtils {
     }
   }
 
-  private def validateNonNull(value: String, conf: String): Unit = {
-    if (value == null) {
+  private def validateNonEmpty(value: String, conf: String): Unit = {
+    if (value == null || value.isEmpty) {
       throw new IllegalArgumentException(conf + " must be defined")
     }
   }

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -204,8 +204,6 @@ object ConfUtils {
 
   case class ProxyConfig(host: String,
                          port: Int,
-                         username: Option[String] = None,
-                         password: Option[String] = None,
                          noProxyHosts: Seq[String] = Seq.empty
                         )
 }

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemSuite.scala
@@ -177,4 +177,60 @@ class DeltaSharingFileSystemSuite extends SparkFunSuite {
       proxyServer.stop()
     }
   }
+
+  test("traffic goes through the proxy when a noProxyHosts configured but does not include the destination") {
+    // Create a local HTTP server.
+    val server = new Server(0)
+    val handler = new ServletHandler()
+    server.setHandler(handler)
+    handler.addServletWithMapping(new ServletHolder(new HttpServlet {
+      override def doGet(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
+        resp.setContentType("text/plain")
+        resp.setStatus(HttpServletResponse.SC_OK)
+
+        // scalastyle:off println
+        resp.getWriter.println("Hello, World!")
+        // scalastyle:on println
+      }
+    }), "/*")
+    server.start()
+    do {
+      Thread.sleep(100)
+    } while (!server.isStarted())
+
+    // Create a local HTTP proxy server.
+    val proxyServer = new ProxyServer(0)
+    proxyServer.initialize()
+    try {
+      // Create a ProxyConfig with the host and port of the local proxy server and noProxyHosts.
+      val conf = new Configuration
+      conf.set(ConfUtils.PROXY_HOST, proxyServer.getHost())
+      conf.set(ConfUtils.PROXY_PORT, proxyServer.getPort().toString)
+      conf.set(ConfUtils.NO_PROXY_HOSTS, "1.2.3.4")
+
+      // Configure the httpClient to use the ProxyConfig.
+      val fs = new DeltaSharingFileSystem() {
+        override def getConf = {
+          conf
+        }
+      }
+
+      // Get http client instance.
+      val httpClient = fs.createHttpClient()
+
+      // Send a request to the local server through the httpClient.
+      val response = httpClient.execute(new HttpGet(server.getURI.toString))
+
+      // Assert that the request is successful.
+      assert(response.getStatusLine.getStatusCode == HttpServletResponse.SC_OK)
+      val content = EntityUtils.toString(response.getEntity)
+      assert(content.trim == "Hello, World!")
+
+      // Assert that the request is not passed through proxy.
+      assert(proxyServer.getCapturedRequests().size == 1)
+    } finally {
+      server.stop()
+      proxyServer.stop()
+    }
+  }
 }

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemSuite.scala
@@ -21,9 +21,9 @@ import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 import org.apache.hadoop.conf.Configuration
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.util.EntityUtils
+import org.apache.spark.SparkFunSuite
 import org.sparkproject.jetty.server.Server
 import org.sparkproject.jetty.servlet.{ServletHandler, ServletHolder}
-import org.apache.spark.SparkFunSuite
 
 import io.delta.sharing.client.model._
 import io.delta.sharing.client.util.{ConfUtils, ProxyServer}
@@ -178,7 +178,7 @@ class DeltaSharingFileSystemSuite extends SparkFunSuite {
     }
   }
 
-  test("traffic goes through the proxy when a noProxyHosts configured but does not include the destination") {
+  test("traffic goes through the proxy when noProxyHosts does not include destination") {
     // Create a local HTTP server.
     val server = new Server(0)
     val handler = new ServletHandler()

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemSuite.scala
@@ -16,11 +16,18 @@
 
 package io.delta.sharing.client
 
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.Path
-import org.apache.spark.SparkFunSuite
+import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 
-import io.delta.sharing.client.model.{AddCDCFile, AddFile, AddFileForCDF, FileAction, RemoveFile}
+import org.apache.hadoop.conf.Configuration
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.util.EntityUtils
+import org.apache.spark.SparkFunSuite
+import org.sparkproject.jetty.server.Server
+import org.sparkproject.jetty.servlet.{ServletHandler, ServletHolder}
+
+import io.delta.sharing.client.model._
+import io.delta.sharing.client.util.{ConfUtils, ProxyServer}
 
 class DeltaSharingFileSystemSuite extends SparkFunSuite {
   import DeltaSharingFileSystem._
@@ -57,5 +64,57 @@ class DeltaSharingFileSystemSuite extends SparkFunSuite {
       assert(fs.isInstanceOf[DeltaSharingFileSystem])
       assert(fs eq path.getFileSystem(conf))
     })
+  }
+
+  test("traffic goes through a proxy when a proxy configured") {
+    // Step 1: Create a local HTTP server
+    val server = new Server(0)
+    val handler = new ServletHandler()
+    server.setHandler(handler)
+    handler.addServletWithMapping(new ServletHolder(new HttpServlet {
+      override def doGet(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
+        resp.setContentType("text/plain")
+        resp.setStatus(HttpServletResponse.SC_OK)
+
+        // scalastyle:off println
+        resp.getWriter.println("Hello, World!")
+        // scalastyle:on println
+      }
+    }), "/*")
+    server.start()
+
+    // Step 2: Create a local HTTP proxy server
+    // Please replace this with actual code to create a proxy server
+    val proxyServer = new ProxyServer(0)
+    proxyServer.initialize()
+    try {
+      // Step 3: Create a ProxyConfig with the host and port of the local proxy server
+      val conf = new Configuration
+      val path = DeltaSharingPath("https://delta.io/foo", "myid", 100).toPath
+      conf.set(ConfUtils.PROXY_HOST, "localhost")
+      conf.set(ConfUtils.PROXY_PORT, proxyServer.getPort().toString)
+      val fs = path.getFileSystem(conf)
+
+      // Step 4: Use reflection to access the httpClient field in DeltaSharingFileSystem
+      val methodName = "createHttpClient"  // replace with your method name
+
+      val method = fs.getClass.getDeclaredMethod(methodName)
+      method.setAccessible(true)
+      val httpClient = method.invoke(fs)
+        .asInstanceOf[CloseableHttpClient]
+      // Step 5: Configure the httpClient to use the ProxyConfig
+      // Please replace this with actual code to configure the httpClient
+
+      // Step 6: Send a request to the local server through the httpClient
+      val response = httpClient.execute(new HttpGet(server.getURI.toString))
+
+      // Step 7: Assert that the request is successful
+      assert(response.getStatusLine.getStatusCode == HttpServletResponse.SC_OK)
+      val content = EntityUtils.toString(response.getEntity)
+      assert(content.trim == "Hello, World!")
+    } finally {
+      server.stop()
+      proxyServer.stop()
+    }
   }
 }

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemSuite.scala
@@ -66,7 +66,7 @@ class DeltaSharingFileSystemSuite extends SparkFunSuite {
   }
 
   test("traffic goes through a proxy when a proxy configured") {
-    // Create a local HTTP server
+    // Create a local HTTP server.
     val server = new Server(0)
     val handler = new ServletHandler()
     server.setHandler(handler)
@@ -85,36 +85,36 @@ class DeltaSharingFileSystemSuite extends SparkFunSuite {
       Thread.sleep(100)
     } while (!server.isStarted())
 
-    // Create a local HTTP proxy server
+    // Create a local HTTP proxy server.
     val proxyServer = new ProxyServer(0)
     proxyServer.initialize()
 
     try {
 
-      // Create a ProxyConfig with the host and port of the local proxy server
+      // Create a ProxyConfig with the host and port of the local proxy server.
       val conf = new Configuration
       conf.set(ConfUtils.PROXY_HOST, proxyServer.getHost())
       conf.set(ConfUtils.PROXY_PORT, proxyServer.getPort().toString)
 
-      // Configure the httpClient to use the ProxyConfig
+      // Configure the httpClient to use the ProxyConfig.
       val fs = new DeltaSharingFileSystem() {
         override def getConf = {
           conf
         }
       }
 
-      // Get http client instance
+      // Get http client instance.
       val httpClient = fs.createHttpClient()
 
-      // Send a request to the local server through the httpClient
+      // Send a request to the local server through the httpClient.
       val response = httpClient.execute(new HttpGet(server.getURI.toString))
 
-      // Assert that the request is successful
+      // Assert that the request is successful.
       assert(response.getStatusLine.getStatusCode == HttpServletResponse.SC_OK)
       val content = EntityUtils.toString(response.getEntity)
       assert(content.trim == "Hello, World!")
 
-      // Assert that the request is passed through proxy
+      // Assert that the request is passed through proxy.
       assert(proxyServer.getCapturedRequests().size == 1)
     } finally {
       server.stop()
@@ -123,7 +123,7 @@ class DeltaSharingFileSystemSuite extends SparkFunSuite {
   }
 
   test("traffic skips the proxy when a noProxyHosts configured") {
-    // Create a local HTTP server
+    // Create a local HTTP server.
     val server = new Server(0)
     val handler = new ServletHandler()
     server.setHandler(handler)
@@ -142,35 +142,35 @@ class DeltaSharingFileSystemSuite extends SparkFunSuite {
       Thread.sleep(100)
     } while (!server.isStarted())
 
-    // Create a local HTTP proxy server
+    // Create a local HTTP proxy server.
     val proxyServer = new ProxyServer(0)
     proxyServer.initialize()
     try {
-      // Create a ProxyConfig with the host and port of the local proxy server and noProxyHosts
+      // Create a ProxyConfig with the host and port of the local proxy server and noProxyHosts.
       val conf = new Configuration
       conf.set(ConfUtils.PROXY_HOST, proxyServer.getHost())
       conf.set(ConfUtils.PROXY_PORT, proxyServer.getPort().toString)
       conf.set(ConfUtils.NO_PROXY_HOSTS, server.getURI.getHost)
 
-      // Configure the httpClient to use the ProxyConfig
+      // Configure the httpClient to use the ProxyConfig.
       val fs = new DeltaSharingFileSystem() {
         override def getConf = {
           conf
         }
       }
 
-      // Get http client instance
+      // Get http client instance.
       val httpClient = fs.createHttpClient()
 
-      // Send a request to the local server through the httpClient
+      // Send a request to the local server through the httpClient.
       val response = httpClient.execute(new HttpGet(server.getURI.toString))
 
-      // Assert that the request is successful
+      // Assert that the request is successful.
       assert(response.getStatusLine.getStatusCode == HttpServletResponse.SC_OK)
       val content = EntityUtils.toString(response.getEntity)
       assert(content.trim == "Hello, World!")
 
-      // Assert that the request is not passed through proxy
+      // Assert that the request is not passed through proxy.
       assert(proxyServer.getCapturedRequests().isEmpty)
     } finally {
       server.stop()

--- a/client/src/test/scala/io/delta/sharing/client/util/ConfUtilsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/ConfUtilsSuite.scala
@@ -90,4 +90,35 @@ class ConfUtilsSuite extends SparkFunSuite {
       maxConnections(newConf(Map(MAX_CONNECTION_CONF -> "-1")))
     }.getMessage.contains(MAX_CONNECTION_CONF)
   }
+
+  test("getProxyConfig with all proxy settings") {
+    val conf = newConf(Map(
+      PROXY_HOST -> "1.2.3.4",
+      PROXY_PORT -> "8080",
+      NO_PROXY_HOSTS -> "localhost,127.0.0.1"
+    ))
+    val proxyConfig = getProxyConfig(conf)
+    assert(proxyConfig.isDefined)
+    assert(proxyConfig.get.host == "1.2.3.4")
+    assert(proxyConfig.get.port == 8080)
+    assert(proxyConfig.get.noProxyHosts == Seq("localhost", "127.0.0.1"))
+  }
+
+  test("getProxyConfig with only host and port") {
+    val conf = newConf(Map(
+      PROXY_HOST -> "1.2.3.4",
+      PROXY_PORT -> "8080"
+    ))
+    val proxyConfig = getProxyConfig(conf)
+    assert(proxyConfig.isDefined)
+    assert(proxyConfig.get.host == "1.2.3.4")
+    assert(proxyConfig.get.port == 8080)
+    assert(proxyConfig.get.noProxyHosts.isEmpty)
+  }
+
+  test("getProxyConfig with no proxy settings") {
+    val conf = newConf()
+    val proxyConfig = getProxyConfig(conf)
+    assert(proxyConfig.isEmpty)
+  }
 }

--- a/client/src/test/scala/io/delta/sharing/client/util/ConfUtilsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/ConfUtilsSuite.scala
@@ -121,4 +121,53 @@ class ConfUtilsSuite extends SparkFunSuite {
     val proxyConfig = getProxyConfig(conf)
     assert(proxyConfig.isEmpty)
   }
+
+  test("getProxyConfig with invalid port") {
+    val conf = newConf(Map(
+      PROXY_HOST -> "localhost",
+      PROXY_PORT -> "70000" // Invalid port number
+    ))
+    intercept[IllegalArgumentException] {
+      getProxyConfig(conf)
+    }.getMessage.contains(PROXY_PORT)
+  }
+
+  test("getProxyConfig with null host") {
+    val conf = newConf(Map(
+      PROXY_PORT -> "8080"
+    ))
+    intercept[IllegalArgumentException] {
+      getProxyConfig(conf)
+    }.getMessage.contains(PROXY_HOST)
+  }
+
+  test("getProxyConfig with empty host") {
+    val conf = newConf(Map(
+      PROXY_HOST -> "", // Empty host
+      PROXY_PORT -> "8080"
+    ))
+    intercept[IllegalArgumentException] {
+      getProxyConfig(conf)
+    }.getMessage.contains(PROXY_HOST)
+  }
+
+  test("getProxyConfig with zero port") {
+    val conf = newConf(Map(
+      PROXY_HOST -> "localhost",
+      PROXY_PORT -> "0" // Zero port number
+    ))
+    intercept[IllegalArgumentException] {
+      getProxyConfig(conf)
+    }.getMessage.contains(PROXY_PORT)
+  }
+
+  test("getProxyConfig with negative port") {
+    val conf = newConf(Map(
+      PROXY_HOST -> "localhost",
+      PROXY_PORT -> "-1" // Negative port number
+    ))
+    intercept[IllegalArgumentException] {
+      getProxyConfig(conf)
+    }.getMessage.contains(PROXY_PORT)
+  }
 }

--- a/client/src/test/scala/io/delta/sharing/client/util/ProxyServer.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/ProxyServer.scala
@@ -1,0 +1,69 @@
+package io.delta.sharing.client.util
+
+import java.net.URI
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+import scala.util.Try
+
+import org.sparkproject.jetty.client.HttpClient
+import org.sparkproject.jetty.http.HttpMethod
+import org.sparkproject.jetty.server.{Request, Server}
+import org.sparkproject.jetty.server.handler.AbstractHandler
+
+class ProxyServer(port: Int) {
+  private val server = new Server(port)
+  private val httpClient = new HttpClient()
+
+  server.setHandler(new ProxyHandler)
+
+  def initialize(): Unit = {
+    new Thread(() => {
+      Try(httpClient.start())
+      Try(server.start())
+    }).start()
+  }
+
+  def stop(): Unit = {
+    Try(server.stop())
+    Try(httpClient.stop())
+  }
+
+  def getPort() : Int = {
+    server.getURI().getPort()
+  }
+
+  private class ProxyHandler extends AbstractHandler {
+    override def handle(target: String,
+                        baseRequest: Request,
+                        request: HttpServletRequest,
+                        response: HttpServletResponse): Unit = {
+
+      Option(request.getHeader("Host")) match {
+        case Some(host) =>
+          Try {
+            val uri = request.getScheme + "://" + host + request.getRequestURI
+            val res = httpClient.newRequest(uri)
+              .method(HttpMethod.GET)
+              .send()
+
+            response.setContentType(res.getMediaType)
+            response.setStatus(res.getStatus)
+            // scalastyle:off
+            response.getWriter.println(res.getContentAsString)
+            // scalastyle:on
+          }.recover {
+            case e: Exception =>
+              e.printStackTrace()
+              // scalastyle:off
+              response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Error in Proxy Server")
+              // scalastyle:on
+          }
+
+          baseRequest.setHandled(true)
+
+        case None =>
+          response.sendError(HttpServletResponse.SC_BAD_REQUEST, "No forwarding URL provided")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds support for Http Proxy when reading data from storage

sample configuration:

```
spark.delta.sharing.network.proxyHost=1.2.3.4
spark.delta.sharing.network.proxyPort=3128
spark.delta.sharing.network.noProxyHosts=5.6.7.8,12.13.14.15
```