### PR TITLE
Add support for http proxy (#450)

### DIFF
--- a/client/src/test/scala/io/delta/sharing/client/util/ConfUtilsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/ConfUtilsSuite.scala
@@ -90,4 +90,84 @@ class ConfUtilsSuite extends SparkFunSuite {
       maxConnections(newConf(Map(MAX_CONNECTION_CONF -> "-1")))
     }.getMessage.contains(MAX_CONNECTION_CONF)
   }
+
+  test("getProxyConfig with all proxy settings") {
+    val conf = newConf(Map(
+      PROXY_HOST -> "1.2.3.4",
+      PROXY_PORT -> "8080",
+      NO_PROXY_HOSTS -> "localhost,127.0.0.1"
+    ))
+    val proxyConfig = getProxyConfig(conf)
+    assert(proxyConfig.isDefined)
+    assert(proxyConfig.get.host == "1.2.3.4")
+    assert(proxyConfig.get.port == 8080)
+    assert(proxyConfig.get.noProxyHosts == Seq("localhost", "127.0.0.1"))
+  }
+
+  test("getProxyConfig with only host and port") {
+    val conf = newConf(Map(
+      PROXY_HOST -> "1.2.3.4",
+      PROXY_PORT -> "8080"
+    ))
+    val proxyConfig = getProxyConfig(conf)
+    assert(proxyConfig.isDefined)
+    assert(proxyConfig.get.host == "1.2.3.4")
+    assert(proxyConfig.get.port == 8080)
+    assert(proxyConfig.get.noProxyHosts.isEmpty)
+  }
+
+  test("getProxyConfig with no proxy settings") {
+    val conf = newConf()
+    val proxyConfig = getProxyConfig(conf)
+    assert(proxyConfig.isEmpty)
+  }
+
+  test("getProxyConfig with invalid port") {
+    val conf = newConf(Map(
+      PROXY_HOST -> "localhost",
+      PROXY_PORT -> "70000" // Invalid port number
+    ))
+    intercept[IllegalArgumentException] {
+      getProxyConfig(conf)
+    }.getMessage.contains(PROXY_PORT)
+  }
+
+  test("getProxyConfig with null host") {
+    val conf = newConf(Map(
+      PROXY_PORT -> "8080"
+    ))
+    intercept[IllegalArgumentException] {
+      getProxyConfig(conf)
+    }.getMessage.contains(PROXY_HOST)
+  }
+
+  test("getProxyConfig with empty host") {
+    val conf = newConf(Map(
+      PROXY_HOST -> "", // Empty host
+      PROXY_PORT -> "8080"
+    ))
+    intercept[IllegalArgumentException] {
+      getProxyConfig(conf)
+    }.getMessage.contains(PROXY_HOST)
+  }
+
+  test("getProxyConfig with zero port") {
+    val conf = newConf(Map(
+      PROXY_HOST -> "localhost",
+      PROXY_PORT -> "0" // Zero port number
+    ))
+    intercept[IllegalArgumentException] {
+      getProxyConfig(conf)
+    }.getMessage.contains(PROXY_PORT)
+  }
+
+  test("getProxyConfig with negative port") {
+    val conf = newConf(Map(
+      PROXY_HOST -> "localhost",
+      PROXY_PORT -> "-1" // Negative port number
+    ))
+    intercept[IllegalArgumentException] {
+      getProxyConfig(conf)
+    }.getMessage.contains(PROXY_PORT)
+  }
 }

--- a/client/src/test/scala/io/delta/sharing/client/util/ProxyServer.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/ProxyServer.scala
@@ -1,0 +1,85 @@
+package io.delta.sharing.client.util
+
+import java.net.URI
+import java.util.Collections
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+import scala.util.Try
+
+import org.sparkproject.jetty.client.HttpClient
+import org.sparkproject.jetty.http.HttpMethod
+import org.sparkproject.jetty.server.{Request, Server}
+import org.sparkproject.jetty.server.handler.AbstractHandler
+
+class ProxyServer(port: Int) {
+  private val server = new Server(port)
+  private val httpClient = new HttpClient()
+  private val capturedRequests = Collections
+    .synchronizedList(new java.util.ArrayList[HttpServletRequest]())
+
+  server.setHandler(new ProxyHandler)
+
+  def initialize(): Unit = {
+    new Thread(() => {
+      Try(httpClient.start())
+      Try(server.start())
+    }).start()
+
+    do {
+      Thread.sleep(100)
+    } while (!server.isStarted())
+  }
+
+  def stop(): Unit = {
+    Try(server.stop())
+    Try(httpClient.stop())
+  }
+
+  def getPort(): Int = {
+    server.getURI().getPort()
+  }
+
+  def getHost(): String = {
+    server.getURI().getHost
+  }
+
+  def getCapturedRequests(): Seq[HttpServletRequest] = {
+    capturedRequests.toArray(Array[HttpServletRequest]()).toSeq
+  }
+
+  private class ProxyHandler extends AbstractHandler {
+    override def handle(target: String,
+                        baseRequest: Request,
+                        request: HttpServletRequest,
+                        response: HttpServletResponse): Unit = {
+
+      capturedRequests.add(request)
+      Option(request.getHeader("Host")) match {
+        case Some(host) =>
+          Try {
+            val uri = request.getScheme + "://" + host + request.getRequestURI
+            val res = httpClient.newRequest(uri)
+              .method(HttpMethod.GET)
+              .send()
+
+            response.setContentType(res.getMediaType)
+            response.setStatus(res.getStatus)
+            // scalastyle:off
+            response.getWriter.println(res.getContentAsString)
+            // scalastyle:on
+          }.recover {
+            case e: Exception =>
+              e.printStackTrace()
+              // scalastyle:off
+              response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Error in Proxy Server")
+            // scalastyle:on
+          }
+
+          baseRequest.setHandled(true)
+
+        case None =>
+          response.sendError(HttpServletResponse.SC_BAD_REQUEST, "No forwarding URL provided")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds support for Http Proxy when reading data from storage

sample configuration:

```
spark.delta.sharing.network.proxyHost=1.2.3.4
spark.delta.sharing.network.proxyPort=3128
spark.delta.sharing.network.noProxyHosts=5.6.7.8,12.13.14.15
```