### PR TITLE
Add json predicate hints to load_as_pandas.

### DIFF
--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -122,7 +122,7 @@ def load_as_pandas(
     return DeltaSharingReader(
         table=Table(name=table, share=share, schema=schema),
         rest_client=DataSharingRestClient(profile),
-        jsonPredicateHints = jsonPredicateHints,
+        jsonPredicateHints=jsonPredicateHints,
         limit=limit,
         version=version,
         timestamp=timestamp

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -117,7 +117,6 @@ def load_as_pandas(
       https://github.com/delta-io/delta-sharing/blob/main/PROTOCOL.md#json-predicates-for-filtering
     :return: A pandas DataFrame representing the shared table.
     """
-    print("Abhijit: load_as_pandas")
     profile_json, share, schema, table = _parse_url(url)
     profile = DeltaSharingProfile.read_from_file(profile_json)
     return DeltaSharingReader(

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -102,7 +102,8 @@ def load_as_pandas(
     url: str,
     limit: Optional[int] = None,
     version: Optional[int] = None,
-    timestamp: Optional[str] = None
+    timestamp: Optional[str] = None,
+    jsonPredicateHints: Optional[str] = None,
 ) -> pd.DataFrame:
     """
     Load the shared table using the given url as a pandas DataFrame.
@@ -112,13 +113,17 @@ def load_as_pandas(
       Use this optional parameter to explore the shared table without loading the entire table to
       the memory.
     :param version: an optional non-negative int. Load the snapshot of table at version
+    :param jsonPredicateHints: Predicate hints to be applied to the table. For more details see:
+      https://github.com/delta-io/delta-sharing/blob/main/PROTOCOL.md#json-predicates-for-filtering
     :return: A pandas DataFrame representing the shared table.
     """
+    print("Abhijit: load_as_pandas")
     profile_json, share, schema, table = _parse_url(url)
     profile = DeltaSharingProfile.read_from_file(profile_json)
     return DeltaSharingReader(
         table=Table(name=table, share=share, schema=schema),
         rest_client=DataSharingRestClient(profile),
+        jsonPredicateHints = jsonPredicateHints,
         limit=limit,
         version=version,
         timestamp=timestamp

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -519,9 +519,9 @@ def test_load_as_pandas_success(
         pytest.param(
             "share8.default.cdf_table_with_partition",
             (
-              '{"op":"equal", "children":['
-              '  {"op":"column","name":"birthday","valueType":"date"},'
-              '  {"op":"literal","value":"2020-02-02","valueType":"date"}]}'
+                '{"op":"equal", "children":['
+                '  {"op":"column","name":"birthday","valueType":"date"},'
+                '  {"op":"literal","value":"2020-02-02","valueType":"date"}]}'
             ),
             pd.DataFrame(
                 {
@@ -536,9 +536,9 @@ def test_load_as_pandas_success(
         pytest.param(
             "share8.default.cdf_table_with_partition",
             (
-              '{"op":"equal", "children":['
-              '  {"op":"column","name":"birthday","valueType":"date"},'
-              '  {"op":"literal","value":"2020-01-01","valueType":"date"}]}'
+                '{"op":"equal", "children":['
+                '  {"op":"column","name":"birthday","valueType":"date"},'
+                '  {"op":"literal","value":"2020-01-01","valueType":"date"}]}'
             ),
             pd.DataFrame(
                 {
@@ -553,9 +553,9 @@ def test_load_as_pandas_success(
         pytest.param(
             "share8.default.cdf_table_with_partition",
             (
-              '{"op":"equal", "children":['
-              '  {"op":"column","name":"birthday","valueType":"date"},'
-              '  {"op":"literal","value":"2022-02-02","valueType":"date"}]}'
+                '{"op":"equal", "children":['
+                '  {"op":"column","name":"birthday","valueType":"date"},'
+                '  {"op":"literal","value":"2022-02-02","valueType":"date"}]}'
             ),
             pd.DataFrame(
                 {
@@ -570,9 +570,9 @@ def test_load_as_pandas_success(
         pytest.param(
             "share8.default.cdf_table_with_partition",
             (
-              '{"op":"greaterThan", "children":['
-              '  {"op":"column","name":"birthday","valueType":"date"},'
-              '  {"op":"literal","value":"2019-01-01","valueType":"date"}]}'
+                '{"op":"greaterThan", "children":['
+                '  {"op":"column","name":"birthday","valueType":"date"},'
+                '  {"op":"literal","value":"2019-01-01","valueType":"date"}]}'
             ),
             pd.DataFrame(
                 {


### PR DESCRIPTION
In this PR, we add support for json predicate hints in load_as_pandas method.
The functionality is tested by unit tests.