### PR TITLE
Do not retry on ConnectionClosedException in branch-1.0

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/util/RetryUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/RetryUtils.scala
@@ -71,6 +71,9 @@ private[sharing] object RetryUtils extends Logging {
           false
         }
       case _: java.net.SocketTimeoutException => true
+      // do not retry on ConnectionClosedException because it can be caused by invalid json returned
+      // from the delta sharing server.
+      case _: org.apache.http.ConnectionClosedException => false
       case _: InterruptedException => false
       case _: InterruptedIOException => false
       case _: IOException => true


### PR DESCRIPTION
Do not retry on ConnectionClosedException, because it can be caused by invalid json returned from the delta sharing server.

The same PR as https://github.com/delta-io/delta-sharing/pull/467