### PR TITLE
[Streaming] Lower the minimum streaming rpc interval to 10s

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -59,7 +59,7 @@ object ConfUtils {
 
   val QUERY_TABLE_VERSION_INTERVAL_SECONDS =
     "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds"
-  val QUERY_TABLE_VERSION_INTERVAL_SECONDS_DEFAULT = "10s"
+  val QUERY_TABLE_VERSION_INTERVAL_SECONDS_DEFAULT = "30s"
 
   val LIMIT_PUSHDOWN_ENABLED_CONF = "spark.delta.sharing.limitPushdown.enabled"
   val LIMIT_PUSHDOWN_ENABLED_DEFAULT = "true"

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -59,7 +59,7 @@ object ConfUtils {
 
   val QUERY_TABLE_VERSION_INTERVAL_SECONDS =
     "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds"
-  val QUERY_TABLE_VERSION_INTERVAL_SECONDS_DEFAULT = "30s"
+  val QUERY_TABLE_VERSION_INTERVAL_SECONDS_DEFAULT = "10s"
 
   val LIMIT_PUSHDOWN_ENABLED_CONF = "spark.delta.sharing.limitPushdown.enabled"
   val LIMIT_PUSHDOWN_ENABLED_DEFAULT = "true"

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -171,8 +171,8 @@ object ConfUtils {
   private def toTimeInSeconds(timeStr: String, conf: String): Int = {
     val timeInSeconds = JavaUtils.timeStringAs(timeStr, TimeUnit.SECONDS)
     validateNonNeg(timeInSeconds, conf)
-    if (conf == QUERY_TABLE_VERSION_INTERVAL_SECONDS && timeInSeconds < 30) {
-      throw new IllegalArgumentException(conf + " must not be less than 30 seconds.")
+    if (conf == QUERY_TABLE_VERSION_INTERVAL_SECONDS && timeInSeconds < 10) {
+      throw new IllegalArgumentException(conf + " must not be less than 10 seconds.")
     }
     if (timeInSeconds > Int.MaxValue) {
       throw new IllegalArgumentException(conf + " is too big: " + timeStr)

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -60,6 +60,7 @@ object ConfUtils {
   val QUERY_TABLE_VERSION_INTERVAL_SECONDS =
     "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds"
   val QUERY_TABLE_VERSION_INTERVAL_SECONDS_DEFAULT = "30s"
+  val MINIMUM_TABLE_VERSION_INTERVAL_SECONDS = 10
 
   val LIMIT_PUSHDOWN_ENABLED_CONF = "spark.delta.sharing.limitPushdown.enabled"
   val LIMIT_PUSHDOWN_ENABLED_DEFAULT = "true"
@@ -171,8 +172,10 @@ object ConfUtils {
   private def toTimeInSeconds(timeStr: String, conf: String): Int = {
     val timeInSeconds = JavaUtils.timeStringAs(timeStr, TimeUnit.SECONDS)
     validateNonNeg(timeInSeconds, conf)
-    if (conf == QUERY_TABLE_VERSION_INTERVAL_SECONDS && timeInSeconds < 10) {
-      throw new IllegalArgumentException(conf + " must not be less than 10 seconds.")
+    if (conf == QUERY_TABLE_VERSION_INTERVAL_SECONDS &&
+      timeInSeconds < MINIMUM_TABLE_VERSION_INTERVAL_SECONDS) {
+      throw new IllegalArgumentException(
+        conf + s" must not be less than $MINIMUM_TABLE_VERSION_INTERVAL_SECONDS seconds.")
     }
     if (timeInSeconds > Int.MaxValue) {
       throw new IllegalArgumentException(conf + " is too big: " + timeStr)

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -143,14 +143,14 @@ case class DeltaSharingSource(
 
   private var lastGetVersionTimestamp: Long = -1
   private var latestTableVersion: Long = -1
-  // minimum 30 seconds
+  // minimum 10 seconds
   private val QUERY_TABLE_VERSION_INTERVAL_MILLIS = {
-    val interval = 30000.max(
+    val interval = 10000.max(
       ConfUtils.streamingQueryTableVersionIntervalSeconds(spark.sessionState.conf) * 1000
     )
-    if (interval < 30000) {
+    if (interval < 10000) {
       throw new IllegalArgumentException(s"QUERY_TABLE_VERSION_INTERVAL_MILLIS($interval) must " +
-        "not be less than 30 seconds.")
+        "not be less than 10 seconds.")
     }
     interval
   }

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -145,15 +145,15 @@ case class DeltaSharingSource(
   private var latestTableVersion: Long = -1
   // minimum 10 seconds
   private val QUERY_TABLE_VERSION_INTERVAL_MILLIS = {
-    val interval = 10000.max(
-      ConfUtils.streamingQueryTableVersionIntervalSeconds(spark.sessionState.conf) * 1000
+    val intervalSeconds = ConfUtils.MINIMUM_TABLE_VERSION_INTERVAL_SECONDS.max(
+      ConfUtils.streamingQueryTableVersionIntervalSeconds(spark.sessionState.conf)
     )
-    logInfo(s"Configured queryTableVersionIntervalSeconds:${interval/1000}.")
-    if (interval < 10000) {
-      throw new IllegalArgumentException(s"QUERY_TABLE_VERSION_INTERVAL_MILLIS($interval) must " +
-        "not be less than 10 seconds.")
+    logInfo(s"Configured queryTableVersionIntervalSeconds:${intervalSeconds}.")
+    if (intervalSeconds < ConfUtils.MINIMUM_TABLE_VERSION_INTERVAL_SECONDS) {
+      throw new IllegalArgumentException(s"QUERY_TABLE_VERSION_INTERVAL_MILLIS($intervalSeconds) " +
+        s"must not be less than ${ConfUtils.MINIMUM_TABLE_VERSION_INTERVAL_SECONDS} seconds.")
     }
-    interval
+    intervalSeconds * 1000
   }
   private val maxVersionsPerRpc: Int = options.maxVersionsPerRpc.getOrElse(
     DeltaSharingOptions.MAX_VERSIONS_PER_RPC_DEFAULT

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -148,6 +148,7 @@ case class DeltaSharingSource(
     val interval = 10000.max(
       ConfUtils.streamingQueryTableVersionIntervalSeconds(spark.sessionState.conf) * 1000
     )
+    logInfo(s"Configured queryTableVersionIntervalSeconds:${interval/1000}.")
     if (interval < 10000) {
       throw new IllegalArgumentException(s"QUERY_TABLE_VERSION_INTERVAL_MILLIS($interval) must " +
         "not be less than 10 seconds.")
@@ -173,6 +174,7 @@ case class DeltaSharingSource(
     if (lastGetVersionTimestamp == -1 ||
       (currentTimeMillis - lastGetVersionTimestamp) >= QUERY_TABLE_VERSION_INTERVAL_MILLIS) {
       val serverVersion = deltaLog.client.getTableVersion(deltaLog.table)
+      logInfo(s"Got table version $serverVersion from Delta Sharing Server.")
       if (serverVersion < 0) {
         throw new IllegalStateException(s"Delta Sharing Server returning negative table version:" +
           s"$serverVersion.")


### PR DESCRIPTION
Lower the streaming rpc interval to 10s, default is still 30s