### PR TITLE
[Streaming] Lower the minimum streaming rpc interval to 10s  in branch 1.0

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -60,6 +60,7 @@ object ConfUtils {
   val QUERY_TABLE_VERSION_INTERVAL_SECONDS =
     "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds"
   val QUERY_TABLE_VERSION_INTERVAL_SECONDS_DEFAULT = "30s"
+  val MINIMUM_TABLE_VERSION_INTERVAL_SECONDS = 10
 
   val LIMIT_PUSHDOWN_ENABLED_CONF = "spark.delta.sharing.limitPushdown.enabled"
   val LIMIT_PUSHDOWN_ENABLED_DEFAULT = "true"
@@ -171,8 +172,10 @@ object ConfUtils {
   private def toTimeInSeconds(timeStr: String, conf: String): Int = {
     val timeInSeconds = JavaUtils.timeStringAs(timeStr, TimeUnit.SECONDS)
     validateNonNeg(timeInSeconds, conf)
-    if (conf == QUERY_TABLE_VERSION_INTERVAL_SECONDS && timeInSeconds < 30) {
-      throw new IllegalArgumentException(conf + " must not be less than 30 seconds.")
+    if (conf == QUERY_TABLE_VERSION_INTERVAL_SECONDS &&
+      timeInSeconds < MINIMUM_TABLE_VERSION_INTERVAL_SECONDS) {
+      throw new IllegalArgumentException(
+        conf + s" must not be less than $MINIMUM_TABLE_VERSION_INTERVAL_SECONDS seconds.")
     }
     if (timeInSeconds > Int.MaxValue) {
       throw new IllegalArgumentException(conf + " is too big: " + timeStr)

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -143,16 +143,17 @@ case class DeltaSharingSource(
 
   private var lastGetVersionTimestamp: Long = -1
   private var latestTableVersion: Long = -1
-  // minimum 30 seconds
+  // minimum 10 seconds
   private val QUERY_TABLE_VERSION_INTERVAL_MILLIS = {
-    val interval = 30000.max(
-      ConfUtils.streamingQueryTableVersionIntervalSeconds(spark.sessionState.conf) * 1000
+    val intervalSeconds = ConfUtils.MINIMUM_TABLE_VERSION_INTERVAL_SECONDS.max(
+      ConfUtils.streamingQueryTableVersionIntervalSeconds(spark.sessionState.conf)
     )
-    if (interval < 30000) {
-      throw new IllegalArgumentException(s"QUERY_TABLE_VERSION_INTERVAL_MILLIS($interval) must " +
-        "not be less than 30 seconds.")
+    logInfo(s"Configured queryTableVersionIntervalSeconds:${intervalSeconds}.")
+    if (intervalSeconds < ConfUtils.MINIMUM_TABLE_VERSION_INTERVAL_SECONDS) {
+      throw new IllegalArgumentException(s"QUERY_TABLE_VERSION_INTERVAL_MILLIS($intervalSeconds) " +
+        s"must not be less than ${ConfUtils.MINIMUM_TABLE_VERSION_INTERVAL_SECONDS} seconds.")
     }
-    interval
+    intervalSeconds * 1000
   }
   private val maxVersionsPerRpc: Int = options.maxVersionsPerRpc.getOrElse(
     DeltaSharingOptions.MAX_VERSIONS_PER_RPC_DEFAULT
@@ -173,6 +174,7 @@ case class DeltaSharingSource(
     if (lastGetVersionTimestamp == -1 ||
       (currentTimeMillis - lastGetVersionTimestamp) >= QUERY_TABLE_VERSION_INTERVAL_MILLIS) {
       val serverVersion = deltaLog.client.getTableVersion(deltaLog.table)
+      logInfo(s"Got table version $serverVersion from Delta Sharing Server.")
       if (serverVersion < 0) {
         throw new IllegalStateException(s"Delta Sharing Server returning negative table version:" +
           s"$serverVersion.")


### PR DESCRIPTION
Lower the rpc interval to 10s

The same change as in #477