### PR TITLE
Add queryID in userAgent for spark delta sharing queries in branch 0.7

### DIFF
--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -1135,7 +1135,10 @@ case class DeltaSharingSource(
       }
       Some(v)
     } else if (options.startingTimestamp.isDefined) {
-      Some(deltaLog.client.getTableVersion(deltaLog.table, options.startingTimestamp))
+      val version = deltaLog.client.getTableVersion(deltaLog.table, options.startingTimestamp)
+      logInfo(s"Got table version $version for timestamp ${options.startingTimestamp} " +
+        s"from Delta Sharing Server.")
+      Some(version)
     } else {
       None
     }

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -184,6 +184,7 @@ case class DeltaSharingSource(
     if (lastGetVersionTimestamp == -1 ||
       (currentTimeMillis - lastGetVersionTimestamp) >= QUERY_TABLE_VERSION_INTERVAL_MILLIS) {
       val serverVersion = deltaLog.client.getTableVersion(deltaLog.table)
+      logInfo(s"Got table version $serverVersion from Delta Sharing Server.")
       if (serverVersion < 0) {
         throw new IllegalStateException(s"Delta Sharing Server returning negative table version:" +
           s"$serverVersion.")

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingRestClientSuite.scala
@@ -41,12 +41,17 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     val httpRequest = new HttpGet("random_url")
 
     val client = new DeltaSharingRestClient(testProfileProvider, forStreaming = false)
-    var h = client.prepareHeaders(httpRequest).getFirstHeader(HttpHeaders.USER_AGENT)
-    assert(!h.getValue.contains(DeltaSharingRestClient.SPARK_STRUCTURED_STREAMING))
+    var h = client.prepareHeaders(httpRequest).getFirstHeader(HttpHeaders.USER_AGENT).getValue
+    assert(!h.contains(DeltaSharingRestClient.SPARK_STRUCTURED_STREAMING))
+    assert(h.contains("Delta-Sharing-Spark"))
+    assert(h.contains(" QueryId-"))
+    assert(h.contains(" Hadoop/"))
+    assert(h.contains(" Linux/"))
+    assert(h.contains(" java/"))
 
     val streamingClient = new DeltaSharingRestClient(testProfileProvider, forStreaming = true)
-    h = streamingClient.prepareHeaders(httpRequest).getFirstHeader(HttpHeaders.USER_AGENT)
-    assert(h.getValue.contains(DeltaSharingRestClient.SPARK_STRUCTURED_STREAMING))
+    h = streamingClient.prepareHeaders(httpRequest).getFirstHeader(HttpHeaders.USER_AGENT).getValue
+    assert(h.contains(DeltaSharingRestClient.SPARK_STRUCTURED_STREAMING))
   }
 
   integrationTest("listAllTables") {


### PR DESCRIPTION
Add queryID in userAgent for spark delta sharing queries in branch 0.7.
And add log for getTableVersion in DeltaSharingSource.