### PR TITLE
Code refactor to split logic for DeltaSharedTableLoader and DeltaSharedTable

### DIFF
--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharedTableLoader.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharedTableLoader.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.server
+
+import java.util.concurrent.TimeUnit
+
+import com.google.common.cache.CacheBuilder
+import io.delta.standalone.internal.DeltaSharedTable
+
+import io.delta.sharing.server.config.{ServerConfig, TableConfig}
+
+
+/**
+ * A class to load Delta tables from `TableConfig`. It also caches the loaded tables internally
+ * to speed up the loading.
+ */
+class DeltaSharedTableLoader(serverConfig: ServerConfig) {
+  private val deltaSharedTableCache = {
+    CacheBuilder.newBuilder()
+      .expireAfterAccess(60, TimeUnit.MINUTES)
+      .maximumSize(serverConfig.deltaTableCacheSize)
+      .build[String, DeltaSharedTable]()
+  }
+
+  def loadTable(tableConfig: TableConfig): DeltaSharedTable = {
+    try {
+      val deltaSharedTable =
+        deltaSharedTableCache.get(
+          tableConfig.location,
+          () => {
+            new DeltaSharedTable(
+              tableConfig,
+              serverConfig.preSignedUrlTimeoutSeconds,
+              serverConfig.evaluatePredicateHints,
+              serverConfig.evaluateJsonPredicateHints,
+              serverConfig.evaluateJsonPredicateHintsV2,
+              serverConfig.queryTablePageSizeLimit,
+              serverConfig.queryTablePageTokenTtlMs,
+              serverConfig.refreshTokenTtlMs
+            )
+          }
+        )
+      if (!serverConfig.stalenessAcceptable) {
+        deltaSharedTable.update()
+      }
+      deltaSharedTable
+    } catch {
+      case CausedBy(e: DeltaSharingUnsupportedOperationException) => throw e
+      case e: Throwable => throw e
+    }
+  }
+}

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -36,12 +36,12 @@ import io.delta.standalone.internal.DeltaCDFErrors
 import io.delta.standalone.internal.DeltaCDFIllegalArgumentException
 import io.delta.standalone.internal.DeltaDataSource
 import io.delta.standalone.internal.DeltaSharedTable
-import io.delta.standalone.internal.DeltaSharedTableLoader
 import net.sourceforge.argparse4j.ArgumentParsers
 import org.apache.commons.io.FileUtils
 import org.slf4j.LoggerFactory
 import scalapb.json4s.Printer
 
+import io.delta.sharing.server.DeltaSharedTableLoader
 import io.delta.sharing.server.config.ServerConfig
 import io.delta.sharing.server.model.{QueryStatus, SingleAction}
 import io.delta.sharing.server.protocol._


### PR DESCRIPTION
Part of effort for supporting Delta Sharing Python to Read Shared DV/CM tables. Refactoring code so that a new DeltaSharedTableKernel can be created and the loader does not care about the DeltaSharedTableImplementation. 

In this refactor I brought the DeltaSharedTableLoader to its own file in the server package. I renamed the old file to DeltaSharedTable