### PR TITLE
Enable evaluateJsonPredicateHintsV2 in server

### DIFF
--- a/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
+++ b/server/src/main/scala/io/delta/sharing/server/config/ServerConfig.scala
@@ -83,8 +83,8 @@ case class ServerConfig(
       deltaTableCacheSize = 10,
       stalenessAcceptable = false,
       evaluatePredicateHints = false,
-      evaluateJsonPredicateHints = false,
-      evaluateJsonPredicateHintsV2 = false,
+      evaluateJsonPredicateHints = true,
+      evaluateJsonPredicateHintsV2 = true,
       requestTimeoutSeconds = 30,
       queryTablePageSizeLimit = 10000,
       queryTablePageTokenTtlMs = 259200000, // 3 days

--- a/server/src/universal/conf/delta-sharing-server.yaml.template
+++ b/server/src/universal/conf/delta-sharing-server.yaml.template
@@ -56,9 +56,9 @@ stalenessAcceptable: false
 # Whether to evaluate user provided `predicateHints`
 evaluatePredicateHints: false
 # Whether to evaluate user provided `jsonPredicateHints`
-evaluateJsonPredicateHints: false
+evaluateJsonPredicateHints: true
 # Whether to evaluate user provided `jsonPredicateHints` for V2 predicates.
-evaluateJsonPredicateHintsV2: false
+evaluateJsonPredicateHintsV2: true
 # The maximum page size permitted by queryTable/queryTableChanges API.
 queryTablePageSizeLimit: 10000
 # The TTL of the page token generated in queryTable/queryTableChanges API (in milliseconds).


### PR DESCRIPTION
Enable evaluateJsonPredicateHintsV2 in server, 
this could fix DeltaSharingSuite:cdf_table_with_partition: filter success, caused by jsonPredicateHintV2 evaluation in the server