### PR TITLE
Feature fix load as spark

### DIFF
--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -150,7 +150,11 @@ def load_as_spark(
     except ImportError:
         raise ImportError("Unable to import pyspark. `load_as_spark` requires PySpark.")
 
-    spark = SparkSession.active()
+    spark = SparkSession.getActiveSession()
+    assert spark is not None, (
+        "No active SparkSession was found. "
+        "`load_as_spark` requires running in a PySpark application."
+    )
     df = spark.read.format("deltaSharing")
     if version is not None:
         df.option("versionAsOf", version)

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -150,11 +150,7 @@ def load_as_spark(
     except ImportError:
         raise ImportError("Unable to import pyspark. `load_as_spark` requires PySpark.")
 
-    spark = SparkSession.getActiveSession()
-    assert spark is not None, (
-        "No active SparkSession was found. "
-        "`load_as_spark` requires running in a PySpark application."
-    )
+    spark = SparkSession.active()
     df = spark.read.format("deltaSharing")
     if version is not None:
         df.option("versionAsOf", version)


### PR DESCRIPTION
Closes  #508

Used SparkSession.active() instead of SparkSession.getActiveSession() in Delta-Sharing.py which returns a spark session regardless of any active session being present or not.