### PR TITLE
Refactor Header

### DIFF
--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -141,6 +141,7 @@ class DataSharingRestClient:
     DELTA_RESPONSE_FORMAT = "responseformat=delta,parquet"
     DELTA_READER_FEATURES = "readerfeatures=deletionvectors,columnmapping"
     DELTA_SHARING_CAPABILITIES_HEADER = "delta-sharing-capabilities"
+    DELTA_TABLE_VERSION_HEADER = "delta-table-version"
     DELTA_FORMAT = "delta"
     PARQUET_FORMAT = "parquet"
 
@@ -306,13 +307,14 @@ class DataSharingRestClient:
         ) as values:
             headers = values[0]
             # it's a bug in the server if it doesn't return delta-table-version in the header
-            if "delta-table-version" not in headers:
+            if DataSharingRestClient.DELTA_TABLE_VERSION_HEADER not in headers:
                 raise LookupError("Missing delta-table-version header")
             lines = values[1]
             protocol_json = json.loads(next(lines))
             metadata_json = json.loads(next(lines))
             return QueryTableMetadataResponse(
-                delta_table_version=int(headers.get("delta-table-version")),
+                delta_table_version=int(headers.get(
+                    DataSharingRestClient.DELTA_TABLE_VERSION_HEADER)),
                 protocol=Protocol.from_json(protocol_json["protocol"]),
                 metadata=Metadata.from_json(metadata_json["metaData"]),
             )
@@ -332,7 +334,7 @@ class DataSharingRestClient:
         ) as values:
             headers = values[0]
             # it's a bug in the server if it doesn't return delta-table-version in the header
-            if "delta-table-version" not in headers:
+            if  DataSharingRestClient.DELTA_TABLE_VERSION_HEADER not in headers:
                 raise LookupError("Missing delta-table-version header")
             if DataSharingRestClient.DELTA_SHARING_CAPABILITIES_HEADER not in headers:
                 return DataSharingRestClient.PARQUET_FORMAT
@@ -366,10 +368,10 @@ class DataSharingRestClient:
             headers = values[0]
 
             # it's a bug in the server if it doesn't return delta-table-version in the header
-            if "delta-table-version" not in headers:
+            if  DataSharingRestClient.DELTA_TABLE_VERSION_HEADER not in headers:
                 raise LookupError("Missing delta-table-version header")
 
-            table_version = int(headers.get("delta-table-version"))
+            table_version = int(headers.get( DataSharingRestClient.DELTA_TABLE_VERSION_HEADER))
             return QueryTableVersionResponse(delta_table_version=table_version)
 
     @retry_with_exponential_backoff
@@ -402,7 +404,7 @@ class DataSharingRestClient:
         ) as values:
             headers = values[0]
             # it's a bug in the server if it doesn't return delta-table-version in the header
-            if "delta-table-version" not in headers:
+            if DataSharingRestClient.DELTA_TABLE_VERSION_HEADER not in headers:
                 raise LookupError("Missing delta-table-version header")
 
             lines = values[1]
@@ -410,7 +412,8 @@ class DataSharingRestClient:
             metadata_json = json.loads(next(lines))
 
             return ListFilesInTableResponse(
-                delta_table_version=int(headers.get("delta-table-version")),
+                delta_table_version=int(headers.get(
+                    DataSharingRestClient.DELTA_TABLE_VERSION_HEADER)),
                 protocol=Protocol.from_json(protocol_json["protocol"]),
                 metadata=Metadata.from_json(metadata_json["metaData"]),
                 add_files=[AddFile.from_json(json.loads(file)["file"]) for file in lines],

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -334,7 +334,7 @@ class DataSharingRestClient:
         ) as values:
             headers = values[0]
             # it's a bug in the server if it doesn't return delta-table-version in the header
-            if  DataSharingRestClient.DELTA_TABLE_VERSION_HEADER not in headers:
+            if DataSharingRestClient.DELTA_TABLE_VERSION_HEADER not in headers:
                 raise LookupError("Missing delta-table-version header")
             if DataSharingRestClient.DELTA_SHARING_CAPABILITIES_HEADER not in headers:
                 return DataSharingRestClient.PARQUET_FORMAT
@@ -368,7 +368,7 @@ class DataSharingRestClient:
             headers = values[0]
 
             # it's a bug in the server if it doesn't return delta-table-version in the header
-            if  DataSharingRestClient.DELTA_TABLE_VERSION_HEADER not in headers:
+            if DataSharingRestClient.DELTA_TABLE_VERSION_HEADER not in headers:
                 raise LookupError("Missing delta-table-version header")
 
             table_version = int(headers.get( DataSharingRestClient.DELTA_TABLE_VERSION_HEADER))

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -371,7 +371,7 @@ class DataSharingRestClient:
             if DataSharingRestClient.DELTA_TABLE_VERSION_HEADER not in headers:
                 raise LookupError("Missing delta-table-version header")
 
-            table_version = int(headers.get( DataSharingRestClient.DELTA_TABLE_VERSION_HEADER))
+            table_version = int(headers.get(DataSharingRestClient.DELTA_TABLE_VERSION_HEADER))
             return QueryTableVersionResponse(delta_table_version=table_version)
 
     @retry_with_exponential_backoff


### PR DESCRIPTION
Super minor refactor to move delta-table-version string as a constant throughout the rest_client.py file to be consistent with the style for the DELTA_SHARING_CAPABILITIES_HEADER