### PR TITLE
refactored server-side code to cleaner packages

### DIFF
--- a/server/src/main/scala/io/delta/common/CloudFileSigner.scala
+++ b/server/src/main/scala/io/delta/common/CloudFileSigner.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.delta.sharing.server
+package io.delta.common
 
 import java.net.URI
 import java.util.Date

--- a/server/src/main/scala/io/delta/common/SnapshotChecker.scala
+++ b/server/src/main/scala/io/delta/common/SnapshotChecker.scala
@@ -16,8 +16,9 @@
 
 package io.delta.common
 
+import io.delta.common.actions.{ColumnMappingTableFeature, DeletionVectorsTableFeature, DeltaAction}
+
 import io.delta.sharing.server.DeltaSharingUnsupportedOperationException
-import io.delta.sharing.server.actions.{ColumnMappingTableFeature, DeletionVectorsTableFeature, DeltaAction}
 
 
 object SnapshotChecker {

--- a/server/src/main/scala/io/delta/common/actions/Codec.scala
+++ b/server/src/main/scala/io/delta/common/actions/Codec.scala
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package io.delta.sharing.server.actions
+package io.delta.common.actions
 
 import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets.US_ASCII
 import java.util.UUID
 
 /**

--- a/server/src/main/scala/io/delta/common/actions/DeletionVectorDescriptor.scala
+++ b/server/src/main/scala/io/delta/common/actions/DeletionVectorDescriptor.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.delta.sharing.server.actions
+package io.delta.common.actions
 
 import java.util.UUID
 

--- a/server/src/main/scala/io/delta/common/actions/DeltaAction.scala
+++ b/server/src/main/scala/io/delta/common/actions/DeltaAction.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.delta.sharing.server.actions
+package io.delta.common.actions
 
 import java.net.URI
 import java.sql.Timestamp

--- a/server/src/main/scala/io/delta/kernelsharedtable/DeltaSharedTableKernel.scala
+++ b/server/src/main/scala/io/delta/kernelsharedtable/DeltaSharedTableKernel.scala
@@ -31,7 +31,8 @@ import scala.util.control.NonFatal
 
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem
 import com.google.common.hash.Hashing
-import io.delta.common.SnapshotChecker
+import io.delta.common.{AbfsFileSigner, GCSFileSigner, PreSignedUrl, S3FileSigner, SnapshotChecker, WasbFileSigner}
+import io.delta.common.actions.{DeletionVectorDescriptor, DeletionVectorsTableFeature, DeltaAddFile, DeltaFormat, DeltaMetadata, DeltaProtocol, DeltaSingleAction}
 import io.delta.kernel.Table
 import io.delta.kernel.data.{ColumnarBatch, ColumnVector, FilteredColumnarBatch}
 import io.delta.kernel.defaults.engine.DefaultEngine
@@ -50,8 +51,7 @@ import org.apache.hadoop.fs.s3a.S3AFileSystem
 import org.apache.spark.sql.types.{DataType, MetadataBuilder, StructType}
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
-import io.delta.sharing.server.{AbfsFileSigner, CausedBy, DeltaSharedTableProtocol, DeltaSharingIllegalArgumentException, DeltaSharingUnsupportedOperationException, ErrorStrings, GCSFileSigner, PreSignedUrl, QueryResult, S3FileSigner, WasbFileSigner}
-import io.delta.sharing.server.actions.{DeletionVectorDescriptor, DeletionVectorsTableFeature, DeltaAddFile, DeltaFormat, DeltaMetadata, DeltaProtocol, DeltaSingleAction}
+import io.delta.sharing.server.{CausedBy, DeltaSharedTableProtocol, DeltaSharingIllegalArgumentException, DeltaSharingUnsupportedOperationException, ErrorStrings, QueryResult}
 import io.delta.sharing.server.config.TableConfig
 import io.delta.sharing.server.model._
 import io.delta.sharing.server.protocol.{QueryTablePageToken, RefreshToken}

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -18,9 +18,8 @@ package io.delta.sharing.server.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.delta.common.actions.{DeltaFormat, DeltaMetadata, DeltaProtocol, DeltaSingleAction}
 import org.codehaus.jackson.annotate.JsonRawValue
-
-import io.delta.sharing.server.actions.{DeltaFormat, DeltaMetadata, DeltaProtocol, DeltaSingleAction}
 
 case class SingleAction(
     file: AddFile = null,

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTable.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTable.scala
@@ -26,6 +26,7 @@ import scala.collection.JavaConverters._
 
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem
 import com.google.common.hash.Hashing
+import io.delta.common.{AbfsFileSigner, GCSFileSigner, PreSignedUrl, S3FileSigner, WasbFileSigner}
 import io.delta.standalone.DeltaLog
 import io.delta.standalone.internal.actions.{AddCDCFile, AddFile, Metadata, Protocol, RemoveFile}
 import io.delta.standalone.internal.exception.DeltaErrors
@@ -41,7 +42,7 @@ import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
-import io.delta.sharing.server.{model, AbfsFileSigner, CausedBy, DeltaSharedTableProtocol, DeltaSharingIllegalArgumentException, DeltaSharingUnsupportedOperationException, ErrorStrings, GCSFileSigner, PreSignedUrl, QueryResult, S3FileSigner, WasbFileSigner}
+import io.delta.sharing.server.{model, CausedBy, DeltaSharedTableProtocol, DeltaSharingIllegalArgumentException, DeltaSharingUnsupportedOperationException, ErrorStrings, QueryResult}
 import io.delta.sharing.server.config.TableConfig
 import io.delta.sharing.server.protocol.{QueryTablePageToken, RefreshToken}
 import io.delta.sharing.server.util.JsonUtils

--- a/server/src/test/scala/io/delta/sharing/server/CloudFileSignerSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/CloudFileSignerSuite.scala
@@ -16,6 +16,7 @@
 
 package io.delta.sharing.server
 
+import io.delta.common.GCSFileSigner
 import org.apache.hadoop.fs.Path
 import org.scalatest.FunSuite
 

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -26,12 +26,12 @@ import javax.net.ssl._
 import scala.collection.mutable.ArrayBuffer
 
 import com.linecorp.armeria.server.Server
+import io.delta.common.actions.{ColumnMappingTableFeature, DeletionVectorDescriptor, DeletionVectorsTableFeature, DeltaAddFile, DeltaFormat, DeltaProtocol, DeltaSingleAction}
 import io.delta.standalone.internal.DeltaSharedTable.{RESPONSE_FORMAT_DELTA, RESPONSE_FORMAT_PARQUET}
 import org.apache.commons.io.IOUtils
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import scalapb.json4s.JsonFormat
 
-import io.delta.sharing.server.actions.{ColumnMappingTableFeature, DeletionVectorDescriptor, DeletionVectorsTableFeature, DeltaAddFile, DeltaFormat, DeltaProtocol, DeltaSingleAction}
 import io.delta.sharing.server.config.ServerConfig
 import io.delta.sharing.server.model._
 import io.delta.sharing.server.protocol._


### PR DESCRIPTION
Moved `Codec.scala`, `DeletionVectorDescriptor.scala`, `DeltaAction.scala` into `actions` package in `common`. Moved `CloudFileSigner.scala` and `DeltaAction.scala` into `common`. This meant changing the imports in some other files. 

This PR is purely a refactor and does not change any core logic. Does not require any additional testing since it is just a refactor