### PR TITLE
add openssl as dependencies in Cargo

### DIFF
--- a/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
+++ b/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 arrow = { version = "^52.0", features = ["pyarrow"] }
 delta_kernel = {version = "^0.2", features = ["cloud", "default", "default-engine"]}
+openssl = { version = "0.10", features = ["vendored"] }
 url = "2"
 
 [dependencies.pyo3]


### PR DESCRIPTION
add openssl as dependencies in Cargo, so that it can support cross release on linux arm64