### PR TITLE
Update PresignedUrlCache exception message for clarity

### DIFF
--- a/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -143,7 +143,7 @@ class CachedTableManager(
       fileId: String): PreSignedUrlCache.Rpc.GetPreSignedUrlResponse = {
     val cachedTable = cache.get(tablePath)
     if (cachedTable == null) {
-      throw new IllegalStateException(s"table $tablePath was removed")
+      throw new IllegalStateException(s"table $tablePath was removed from PresignedUrlCache. Perhaps it expired after $expireAfterAccessMs ms")
     }
     cachedTable.lastAccess = System.currentTimeMillis()
     val url = cachedTable.idToUrl.getOrElse(fileId, {


### PR DESCRIPTION
Why:
Today, when a job doesn't access the delta table before `expireAfterAccessMs`, the presigned url is removed from the cache. When the job does try to access that table, the entry is removed from the concurrent hash map and an IllegalStateException is thrown. This exception message says the table was "removed". The message is confusing if the developer doesn't understand the table was "removed" from the cache. It is not unreasonable for the developer to be confused that the delta table was suddenly removed completely!

How this works:
This changes the exception message to carry the expireMilliseconds information in the stack trace. This should help developers understand and adjust their job configurations