### PR TITLE
add README for delta-kernel-rust-sharing-wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ delta_sharing.load_as_pandas(table_url, limit=10)
 # Load a table as a Pandas DataFrame. This can be used to process tables that can fit in the memory.
 delta_sharing.load_as_pandas(table_url)
 
+# Load a table as a Pandas DataFrame explicitly using Delta Format
+delta_sharing.load_as_pandas(table_url, use_delta_format = True)
+
 # If the code is running with PySpark, you can use `load_as_spark` to load the table as a Spark DataFrame.
 delta_sharing.load_as_spark(table_url)
 ```

--- a/python/delta-kernel-rust-sharing-wrapper/README.md
+++ b/python/delta-kernel-rust-sharing-wrapper/README.md
@@ -1,0 +1,15 @@
+# Delta Kernel Rust Sharing Wrapper
+
+This adds a thin python bindings via maturin and pyo3 for delta-kernel-rust.
+
+## usage
+To build the wheel locally you will need to create a venv and set up the deps:
+
+    cd [delta-sharing-root]/python/delta-kernel-rust-sharing-wrapper # if you're not already there
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install maturin
+    pip freeze
+    maturin develop
+
+Now it should generate the wheel file, and you'll be able to use the delta_sharing_kernel_rust_wrapper library in python.


### PR DESCRIPTION
add README for delta-kernel-rust-sharing-wrapper, for examples on how to build the wrapper locally. 