### PR TITLE
Add delta-kernel-rust-sharing-wrapper as a install requirement for delta_sharing

### DIFF
--- a/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
+++ b/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
@@ -2,7 +2,7 @@
 name = "delta-kernel-rust-sharing-wrapper"
 edition = "2021"
 license = "Apache-2.0"
-version = "0.0.1"
+version = "0.1.0"
 
 [lib]
 name = "delta_kernel_rust_sharing_wrapper"

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "1.0.7"
+__version__ = "1.1.0"

--- a/python/setup.py
+++ b/python/setup.py
@@ -42,6 +42,7 @@ setup(
     ],
     python_requires='>=3.8',
     install_requires=[
+        'delta-kernel-rust-sharing-wrapper',
         'pandas',
         'pyarrow>=16.1.0',
         'fsspec>=0.7.4',


### PR DESCRIPTION
Add delta-kernel-rust-sharing-wrapper as a install requirement for delta_sharing