### PR TITLE
Require delta-kernel-rust-sharing-wrapper for delta_sharing installation

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -42,6 +42,7 @@ setup(
     ],
     python_requires='>=3.8',
     install_requires=[
+        'delta-kernel-rust-sharing-wrapper',
         'pandas',
         'pyarrow>=16.1.0',
         'fsspec>=0.7.4',


### PR DESCRIPTION
Require delta-kernel-rust-sharing-wrapper for delta_sharing installation