### PR TITLE
Make delta-sharing-client compatible with Spark 4.0

### DIFF
--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -24,20 +24,33 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkException
 import org.apache.spark.delta.sharing.{CachedTableManager, TableRefreshResult}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{Column, Encoder, SparkSession}
+import org.apache.spark.sql.{DeltaSharingScanUtils, Encoder, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Cast, Expression, Literal, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{
+  And,
+  Attribute,
+  Cast,
+  Expression,
+  Literal,
+  SubqueryExpression
+}
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 
 import io.delta.sharing.client.{DeltaSharingClient, DeltaSharingRestClient}
-import io.delta.sharing.client.model.{AddFile, CDFColumnInfo, DeltaTableMetadata, Metadata, Protocol, Table => DeltaSharingTable}
+import io.delta.sharing.client.model.{
+  AddFile,
+  CDFColumnInfo,
+  DeltaTableMetadata,
+  Metadata,
+  Protocol,
+  Table => DeltaSharingTable
+}
 import io.delta.sharing.client.util.ConfUtils
 import io.delta.sharing.spark.perf.DeltaSharingLimitPushDown
-
 
 /**
  * Used to query the current state of the transaction logs of a remote shared Delta table.
@@ -298,7 +311,9 @@ class RemoteSnapshot(
       tableFiles.files.toDS()
     }
 
-    val columnFilter = new Column(rewrittenFilters.reduceLeftOption(And).getOrElse(Literal(true)))
+    val columnFilter = DeltaSharingScanUtils.toColumn(
+      rewrittenFilters.reduceLeftOption(And).getOrElse(Literal(true))
+    )
     remoteFiles.filter(columnFilter).as[AddFile].collect()
   }
 }

--- a/client/src/main/scala/org/apache/spark/sql/DeltaSharingScanUtils.scala
+++ b/client/src/main/scala/org/apache/spark/sql/DeltaSharingScanUtils.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.types.StructType
 
@@ -27,9 +28,15 @@ object DeltaSharingScanUtils {
     Dataset.ofRows(spark, plan)
   }
 
-  // A wraper to expose sqlContext.internalCreateDataFrame
+  // A wrapper to expose sqlContext.internalCreateDataFrame
   def internalCreateDataFrame(spark: SparkSession, schema: StructType): DataFrame = {
     spark.sqlContext.internalCreateDataFrame(
       spark.sparkContext.emptyRDD[InternalRow], schema, isStreaming = true)
+  }
+
+  // A wrapper to expose Column.apply(expr: Expression) function.
+  // This is needed because the Column object is in private[sql] scope.
+  def toColumn(expr: Expression): Column = {
+    Column(expr)
   }
 }


### PR DESCRIPTION
Currently delta-sharing-client is not compatible with Spark Master due to this commit
https://github.com/apache/spark/commit/a767f5cb1704075ee249169e8faf2ab3610b9dbc#diff-81eca9f7af2e9b23b13904131c3d32b0af9e9e1dcc7ddb5efba13201b00066c4 which changes the Column constructor. This PR changes `new Column(...)` to `Column(...)` to use the constructors in `object Column`, so delta-sharing-client can cross compile with both spark-3.5 and spark-4.0. 

Tested locally in sbt shell:
- **Compile with spark-3.x:** run `client/compile` without changing `build.sbt` > finished successfully
- **Compile with spark-4.0:** set `sparkVersion = "4.0.0-preview1"` in `build.sbt` > run `reload` > run `++ 2.13.11` to switch to scala 2.13 (spark-4.0 only runs on scala 2.13) > run `client/compile` > finished successfully