### PR TITLE
Rename header from endStreamAction to includeEndStreamAction

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -984,7 +984,7 @@ class DeltaSharingRestClient(
           val lastLineAction = JsonUtils.fromJson[SingleAction](response.lines.last)
           if (lastLineAction.endStreamAction == null) {
             throw new IllegalStateException(s"Client sets " +
-              s"${DELTA_SHARING_END_STREAM_ACTION}=true in the " +
+              s"${DELTA_SHARING_INCLUDE_END_STREAM_ACTION}=true in the " +
               s"header, server responded with the header set to true(${response.capabilities}, " +
               s"and ${response.lines.size} lines, and last line parsed as " +
               s"${lastLineAction.unwrap.getClass()}," + getDsQueryIdForLogging)
@@ -993,12 +993,12 @@ class DeltaSharingRestClient(
             s"Successfully verified endStreamAction in the response" + getDsQueryIdForLogging
           )
         case Some(false) =>
-          logWarning(s"Client sets ${DELTA_SHARING_END_STREAM_ACTION}=true in the " +
+          logWarning(s"Client sets ${DELTA_SHARING_INCLUDE_END_STREAM_ACTION}=true in the " +
             s"header, but the server responded with the header set to false(" +
             s"${response.capabilities})," + getDsQueryIdForLogging
           )
         case None =>
-          logWarning(s"Client sets ${DELTA_SHARING_END_STREAM_ACTION}=true in the" +
+          logWarning(s"Client sets ${DELTA_SHARING_INCLUDE_END_STREAM_ACTION}=true in the" +
             s" header, but server didn't respond with the header(${response.capabilities}), " +
             s"for query($dsQueryId)."
           )
@@ -1009,7 +1009,7 @@ class DeltaSharingRestClient(
   private def getRespondedHeaders(capabilities: Option[String]): (String, Option[Boolean]) = {
     val capabilitiesMap = parseDeltaSharingCapabilities(capabilities)
     val includedEndStreamActionOpt = capabilitiesMap
-      .get(DELTA_SHARING_END_STREAM_ACTION)
+      .get(DELTA_SHARING_INCLUDE_END_STREAM_ACTION)
     (
       capabilitiesMap.get(RESPONSE_FORMAT).getOrElse(RESPONSE_FORMAT_PARQUET),
       includedEndStreamActionOpt.map(_.toBoolean)
@@ -1189,7 +1189,7 @@ class DeltaSharingRestClient(
     }
 
     if (includeEndStreamAction) {
-      capabilities = capabilities :+ s"$DELTA_SHARING_END_STREAM_ACTION=true"
+      capabilities = capabilities :+ s"$DELTA_SHARING_INCLUDE_END_STREAM_ACTION=true"
     }
 
     val cap = capabilities.mkString(DELTA_SHARING_CAPABILITIES_DELIMITER)
@@ -1214,7 +1214,7 @@ object DeltaSharingRestClient extends Logging {
   val RESPONSE_FORMAT = "responseformat"
   val READER_FEATURES = "readerfeatures"
   val DELTA_SHARING_CAPABILITIES_ASYNC_READ = "asyncquery"
-  val DELTA_SHARING_END_STREAM_ACTION = "endstreamaction"
+  val DELTA_SHARING_INCLUDE_END_STREAM_ACTION = "includeendstreamaction"
   val RESPONSE_FORMAT_DELTA = "delta"
   val RESPONSE_FORMAT_PARQUET = "parquet"
   val DELTA_SHARING_CAPABILITIES_DELIMITER = ";"

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -92,7 +92,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     var httpRequestBase = new DeltaSharingRestClient(
       testProfileProvider, forStreaming = false, readerFeatures = "willBeIgnored").prepareHeaders(httpRequest)
     checkUserAgent(httpRequestBase, false)
-    checkDeltaSharingCapabilities(httpRequestBase, s"${RESPONSE_FORMAT}=parquet;$DELTA_SHARING_END_STREAM_ACTION=true")
+    checkDeltaSharingCapabilities(httpRequestBase, s"${RESPONSE_FORMAT}=parquet;$DELTA_SHARING_INCLUDE_END_STREAM_ACTION=true")
 
     val readerFeatures = "deletionVectors,columnMapping,timestampNTZ"
     httpRequestBase = new DeltaSharingRestClient(
@@ -102,7 +102,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       readerFeatures = readerFeatures).prepareHeaders(httpRequest)
     checkUserAgent(httpRequestBase, true)
     checkDeltaSharingCapabilities(
-      httpRequestBase, s"$RESPONSE_FORMAT=delta;$READER_FEATURES=$readerFeatures;$DELTA_SHARING_END_STREAM_ACTION=true"
+      httpRequestBase, s"$RESPONSE_FORMAT=delta;$READER_FEATURES=$readerFeatures;$DELTA_SHARING_INCLUDE_END_STREAM_ACTION=true"
     )
 
     httpRequestBase = new DeltaSharingRestClient(

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -777,7 +777,9 @@ object DeltaSharingService {
   }
 
   private def getEndStreamActionInHeader(headerCapabilities: Map[String, String]): Boolean = {
-    headerCapabilities.get(DELTA_SHARING_INCLUDE_END_STREAM_ACTION).map(_.toBoolean).getOrElse(false)
+    headerCapabilities.get(
+      DELTA_SHARING_INCLUDE_END_STREAM_ACTION
+    ).map(_.toBoolean).getOrElse(false)
   }
 
   private[server] def getResponseFormatSet(headerCapabilities: Map[String, String]): Set[String] = {

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -618,7 +618,7 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       includeEndStreamAction: Boolean = false): HttpResponse = {
     var capabilities = Seq[String](s"${DELTA_SHARING_RESPONSE_FORMAT}=$responseFormat")
     if (includeEndStreamAction) {
-      capabilities = capabilities :+ s"$DELTA_SHARING_END_STREAM_ACTION=true"
+      capabilities = capabilities :+ s"$DELTA_SHARING_INCLUDE_END_STREAM_ACTION=true"
     }
     val dsCapHeader = capabilities.mkString(DELTA_SHARING_CAPABILITIES_DELIMITER)
 
@@ -654,7 +654,7 @@ object DeltaSharingService {
   val DELTA_SHARING_CAPABILITIES_HEADER = "delta-sharing-capabilities"
   val DELTA_SHARING_RESPONSE_FORMAT = "responseformat"
   val DELTA_SHARING_CAPABILITIES_ASYNC_QUERY = "asyncquery"
-  val DELTA_SHARING_END_STREAM_ACTION = "endstreamaction"
+  val DELTA_SHARING_INCLUDE_END_STREAM_ACTION = "includeendstreamaction"
   val DELTA_SHARING_READER_FEATURES = "readerfeatures"
   val DELTA_SHARING_CAPABILITIES_DELIMITER = ";"
 
@@ -777,7 +777,7 @@ object DeltaSharingService {
   }
 
   private def getEndStreamActionInHeader(headerCapabilities: Map[String, String]): Boolean = {
-    headerCapabilities.get(DELTA_SHARING_END_STREAM_ACTION).map(_.toBoolean).getOrElse(false)
+    headerCapabilities.get(DELTA_SHARING_INCLUDE_END_STREAM_ACTION).map(_.toBoolean).getOrElse(false)
   }
 
   private[server] def getResponseFormatSet(headerCapabilities: Map[String, String]): Set[String] = {
@@ -796,7 +796,7 @@ object DeltaSharingService {
 
   private[server] def getRequestEndStreamAction(
       headerCapabilities: Map[String, String]): Boolean = {
-    headerCapabilities.get(DELTA_SHARING_END_STREAM_ACTION).exists(_.toBoolean)
+    headerCapabilities.get(DELTA_SHARING_INCLUDE_END_STREAM_ACTION).exists(_.toBoolean)
   }
 
   def main(args: Array[String]): Unit = {

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -31,6 +31,7 @@ import org.apache.commons.io.IOUtils
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import scalapb.json4s.JsonFormat
 
+import io.delta.sharing.server.DeltaSharingService.DELTA_SHARING_INCLUDE_END_STREAM_ACTION
 import io.delta.sharing.server.common.JsonUtils
 import io.delta.sharing.server.common.actions.{ColumnMappingTableFeature, DeletionVectorDescriptor, DeletionVectorsTableFeature, DeltaAddFile, DeltaFormat, DeltaProtocol, DeltaSingleAction}
 import io.delta.sharing.server.config.ServerConfig
@@ -158,7 +159,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     deltaSharingCapabilities += s";responseformat=$responseFormat"
     deltaSharingCapabilities += readerFeatures
     if (includeEndStreamAction) {
-      deltaSharingCapabilities += s";endstreamaction=true"
+      deltaSharingCapabilities += s";$DELTA_SHARING_INCLUDE_END_STREAM_ACTION=true"
     }
     connection.setRequestProperty("delta-sharing-capabilities", deltaSharingCapabilities)
 
@@ -187,7 +188,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
       val responseCapabilities = connection.getHeaderField("delta-sharing-capabilities")
       var expectedHeader = s"responseformat=$responseFormat"
       if (includeEndStreamAction) {
-        expectedHeader += s";endstreamaction=true"
+        expectedHeader += s";$DELTA_SHARING_INCLUDE_END_STREAM_ACTION=true"
       }
       assert(responseCapabilities == expectedHeader, s"Incorrect header: $responseCapabilities")
     }


### PR DESCRIPTION
Rename header from endStreamAction to includeEndStreamAction:
This name suggests that the header is a directive or option that indicates the inclusion of the EndStreamAction. It clearly communicates its purpose and indicates that it may affect both the request and response.