### PR TITLE
Update expected error message in python test

### DIFF
--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -930,7 +930,7 @@ def test_load_as_pandas_exception(
             "share8.default.table_with_cm_id",
             None,
             None,
-            "Kernel error: Generic delta kernel error: Don't support id column mapping yet",
+            "Kernel error: Generic delta kernel error: Column ID mapping mode not supported",
             id="column mapping id not supported",
         ),
     ],


### PR DESCRIPTION
The kernel version upgrade (#607) also changed an error message, causing tests to fail. This was not caught in local testing or pre-merge CI checks since these were integration tests.