### PR TITLE
reference rust wrapper 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If this doesn’t work because of an issue downloading delta-kernel-rust-sharing
 - Check the linux glibc version >= 2.31
 
 If you cannot upgrade glibc or your OS is not supported by the delta-kernel-rust-sharing-wrapper pypi install  you will need to install the package manually.
-See https://pypi.org/project/delta-kernel-rust-sharing-wrapper/0.1.0/#files for supported OS.
+See https://pypi.org/project/delta-kernel-rust-sharing-wrapper/0.2.0/#files for supported OS.
 
 To install the delta-kernel-rust-sharing-wrapper package manually:
 ```

--- a/python/setup.py
+++ b/python/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     python_requires='>=3.8',
     install_requires=[
-        'delta-kernel-rust-sharing-wrapper',
+        'delta-kernel-rust-sharing-wrapper>=0.2.0',
         'pandas',
         'pyarrow>=16.1.0',
         'fsspec>=0.7.4',


### PR DESCRIPTION
Update references to the rust wrapper to use version 0.2.0