### PR TITLE
Fix wheels build by removing duplicate wheels

### DIFF
--- a/.github/workflows/build-kernel-wheels.yml
+++ b/.github/workflows/build-kernel-wheels.yml
@@ -1,4 +1,4 @@
-name: Build wheels for 4 os for delta-kernel-rust-sharing-wrapper 
+name: Build delta-kernel-rust-sharing-wrapper wheels for 4 OS and 2 architectures
 
 on:
   push:
@@ -18,17 +18,13 @@ jobs:
         os: [ubuntu-latest, ubuntu-20.04, macos-latest, windows-latest]
         python-version: [3.8]
         arch: [x86_64, arm64]
-        include:
-          - os: macos-latest
-            arch: x86_64
-          - os: macos-latest
-            arch: arm64
+        exclude:
           - os: ubuntu-latest
-            arch: x86_64
+            arch: arm64
           - os: ubuntu-20.04
-            arch: x86_64
+            arch: arm64
           - os: windows-latest
-            arch: x86_64
+            arch: arm64
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Previously, the ARM jobs for Linux and Windows were non-functional and created the same wheel as their x86 counterpart. When the final merge job runs, the existence of two identical wheel files caused the wheel in the merged zip file to potentially get corrupted. This PR fixes that issue by removing the ARM jobs for Linux and Windows.

To verify that the wheels are fixed, I re-ran the merge action 10 times, and none of the wheels in any of the runs were corrupted. In contrast, 6 out of 10 runs with the previous build workflow had at least one wheel that was corrupted. Corruption was determined by checking if the wheel files would unzip, since a wheel file is a ZIP archive under the hood.