### PR TITLE
update delta-kernel-rust-sharing-wrapper to 0.2.1 and fix path in workflows

### DIFF
--- a/.github/workflows/build-kernel-wheels.yml
+++ b/.github/workflows/build-kernel-wheels.yml
@@ -3,11 +3,11 @@ name: Build delta-kernel-rust-sharing-wrapper wheels for 4 OS and 2 architecture
 on:
   push:
     paths:
-      - python/delta-sharing-kernel/**
+      - python/delta-kernel-rust-sharing-wrapper/**
       - .github/workflows/**
   pull_request:
     paths:
-      - python/delta-sharing-kernel/**
+      - python/delta-kernel-rust-sharing-wrapper/**
       - .github/workflows/**
 
 jobs:

--- a/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
+++ b/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
@@ -2,7 +2,7 @@
 name = "delta-kernel-rust-sharing-wrapper"
 edition = "2021"
 license = "Apache-2.0"
-version = "0.2.0"
+version = "0.2.1"
 
 [lib]
 name = "delta_kernel_rust_sharing_wrapper"


### PR DESCRIPTION
Bump version to 0.2.1 for releasing the fixed build.

The path for the workflows also was not updated after renaming python/delta-sharing-kernel to python/delta-kernel-rust-sharing-wrapper. I believe it was updated while working on #612 but accidentally got undone before it was merged.