### PR TITLE
Merge fixes from main to 1.3 branch

### DIFF
--- a/.github/workflows/build-kernel-wheels.yml
+++ b/.github/workflows/build-kernel-wheels.yml
@@ -1,13 +1,13 @@
-name: Build wheels for 4 os for delta-kernel-rust-sharing-wrapper 
+name: Build delta-kernel-rust-sharing-wrapper wheels for 4 OS and 2 architectures
 
 on:
   push:
     paths:
-      - python/delta-sharing-kernel/**
+      - python/delta-kernel-rust-sharing-wrapper/**
       - .github/workflows/**
   pull_request:
     paths:
-      - python/delta-sharing-kernel/**
+      - python/delta-kernel-rust-sharing-wrapper/**
       - .github/workflows/**
 
 jobs:
@@ -18,17 +18,13 @@ jobs:
         os: [ubuntu-latest, ubuntu-20.04, macos-latest, windows-latest]
         python-version: [3.8]
         arch: [x86_64, arm64]
-        include:
-          - os: macos-latest
-            arch: x86_64
-          - os: macos-latest
-            arch: arm64
+        exclude:
           - os: ubuntu-latest
-            arch: x86_64
+            arch: arm64
           - os: ubuntu-20.04
-            arch: x86_64
+            arch: arm64
           - os: windows-latest
-            arch: x86_64
+            arch: arm64
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ If the table supports history sharing(`tableConfig.cdfEnabled=true` in the OSS D
 # Load table changes from version 0 to version 5, as a Pandas DataFrame.
 delta_sharing.load_table_changes_as_pandas(table_url, starting_version=0, ending_version=5)
 
+# Load table changes from version 0 to version 5 as a Pandas DataFrame, explicitly using Delta Format.
+delta_sharing.load_table_changes_as_pandas(table_url, starting_version=0, ending_version=5, use_delta_format=True)
+
 # If the code is running with PySpark, you can load table changes as Spark DataFrame.
 delta_sharing.load_table_changes_as_spark(table_url, starting_version=0, ending_version=5)
 ```

--- a/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
+++ b/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
@@ -2,7 +2,7 @@
 name = "delta-kernel-rust-sharing-wrapper"
 edition = "2021"
 license = "Apache-2.0"
-version = "0.2.0"
+version = "0.2.1"
 
 [lib]
 name = "delta_kernel_rust_sharing_wrapper"


### PR DESCRIPTION
Merged in fixes from main.

Don't need to update the rust wrapper's version in the dependencies as we had >=0.2.0. Since rust wrapper 0.2.0 was yanked, 0.2.1 will be used when installing delta-sharing 1.3.1.