### PR TITLE
Sameerawi/rest client delta table version upgrade

### DIFF
--- a/python/delta_sharing/protocol.py
+++ b/python/delta_sharing/protocol.py
@@ -23,7 +23,7 @@ import fsspec
 
 @dataclass(frozen=True)
 class DeltaSharingProfile:
-    CURRENT: ClassVar[int] = 2
+    CURRENT: ClassVar[int] = 3
 
     share_credentials_version: int
     endpoint: str
@@ -159,7 +159,7 @@ class Table:
 
 @dataclass(frozen=True)
 class Protocol:
-    CURRENT: ClassVar[int] = 1
+    CURRENT: ClassVar[int] = 3
 
     min_reader_version: int
 
@@ -175,7 +175,8 @@ class Protocol:
     def from_json(json) -> "Protocol":
         if isinstance(json, (str, bytes, bytearray)):
             json = loads(json)
-        return Protocol(min_reader_version=int(json["minReaderVersion"]))
+            deltaProtocol = json["deltaProtocol"]
+        return Protocol(min_reader_version=int(deltaProtocol["minReaderVersion"]))
 
 
 @dataclass(frozen=True)
@@ -206,7 +207,7 @@ class Metadata:
     @staticmethod
     def from_json(json) -> "Metadata":
         if isinstance(json, (str, bytes, bytearray)):
-            json = loads(json)
+            json = loads(json)["deltaMetadata"]
         if "configuration" in json:
             configuration = json["configuration"]
         else:

--- a/python/delta_sharing/protocol.py
+++ b/python/delta_sharing/protocol.py
@@ -175,8 +175,7 @@ class Protocol:
     def from_json(json) -> "Protocol":
         if isinstance(json, (str, bytes, bytearray)):
             json = loads(json)
-            deltaProtocol = json["deltaProtocol"]
-        return Protocol(min_reader_version=int(deltaProtocol["minReaderVersion"]))
+        return Protocol(min_reader_version=int(json["minReaderVersion"]))
 
 
 @dataclass(frozen=True)
@@ -207,7 +206,7 @@ class Metadata:
     @staticmethod
     def from_json(json) -> "Metadata":
         if isinstance(json, (str, bytes, bytearray)):
-            json = loads(json)["deltaMetadata"]
+            json = loads(json)
         if "configuration" in json:
             configuration = json["configuration"]
         else:

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -296,7 +296,8 @@ class DataSharingRestClient:
 
             return QueryTableMetadataResponse(
                 delta_table_version=int(headers.get(
-                    DataSharingRestClient.DELTA_TABLE_VERSION_HEADER)), protocol=protocol, metadata=metadata)
+                    DataSharingRestClient.DELTA_TABLE_VERSION_HEADER)),
+                        protocol=protocol, metadata=metadata)
 
     @retry_with_exponential_backoff
     def autoresolve_query_format(self, table: Table):

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -281,12 +281,20 @@ class DataSharingRestClient:
             lines = values[1]
             protocol_json = json.loads(next(lines))
             metadata_json = json.loads(next(lines))
+
+            if "deltaProtocol" in protocol_json["protocol"]:
+                protocol = Protocol.from_json(json.dumps(protocol_json["protocol"]["deltaProtocol"]))
+            else:
+                protocol = Protocol.from_json(json.dumps(protocol_json["protocol"]))
+
+            if "deltaMetadata" in metadata_json["metaData"]:
+                metadata = Metadata.from_json(json.dumps(metadata_json["metaData"]["deltaMetadata"]))
+            else:
+                metadata = Metadata.from_json(json.dumps(metadata_json["metaData"]))
+
             return QueryTableMetadataResponse(
                 delta_table_version=int(headers.get(
-                    DataSharingRestClient.DELTA_TABLE_VERSION_HEADER)),
-                protocol=Protocol.from_json(json.dumps(protocol_json["protocol"])),
-                metadata=Metadata.from_json(json.dumps(metadata_json["metaData"])),
-            )
+                    DataSharingRestClient.DELTA_TABLE_VERSION_HEADER)), protocol=protocol, metadata=metadata)
 
     @retry_with_exponential_backoff
     def autoresolve_query_format(self, table: Table):

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -284,8 +284,8 @@ class DataSharingRestClient:
             return QueryTableMetadataResponse(
                 delta_table_version=int(headers.get(
                     DataSharingRestClient.DELTA_TABLE_VERSION_HEADER)),
-                protocol=Protocol.from_json(protocol_json["protocol"]),
-                metadata=Metadata.from_json(metadata_json["metaData"]),
+                protocol=Protocol.from_json(json.dumps(protocol_json["protocol"])),
+                metadata=Metadata.from_json(json.dumps(metadata_json["metaData"])),
             )
 
     @retry_with_exponential_backoff

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -297,7 +297,9 @@ class DataSharingRestClient:
             return QueryTableMetadataResponse(
                 delta_table_version=int(headers.get(
                     DataSharingRestClient.DELTA_TABLE_VERSION_HEADER)),
-                        protocol=protocol, metadata=metadata)
+                protocol=protocol,
+                metadata=metadata
+            )
 
     @retry_with_exponential_backoff
     def autoresolve_query_format(self, table: Table):

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -283,12 +283,14 @@ class DataSharingRestClient:
             metadata_json = json.loads(next(lines))
 
             if "deltaProtocol" in protocol_json["protocol"]:
-                protocol = Protocol.from_json(json.dumps(protocol_json["protocol"]["deltaProtocol"]))
+                protocol = Protocol.from_json(
+                    json.dumps(protocol_json["protocol"]["deltaProtocol"]))
             else:
                 protocol = Protocol.from_json(json.dumps(protocol_json["protocol"]))
 
             if "deltaMetadata" in metadata_json["metaData"]:
-                metadata = Metadata.from_json(json.dumps(metadata_json["metaData"]["deltaMetadata"]))
+                metadata = Metadata.from_json(
+                    json.dumps(metadata_json["metaData"]["deltaMetadata"]))
             else:
                 metadata = Metadata.from_json(json.dumps(metadata_json["metaData"]))
 

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "1.1.0"
+__version__ = "32"

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "30"
+__version__ = "1.1.0"

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "40"
+__version__ = "1.1.0"

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "1.1.0"
+__version__ = "30"

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "35"
+__version__ = "36"

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "37"
+__version__ = "1.1.0"

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "34"
+__version__ = "35"

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "33"
+__version__ = "34"

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "1.1.0"
+__version__ = "38"

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "38"
+__version__ = "40"

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "36"
+__version__ = "37"

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "32"
+__version__ = "33"


### PR DESCRIPTION
This PR is to fix the issue https://github.com/delta-io/delta/issues/4004

Changes :

1. DeltaSharingProfile and Protocol versions have been upgraded to version 3 to access tables with deletion vectors enabled.
2. Unwrapped the delta action in the response action when responseFormat=delta  which was applied in DeltaSharing server side by https://github.com/delta-io/delta-sharing/commit/2eca6689be0dafe34f69a544da67b8c30e857b40