### PR TITLE
This PR adds support for Azure Managed Identity in Python Delta-Sharing Client

### DIFF
--- a/python/delta_sharing/_internal_auth.py
+++ b/python/delta_sharing/_internal_auth.py
@@ -158,6 +158,7 @@ class OAuthClient:
             raise RuntimeError(
                 "'expires_in' field must be an integer or a string convertible to integer"
             )
+        #print(json_node['access_token'])
         return OAuthClientCredentials(
             json_node['access_token'],
             expires_in,
@@ -198,16 +199,109 @@ class OAuthClientCredentialsAuthProvider(AuthCredentialProvider):
         return None
 
 
+class AzureManagedIdentityAuthProvider(AuthCredentialProvider):
+    def __init__(self,  auth_config: AuthConfig = AuthConfig()):
+        self.auth_config = auth_config
+        self.current_token: Optional[OAuthClientCredentials] = None
+        self.lock = threading.RLock()
+
+
+    def managed_identity_token(self) -> OAuthClientCredentials:
+        # Azure IMDS endpoint to get the access token.
+        # This interface allows any client application running on the VM to acquire an access token via HTTP REST calls.
+        # For more details, see:
+        # https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http
+        url = "http://169.254.169.254/metadata/identity/oauth2/token"
+
+        resource = "https://management.azure.com/"
+        # Headers required to access Azure Instance Metadata Service
+        headers = {"Metadata": "true"}
+
+        # Parameters to specify the resource and API version
+        params = {
+            "api-version": "2019-08-01",
+            "resource": resource
+        }
+
+        # Make the GET request to fetch the token
+        response = requests.get(url, headers=headers, params=params)
+
+        # Check if the request was successful
+        if response.status_code == 200:
+            # Return the access token
+            return self.parse_oauth_token_response(response.text)
+
+        else:
+            # Handle errors
+            raise Exception(f"Failed to obtain token: {response.status_code} - {response.text}")
+
+    def parse_oauth_token_response(self, response: str) -> OAuthClientCredentials:
+        if not response:
+            raise RuntimeError("Empty response from OAuth token endpoint")
+        # Parsing the response according to azure managed identity spec
+        # https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http
+        json_node = json.loads(response)
+        if 'access_token' not in json_node or not isinstance(json_node['access_token'], str):
+            raise RuntimeError("Missing 'access_token' field in OAuth token response")
+        if 'expires_in' not in json_node:
+            raise RuntimeError("Missing 'expires_in' field in OAuth token response")
+        try:
+            expires_in = int(json_node['expires_in'])  # Convert to int if it's a string
+        except ValueError:
+            raise RuntimeError(
+                "'expires_in' field must be an integer or a string convertible to integer"
+            )
+        return OAuthClientCredentials(
+            json_node['access_token'],
+            expires_in,
+            int(datetime.now().timestamp())
+        )
+
+    def add_auth_header(self,session: requests.Session) -> None:
+        token = self.maybe_refresh_token()
+
+        with self.lock:
+            session.headers.update(
+                {
+                    "Authorization": f"Bearer {token.access_token}",
+                }
+            )
+
+    def maybe_refresh_token(self) -> OAuthClientCredentials:
+        with self.lock:
+            if self.current_token and not self.needs_refresh(self.current_token):
+                return self.current_token
+            new_token = self.managed_identity_token()
+            self.current_token = new_token
+            return new_token
+
+    def needs_refresh(self, token: OAuthClientCredentials) -> bool:
+        now = int(time.time())
+        expiration_time = token.creation_timestamp + token.expires_in
+        return expiration_time - now < self.auth_config.token_renewal_threshold_in_seconds
+
+    def is_expired(self) -> bool:
+        return False
+
+    def get_expiration_time(self) -> Optional[str]:
+        return None
+
 class AuthCredentialProviderFactory:
     __oauth_auth_provider_cache : Dict[
         DeltaSharingProfile,
         OAuthClientCredentialsAuthProvider] = {}
+
+    __managed_identity_provider_cache : Dict[
+        DeltaSharingProfile,
+        AzureManagedIdentityAuthProvider] = {}
 
     @staticmethod
     def create_auth_credential_provider(profile: DeltaSharingProfile):
         if profile.share_credentials_version == 2:
             if profile.type == "oauth_client_credentials":
                 return AuthCredentialProviderFactory.__oauth_client_credentials(profile)
+            elif profile.type == "experimental_managed_identity":
+                return AuthCredentialProviderFactory.__experimental_managed_identity(profile)
             elif profile.type == "basic":
                 return AuthCredentialProviderFactory.__auth_basic(profile)
         elif (profile.share_credentials_version == 1 and
@@ -251,3 +345,12 @@ class AuthCredentialProviderFactory:
     @staticmethod
     def __auth_basic(profile):
         return BasicAuthProvider(profile.endpoint, profile.username, profile.password)
+
+    @staticmethod
+    def __experimental_managed_identity(profile):
+        if profile in AuthCredentialProviderFactory.__managed_identity_provider_cache:
+            return AuthCredentialProviderFactory.__managed_identity_provider_cache[profile]
+
+        provider = AzureManagedIdentityAuthProvider()
+        AuthCredentialProviderFactory.__managed_identity_provider_cache[profile] = provider
+        return provider

--- a/python/delta_sharing/tests/test_auth.py
+++ b/python/delta_sharing/tests/test_auth.py
@@ -14,13 +14,13 @@
 # limitations under the License.
 #
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from datetime import datetime, timedelta
 from delta_sharing._internal_auth import (OAuthClient,
                                           BasicAuthProvider,
                                           AuthCredentialProviderFactory,
                                           OAuthClientCredentialsAuthProvider,
-                                          OAuthClientCredentials)
+                                          OAuthClientCredentials, AzureManagedIdentityAuthProvider)
 from requests import Session
 import requests
 from delta_sharing._internal_auth import BearerTokenAuthProvider
@@ -292,3 +292,77 @@ def test_oauth_auth_provider_with_different_profiles():
     provider2 = AuthCredentialProviderFactory.create_auth_credential_provider(profile_oauth2)
 
     assert provider1 != provider2
+
+def test_azure_managed_identity_auth_provider_initialization():
+    provider = AzureManagedIdentityAuthProvider()
+    assert provider.current_token is None
+
+
+def test_azure_managed_identity_auth_provider_add_auth_header():
+    provider = AzureManagedIdentityAuthProvider()
+    mock_session = MagicMock(spec=Session)
+    mock_session.headers = MagicMock()
+
+    token = OAuthClientCredentials("access-token", 3600, int(datetime.now().timestamp()))
+    provider.current_token = token
+
+    provider.add_auth_header(mock_session)
+
+    mock_session.headers.update.assert_called_once_with(
+        {"Authorization": f"Bearer {token.access_token}"}
+    )
+
+
+def test_azure_managed_identity_auth_provider_refresh_token():
+    provider = AzureManagedIdentityAuthProvider()
+    mock_session = MagicMock(spec=Session)
+    mock_session.headers = MagicMock()
+
+    expired_token = OAuthClientCredentials(
+        "expired-token", 1, int(datetime.now().timestamp()) - 3600)
+    new_token = OAuthClientCredentials(
+        "new-token", 3600, int(datetime.now().timestamp()))
+    provider.current_token = expired_token
+
+    with patch.object(provider, 'managed_identity_token', return_value=new_token):
+        provider.add_auth_header(mock_session)
+
+    mock_session.headers.update.assert_called_once_with(
+        {"Authorization": f"Bearer {new_token.access_token}"}
+    )
+
+
+def test_azure_managed_identity_auth_provider_needs_refresh():
+    provider = AzureManagedIdentityAuthProvider()
+
+    expired_token = OAuthClientCredentials(
+        "expired-token", 1, int(datetime.now().timestamp()) - 3600)
+    assert provider.needs_refresh(expired_token)
+
+    token_expiring_soon = OAuthClientCredentials(
+        "expiring-soon-token", 600 - 5, int(datetime.now().timestamp()))
+    assert provider.needs_refresh(token_expiring_soon)
+
+    valid_token = OAuthClientCredentials(
+        "valid-token", 600 + 10, int(datetime.now().timestamp()))
+    assert not provider.needs_refresh(valid_token)
+
+
+def test_azure_managed_identity_auth_provider_is_expired():
+    provider = AzureManagedIdentityAuthProvider()
+    assert not provider.is_expired()
+
+
+def test_azure_managed_identity_auth_provider_get_expiration_time():
+    provider = AzureManagedIdentityAuthProvider()
+    assert provider.get_expiration_time() is None
+
+
+def test_factory_creation_managed_identity():
+    profile_managed_identity = DeltaSharingProfile(
+        share_credentials_version=2,
+        type="experimental_managed_identity",
+        endpoint="https://localhost/delta-sharing/"
+    )
+    provider = AuthCredentialProviderFactory.create_auth_credential_provider(profile_managed_identity)
+    assert isinstance(provider, AzureManagedIdentityAuthProvider)


### PR DESCRIPTION
Add Support for Azure Managed Identity in Python Delta-Sharing Client. 

Note to reviewer please read bellow:
## What is Azure Managed Identity?

Azure Managed Identity allows applications running on Azure compute resources (e.g., Azure Virtual Machines) to access Azure services without the need for managing credentials explicitly. The identity is automatically provisioned by Azure infrastructure, eliminating the need for hardcoded secrets.

To obtain an access token, the application can call a specific internal endpoint available only within the Azure VM environment:

```
GET 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/' HTTP/1.1 Metadata: true
```

Example Response
```
HTTP/1.1 200 OK
Content-Type: application/json
{
  "access_token": "eyJ0eXAi...",
  "refresh_token": "",
  "expires_in": "3599",
  "expires_on": "1506484173",
  "not_before": "1506480273",
  "resource": "https://management.azure.com/",
  "token_type": "Bearer"
}
```
This token can then be used by the client to authenticate against Azure services and if delta-sharing server supports accepting this token delta-sharing client can authenticate against the server.

For more details, refer to the [official Azure documentation](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http).

Future Work
* Other Cloud Providers: Support for managed identities in AWS, GCP.