### PR TITLE
Upgrade delta-kernel-rs to 0.6.1

### DIFF
--- a/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
+++ b/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
@@ -10,12 +10,12 @@ name = "delta_kernel_rust_sharing_wrapper"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow = { version = "53.3.0", features = ["pyarrow"] }
-delta_kernel = { version = "0.6.0", features = ["cloud", "default-engine"]}
+arrow = { version = "54.0.0", features = ["pyarrow"] }
+delta_kernel = { version = "0.6.1", features = ["cloud", "default-engine"]}
 openssl = { version = "0.10", features = ["vendored"] }
 url = "2"
 
 [dependencies.pyo3]
-version = "0.22.4"
+version = "0.23.3"
 # "abi3-py38" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.8
 features = ["abi3-py38"]


### PR DESCRIPTION
This version fixes a bug where reading a table partitioned on timestamp may error.