### PR TITLE
[WIP] Enable Support for Custom Session+Proxy Configurations

### DIFF
--- a/python/delta_sharing/__init__.py
+++ b/python/delta_sharing/__init__.py
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 
-from delta_sharing.delta_sharing import SharingClient, load_as_pandas, load_as_spark
+from delta_sharing.delta_sharing import load_as_pandas, load_as_spark
 from delta_sharing.delta_sharing import get_table_metadata, get_table_protocol, get_table_version
 from delta_sharing.delta_sharing import load_table_changes_as_pandas, load_table_changes_as_spark
 from delta_sharing.protocol import Share, Schema, Table
+from delta_sharing.sharing_client import SharingClient
 from delta_sharing.version import __version__
 
 

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -54,8 +54,8 @@ def _parse_url(url: str) -> Tuple[str, str, str, str]:
 
 
 def get_table_version(
-        url: str,
-        starting_timestamp: Optional[str] = None
+    url: str,
+    starting_timestamp: Optional[str] = None
 ) -> int:
     """
     Get the shared table version using the given url.
@@ -101,13 +101,13 @@ def get_table_metadata(url: str) -> Metadata:
 
 
 def load_as_pandas(
-        url: str,
-        limit: Optional[int] = None,
-        version: Optional[int] = None,
-        timestamp: Optional[str] = None,
-        jsonPredicateHints: Optional[str] = None,
-        use_delta_format: Optional[bool] = None,
-        sharing_client: Optional[SharingClient] = None,
+    url: str,
+    limit: Optional[int] = None,
+    version: Optional[int] = None,
+    timestamp: Optional[str] = None,
+    jsonPredicateHints: Optional[str] = None,
+    use_delta_format: Optional[bool] = None,
+    sharing_client: Optional[SharingClient] = None,
 ) -> pd.DataFrame:
     """
     Load the shared table using the given url as a pandas DataFrame.
@@ -136,9 +136,9 @@ def load_as_pandas(
 
 
 def load_as_spark(
-        url: str,
-        version: Optional[int] = None,
-        timestamp: Optional[str] = None
+    url: str,
+    version: Optional[int] = None,
+    timestamp: Optional[str] = None
 ) -> "PySparkDataFrame":  # noqa: F821
     """
     Load the shared table using the given url as a Spark DataFrame. `PySpark` must be installed,
@@ -170,11 +170,11 @@ def load_as_spark(
 
 
 def load_table_changes_as_spark(
-        url: str,
-        starting_version: Optional[int] = None,
-        ending_version: Optional[int] = None,
-        starting_timestamp: Optional[str] = None,
-        ending_timestamp: Optional[str] = None
+    url: str,
+    starting_version: Optional[int] = None,
+    ending_version: Optional[int] = None,
+    starting_timestamp: Optional[str] = None,
+    ending_timestamp: Optional[str] = None
 ) -> "PySparkDataFrame":  # noqa: F821
     """
     Load the table changes of a shared table as a Spark DataFrame using the given url.
@@ -215,13 +215,13 @@ def load_table_changes_as_spark(
 
 
 def load_table_changes_as_pandas(
-        url: str,
-        starting_version: Optional[int] = None,
-        ending_version: Optional[int] = None,
-        starting_timestamp: Optional[str] = None,
-        ending_timestamp: Optional[str] = None,
-        use_delta_format: Optional[bool] = None,
-        sharing_client: Optional[SharingClient] = None,
+    url: str,
+    starting_version: Optional[int] = None,
+    ending_version: Optional[int] = None,
+    starting_timestamp: Optional[str] = None,
+    ending_timestamp: Optional[str] = None,
+    use_delta_format: Optional[bool] = None,
+    sharing_client: Optional[SharingClient] = None,
 ) -> pd.DataFrame:
     """
     Load the table changes of shared table as a pandas DataFrame using the given url.

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -389,10 +389,11 @@ class DeltaSharingReader:
         if len(response.actions) == 0:
             return get_empty_table(self._add_special_cdf_schema(schema_json))
 
+        session = self._rest_client.get_session()
         converters = to_converters(schema_json)
         pdfs = []
         for action in response.actions:
-            pdf = DeltaSharingReader._to_pandas(action, converters, True, None)
+            pdf = DeltaSharingReader._to_pandas(action, converters, True, None, session=session)
             pdfs.append(pdf)
 
         return pd.concat(pdfs, axis=0, ignore_index=True, copy=False)

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -36,16 +36,16 @@ from delta_sharing.fake_checkpoint import get_fake_checkpoint_byte_array
 
 class DeltaSharingReader:
     def __init__(
-            self,
-            table: Table,
-            rest_client: DataSharingRestClient,
-            *,
-            predicateHints: Optional[Sequence[str]] = None,
-            jsonPredicateHints: Optional[str] = None,
-            limit: Optional[int] = None,
-            version: Optional[int] = None,
-            timestamp: Optional[str] = None,
-            use_delta_format: Optional[bool] = None,
+        self,
+        table: Table,
+        rest_client: DataSharingRestClient,
+        *,
+        predicateHints: Optional[Sequence[str]] = None,
+        jsonPredicateHints: Optional[str] = None,
+        limit: Optional[int] = None,
+        version: Optional[int] = None,
+        timestamp: Optional[str] = None,
+        use_delta_format: Optional[bool] = None,
     ):
         self._table = table
         self._rest_client = rest_client
@@ -187,7 +187,7 @@ class DeltaSharingReader:
                 pdfs.append(pdf)
                 left -= len(pdf)
                 assert (
-                        left >= 0
+                    left >= 0
                 ), f"'_to_pandas' returned too many rows. Required: {left}, returned: {len(pdf)}"
                 if left == 0:
                     break
@@ -241,14 +241,14 @@ class DeltaSharingReader:
         return table_path
 
     def __write_temp_delta_log_cdf(
-            self,
-            log_dir: str,
-            delta_protocol: dict,
-            min_version: int,
-            max_version: int,
-            version_to_metadata: Dict[int, Any],
-            version_to_actions: Dict[int, Any],
-            version_to_timestamp: Dict[int, int]
+        self,
+        log_dir: str,
+        delta_protocol: dict,
+        min_version: int,
+        max_version: int,
+        version_to_metadata: Dict[int, Any],
+        version_to_actions: Dict[int, Any],
+        version_to_timestamp: Dict[int, int]
     ):
         min_version_file_name = str(min_version).zfill(20) + ".json"
         min_version_path = os.path.join(log_dir, min_version_file_name)
@@ -398,13 +398,13 @@ class DeltaSharingReader:
         return pd.concat(pdfs, axis=0, ignore_index=True, copy=False)
 
     def _copy(
-            self,
-            *,
-            predicateHints: Optional[Sequence[str]],
-            jsonPredicateHints: Optional[str],
-            limit: Optional[int],
-            version: Optional[int],
-            timestamp: Optional[str]
+        self,
+        *,
+        predicateHints: Optional[Sequence[str]],
+        jsonPredicateHints: Optional[str],
+        limit: Optional[int],
+        version: Optional[int],
+        timestamp: Optional[str]
     ) -> "DeltaSharingReader":
         return DeltaSharingReader(
             table=self._table,
@@ -417,11 +417,11 @@ class DeltaSharingReader:
 
     @staticmethod
     def _to_pandas(
-            action: FileAction,
-            converters: Dict[str, Callable[[str], Any]],
-            for_cdf: bool,
-            limit: Optional[int],
-            session: Optional[requests.Session]
+        action: FileAction,
+        converters: Dict[str, Callable[[str], Any]],
+        for_cdf: bool,
+        limit: Optional[int],
+        session: Optional[requests.Session]
     ) -> pd.DataFrame:
         url = urlparse(action.url)
         if "storage.googleapis.com" in (url.netloc.lower()):

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -126,11 +126,11 @@ def _client_user_agent() -> str:
         import platform
 
         return (
-                f"Delta-Sharing-Python/{__version__}"
-                + f" pandas/{pandas.__version__}"
-                + f" PyArrow/{pyarrow.__version__}"
-                + f" Python/{platform.python_version()}"
-                + f" System/{platform.platform()}"
+            f"Delta-Sharing-Python/{__version__}"
+            + f" pandas/{pandas.__version__}"
+            + f" PyArrow/{pyarrow.__version__}"
+            + f" Python/{platform.python_version()}"
+            + f" System/{platform.platform()}"
         )
     except Exception as e:
         logging.warning(
@@ -174,8 +174,8 @@ class DataSharingRestClient:
 
     def set_sharing_capabilities_header(self):
         delta_sharing_capabilities = (
-                DataSharingRestClient.DELTA_AND_PARQUET_RESPONSE_FORMAT + ';' +
-                DataSharingRestClient.DELTA_READER_FEATURES
+            DataSharingRestClient.DELTA_AND_PARQUET_RESPONSE_FORMAT + ';' +
+            DataSharingRestClient.DELTA_READER_FEATURES
         )
         self._session.headers.update(
             {
@@ -188,8 +188,8 @@ class DataSharingRestClient:
 
     def set_delta_format_header(self):
         delta_sharing_capabilities = (
-                DataSharingRestClient.DELTA_RESPONSE_FORMAT + ';' +
-                DataSharingRestClient.DELTA_READER_FEATURES
+            DataSharingRestClient.DELTA_RESPONSE_FORMAT + ';' +
+            DataSharingRestClient.DELTA_READER_FEATURES
         )
         self._session.headers.update(
             {
@@ -202,7 +202,7 @@ class DataSharingRestClient:
 
     @retry_with_exponential_backoff
     def list_shares(
-            self, *, max_results: Optional[int] = None, page_token: Optional[str] = None
+        self, *, max_results: Optional[int] = None, page_token: Optional[str] = None
     ) -> ListSharesResponse:
         data: Dict = {}
         if max_results is not None:
@@ -219,7 +219,7 @@ class DataSharingRestClient:
 
     @retry_with_exponential_backoff
     def list_schemas(
-            self, share: Share, *, max_results: Optional[int] = None, page_token: Optional[str] = None
+        self, share: Share, *, max_results: Optional[int] = None, page_token: Optional[str] = None
     ) -> ListSchemasResponse:
         data: Dict = {}
         if max_results is not None:
@@ -238,7 +238,7 @@ class DataSharingRestClient:
 
     @retry_with_exponential_backoff
     def list_tables(
-            self, schema: Schema, *, max_results: Optional[int] = None, page_token: Optional[str] = None
+        self, schema: Schema, *, max_results: Optional[int] = None, page_token: Optional[str] = None
     ) -> ListTablesResponse:
         data: Dict = {}
         if max_results is not None:
@@ -247,7 +247,7 @@ class DataSharingRestClient:
             data["pageToken"] = page_token
 
         with self._get_internal(
-                f"/shares/{schema.share}/schemas/{schema.name}/tables", data
+            f"/shares/{schema.share}/schemas/{schema.name}/tables", data
         ) as lines:
             tables_json = json.loads(next(lines))
             return ListTablesResponse(
@@ -257,7 +257,7 @@ class DataSharingRestClient:
 
     @retry_with_exponential_backoff
     def list_all_tables(
-            self, share: Share, *, max_results: Optional[int] = None, page_token: Optional[str] = None
+        self, share: Share, *, max_results: Optional[int] = None, page_token: Optional[str] = None
     ) -> ListAllTablesResponse:
         data: Dict = {}
         if max_results is not None:
@@ -275,8 +275,8 @@ class DataSharingRestClient:
     @retry_with_exponential_backoff
     def query_table_metadata(self, table: Table) -> QueryTableMetadataResponse:
         with self._get_internal(
-                f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/metadata",
-                return_headers=True
+            f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/metadata",
+            return_headers=True
         ) as values:
             headers = values[0]
             # it's a bug in the server if it doesn't return delta-table-version in the header
@@ -302,8 +302,8 @@ class DataSharingRestClient:
         self.set_sharing_capabilities_header()
 
         with self._get_internal(
-                f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/metadata",
-                return_headers=True
+            f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/metadata",
+            return_headers=True
         ) as values:
             # removing the client-reader-features that were set to avoid diverging standard codepath
             self.remove_sharing_capabilities_header()
@@ -326,16 +326,16 @@ class DataSharingRestClient:
 
     @retry_with_exponential_backoff
     def query_table_version(
-            self,
-            table: Table,
-            starting_timestamp: Optional[str] = None,
+        self,
+        table: Table,
+        starting_timestamp: Optional[str] = None,
     ) -> QueryTableVersionResponse:
         query_str = f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/version"
         if starting_timestamp is not None:
             query_str += f"?startingTimestamp={quote(starting_timestamp)}"
         with self._get_internal(
-                query_str,
-                return_headers=True
+            query_str,
+            return_headers=True
         ) as values:
             headers = values[0]
 
@@ -348,14 +348,14 @@ class DataSharingRestClient:
 
     @retry_with_exponential_backoff
     def list_files_in_table(
-            self,
-            table: Table,
-            *,
-            predicateHints: Optional[Sequence[str]] = None,
-            jsonPredicateHints: Optional[str] = None,
-            limitHint: Optional[int] = None,
-            version: Optional[int] = None,
-            timestamp: Optional[str] = None,
+        self,
+        table: Table,
+        *,
+        predicateHints: Optional[Sequence[str]] = None,
+        jsonPredicateHints: Optional[str] = None,
+        limitHint: Optional[int] = None,
+        version: Optional[int] = None,
+        timestamp: Optional[str] = None,
     ) -> ListFilesInTableResponse:
         data: Dict = {}
         if predicateHints is not None:
@@ -370,9 +370,9 @@ class DataSharingRestClient:
             data["timestamp"] = timestamp
 
         with self._post_internal(
-                f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/query",
-                data=data,
-                return_headers=True
+            f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/query",
+            data=data,
+            return_headers=True
         ) as values:
             headers = values[0]
             # it's a bug in the server if it doesn't return delta-table-version in the header
@@ -452,30 +452,30 @@ class DataSharingRestClient:
         self._session.close()
 
     def _get_internal(
-            self,
-            target: str,
-            data: Optional[Dict[str, Any]] = None,
-            return_headers: bool = False,
+        self,
+        target: str,
+        data: Optional[Dict[str, Any]] = None,
+        return_headers: bool = False,
     ):
         return self._request_internal(
             request=self._session.get, return_headers=return_headers, target=target, params=data)
 
     def _post_internal(
-            self,
-            target: str,
-            data: Optional[Dict[str, Any]] = None,
-            return_headers: bool = False,
+        self,
+        target: str,
+        data: Optional[Dict[str, Any]] = None,
+        return_headers: bool = False,
     ):
         return self._request_internal(
             request=self._session.post, return_headers=return_headers, target=target, json=data)
 
     @contextmanager
     def _request_internal(
-            self,
-            request,
-            return_headers,
-            target: str,
-            **kwargs,
+        self,
+        request,
+        return_headers,
+        target: str,
+        **kwargs,
     ):
         assert target.startswith("/"), "Targets should start with '/'"
         self._auth_credential_provider.add_auth_header(self._session)

--- a/python/delta_sharing/sharing_client.py
+++ b/python/delta_sharing/sharing_client.py
@@ -1,0 +1,108 @@
+from itertools import chain
+from typing import BinaryIO, List, Optional, Sequence, TextIO, Union
+from pathlib import Path
+import requests
+
+from delta_sharing.protocol import DeltaSharingProfile, Schema, Share, Table
+from delta_sharing.reader import DeltaSharingReader
+from delta_sharing.rest_client import DataSharingRestClient
+
+from requests.exceptions import HTTPError
+
+
+class SharingClient:
+    """
+    A Delta Sharing client to query shares/schemas/tables from a Delta Sharing Server.
+
+    :param profile: The path to the profile file or a DeltaSharingProfile object.
+    :param session: An optional requests.Session object to use for HTTP requests.
+                    You can use this to customize proxy settings, authentication, etc.
+    """
+    def __init__(self, profile: Union[str, BinaryIO, TextIO, Path, DeltaSharingProfile], session: Optional[requests.Session] = None):
+        if not isinstance(profile, DeltaSharingProfile):
+            profile = DeltaSharingProfile.read_from_file(profile)
+        self._profile = profile
+        self._rest_client = DataSharingRestClient(profile, session=session)
+
+    @property
+    def rest_client(self) -> DataSharingRestClient:
+        """
+        Get the underlying DataSharingRestClient used by this SharingClient.
+
+        :return: The DataSharingRestClient instance.
+        """
+        return self._rest_client
+
+    def __list_all_tables_in_share(self, share: Share) -> Sequence[Table]:
+        tables: List[Table] = []
+        page_token: Optional[str] = None
+        while True:
+            response = self._rest_client.list_all_tables(share=share, page_token=page_token)
+            tables.extend(response.tables)
+            page_token = response.next_page_token
+            if page_token is None or page_token == "":
+                return tables
+
+    def list_shares(self) -> Sequence[Share]:
+        """
+        List shares that can be accessed by you in a Delta Sharing Server.
+
+        :return: the shares that can be accessed.
+        """
+        shares: List[Share] = []
+        page_token: Optional[str] = None
+        while True:
+            response = self._rest_client.list_shares(page_token=page_token)
+            shares.extend(response.shares)
+            page_token = response.next_page_token
+            if page_token is None or page_token == "":
+                return shares
+
+    def list_schemas(self, share: Share) -> Sequence[Schema]:
+        """
+        List schemas in a share that can be accessed by you in a Delta Sharing Server.
+
+        :param share: the share to list.
+        :return: the schemas in a share.
+        """
+        schemas: List[Schema] = []
+        page_token: Optional[str] = None
+        while True:
+            response = self._rest_client.list_schemas(share=share, page_token=page_token)
+            schemas.extend(response.schemas)
+            page_token = response.next_page_token
+            if page_token is None or page_token == "":
+                return schemas
+
+    def list_tables(self, schema: Schema) -> Sequence[Table]:
+        """
+        List tables in a schema that can be accessed by you in a Delta Sharing Server.
+
+        :param schema: the schema to list.
+        :return: the tables in a schema.
+        """
+        tables: List[Table] = []
+        page_token: Optional[str] = None
+        while True:
+            response = self._rest_client.list_tables(schema=schema, page_token=page_token)
+            tables.extend(response.tables)
+            page_token = response.next_page_token
+            if page_token is None or page_token == "":
+                return tables
+
+    def list_all_tables(self) -> Sequence[Table]:
+        """
+        List all tables that can be accessed by you in a Delta Sharing Server.
+
+        :return: all tables that can be accessed.
+        """
+        shares = self.list_shares()
+        try:
+            return list(chain(*(self.__list_all_tables_in_share(share) for share in shares)))
+        except HTTPError as e:
+            if e.response.status_code == 404:
+                # The server doesn't support all-tables API. Fallback to the old APIs instead.
+                schemas = chain(*(self.list_schemas(share) for share in shares))
+                return list(chain(*(self.list_tables(schema) for schema in schemas)))
+            else:
+                raise e

--- a/python/delta_sharing/tests/test_custom_session.py
+++ b/python/delta_sharing/tests/test_custom_session.py
@@ -1,0 +1,64 @@
+import requests
+import pytest
+import pandas as pd
+from unittest import mock
+from datetime import date
+import os
+
+from delta_sharing.delta_sharing import (
+    DeltaSharingProfile,
+    SharingClient,
+    load_as_pandas,
+)
+from delta_sharing.rest_client import DataSharingRestClient
+from delta_sharing.reader import DeltaSharingReader
+
+def test_load_as_pandas_with_proxy(profile_path: str):
+    profile = DeltaSharingProfile.read_from_file(profile_path)
+    
+    session = requests.Session()
+    session.proxies = {
+        "http": "http://proxy.example.com:8080",
+        "https": "http://proxy.example.com:8080",
+    }
+    session.headers.update({"X-Proxy-Test": "true"})
+    
+    sharing_client = SharingClient(profile, session=session)
+
+    expected_df = pd.DataFrame(
+        {
+            "eventTime": [pd.Timestamp("2021-04-28 06:32:22.421"), pd.Timestamp("2021-04-28 06:32:02.070")],
+            "date": [date(2021, 4, 28), date(2021, 4, 28)]
+        }
+    )
+
+    with mock.patch.object(DataSharingRestClient, 'list_files_in_table', autospec=True) as mock_list_files_in_table:
+        mock_response = mock.Mock()
+        mock_response.metadata.schema_string = '{"fields":[{"name":"eventTime","type":"timestamp"},{"name":"date","type":"date"}]}'
+        mock_response.add_files = [
+            mock.Mock(url="http://example.com/file1.parquet"),
+            mock.Mock(url="http://example.com/file2.parquet")
+        ]
+        mock_list_files_in_table.return_value = mock_response
+
+        with mock.patch('fsspec.filesystem', autospec=True) as mock_filesystem:
+            mock_fs_instance = mock_filesystem.return_value
+            mock_fs_instance.open.return_value.__enter__.return_value.read.return_value = b''
+
+            with mock.patch.object(DeltaSharingReader, 'to_pandas', return_value=expected_df):
+                url = f"{profile_path}#share.schema.table"
+
+                actual_df = load_as_pandas(url, sharing_client=sharing_client)
+                
+                pd.testing.assert_frame_equal(actual_df, expected_df)
+
+                rest_client_instance = sharing_client.rest_client
+                session_used = rest_client_instance.get_session()
+                
+                assert session_used is session
+                assert session_used.proxies == session.proxies
+                assert session_used.headers["X-Proxy-Test"] == "true"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
# Description 

This PR introduces the ability for users to pass custom requests.Session objects to the SharingClient in the Delta Sharing Python library. This enhancement allows users to configure more complex session settings that cannot be achieved using environment variables alone, such as authenticated proxies, custom headers, SSL configurations, timeout settings, and other session-related configurations that give users greater flexibility when working in complex network environments or when specific session configurations are required.



# Key Changes

## 1. `SharingClient` Class Update

The `SharingClient` class now accepts an optional session parameter in its constructor. This allows users to now pass a custom `requests.Session` object when creating a `SharingClient`. If no session is provided, a new `requests.Session` will be created as before:

```
class SharingClient:
    def __init__(
        self,
        profile: Union[str, BinaryIO, TextIO, Path, DeltaSharingProfile],
        session: Optional[requests.Session] = None
    ):
        if not isinstance(profile, DeltaSharingProfile):
            profile = DeltaSharingProfile.read_from_file(profile)
        self._profile = profile
        self._rest_client = DataSharingRestClient(profile, session=session)
```


## 2. `DataSharingRestClient` Class Update

The `DataSharingRestClient` class now accepts an optional `session` parameter. The custom session is passed from `SharingClient` to `DataSharingRestClient`, ensuring all HTTP requests utilize the custom session.

```
class DataSharingRestClient:
    def __init__(
        self,
        profile: DeltaSharingProfile,
        num_retries=10,
        session: Optional[requests.Session] = None
    ):
        self._profile = profile
        self._num_retries = num_retries
        self._sleeper = lambda sleep_ms: time.sleep(sleep_ms / 1000)
        self.__auth_session(profile, session)

        self._session.headers.update(
            {
                "User-Agent": DataSharingRestClient.USER_AGENT,
            }
        )
```

The `__auth_session` method uses the provided session or creates a new one if none is provided:

```
def __auth_session(self, profile, session: Optional[requests.Session] = None):
    self._session = session or requests.Session()
    self._auth_credential_provider = (
        AuthCredentialProviderFactory.create_auth_credential_provider(profile)
    )
    if urlparse(profile.endpoint).hostname == "localhost":
        self._session.verify = False
  ```
## 3. High-Level Function Updates

The `load_as_pandas` and `load_table_changes_as_pandas` functions now accept an optional `sharing_client` parameter. If a `sharing_client` is provided, these functions will use its `rest_client` for making HTTP requests, ensuring the custom session is used.

  ```
  def load_as_pandas(
    url: str,
    limit: Optional[int] = None,
    version: Optional[int] = None,
    timestamp: Optional[str] = None,
    jsonPredicateHints: Optional[str] = None,
    use_delta_format: Optional[bool] = None,
    sharing_client: Optional[SharingClient] = None,
) -> pd.DataFrame:
    profile_json, share, schema, table = _parse_url(url)
    profile = DeltaSharingProfile.read_from_file(profile_json)
    rest_client = (sharing_client and sharing_client.rest_client) or DataSharingRestClient(profile)
    return DeltaSharingReader(
        table=Table(name=table, share=share, schema=schema),
        rest_client=rest_client,
        jsonPredicateHints=jsonPredicateHints,
        limit=limit,
        version=version,
        timestamp=timestamp,
        use_delta_format=use_delta_format
    ).to_pandas()
  ```
# Example Usage

This is a simplified example of how to use the updated `SharingClient` with a custom `requests.Session` to configure an authenticated proxy, custom headers, and other settings. I'm happy to add this to the docs if needed too: 

```
import requests
from delta_sharing import SharingClient, load_as_pandas

custom_session = requests.Session()

custom_session.proxies = {
    'http': 'http://username:password@proxyserver:port',
    'https': 'https://username:password@proxyserver:port',
}

custom_session.headers.update({'Custom-Header': 'CustomValue'})
custom_session.timeout = 30  # Timeout in seconds
custom_session.verify = '/path/to/custom/cert.pem'  # Path to SSL certificate

profile_path = '/path/to/delta_sharing_profile.share'
client = SharingClient(profile_path, session=custom_session)

shares = client.list_shares()

table_url = f"{profile_path}#share_name.schema_name.table_name"
df = load_as_pandas(table_url, sharing_client=client)

print(df.head())
``` 