### PR TITLE
Enable Support for Custom Session+Proxy Configurations

### DIFF
--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from itertools import chain
-from typing import BinaryIO, List, Optional, Sequence, TextIO, Tuple, Union
-from pathlib import Path
+from typing import Optional, Tuple
 
 import pandas as pd
 
@@ -26,12 +24,10 @@ try:
 except ImportError:
     pass
 
-from delta_sharing.protocol import DeltaSharingProfile, Schema, Share, Table
+from delta_sharing.sharing_client import SharingClient
+from delta_sharing.protocol import DeltaSharingProfile, Table
 from delta_sharing.reader import DeltaSharingReader
 from delta_sharing.rest_client import DataSharingRestClient
-
-from requests.exceptions import HTTPError
-
 
 def _parse_url(url: str) -> Tuple[str, str, str, str]:
     """
@@ -105,6 +101,7 @@ def load_as_pandas(
     timestamp: Optional[str] = None,
     jsonPredicateHints: Optional[str] = None,
     use_delta_format: Optional[bool] = None,
+    sharing_client: Optional[SharingClient] = None,
 ) -> pd.DataFrame:
     """
     Load the shared table using the given url as a pandas DataFrame.
@@ -120,9 +117,10 @@ def load_as_pandas(
     """
     profile_json, share, schema, table = _parse_url(url)
     profile = DeltaSharingProfile.read_from_file(profile_json)
+    rest_client = (sharing_client and sharing_client.rest_client) or DataSharingRestClient(profile)
     return DeltaSharingReader(
         table=Table(name=table, share=share, schema=schema),
-        rest_client=DataSharingRestClient(profile),
+        rest_client=rest_client,
         jsonPredicateHints=jsonPredicateHints,
         limit=limit,
         version=version,
@@ -216,7 +214,8 @@ def load_table_changes_as_pandas(
     ending_version: Optional[int] = None,
     starting_timestamp: Optional[str] = None,
     ending_timestamp: Optional[str] = None,
-    use_delta_format: Optional[bool] = None
+    use_delta_format: Optional[bool] = None,
+    sharing_client: Optional[SharingClient] = None,
 ) -> pd.DataFrame:
     """
     Load the table changes of shared table as a pandas DataFrame using the given url.
@@ -233,9 +232,10 @@ def load_table_changes_as_pandas(
     """
     profile_json, share, schema, table = _parse_url(url)
     profile = DeltaSharingProfile.read_from_file(profile_json)
+    rest_client = (sharing_client and sharing_client.rest_client) or DataSharingRestClient(profile)
     return DeltaSharingReader(
         table=Table(name=table, share=share, schema=schema),
-        rest_client=DataSharingRestClient(profile),
+        rest_client=rest_client,
         use_delta_format=use_delta_format
     ).table_changes_to_pandas(CdfOptions(
         starting_version=starting_version,
@@ -246,89 +246,3 @@ def load_table_changes_as_pandas(
         # handle them properly when replaying the delta log
         include_historical_metadata=use_delta_format
     ))
-
-
-class SharingClient:
-    """
-    A Delta Sharing client to query shares/schemas/tables from a Delta Sharing Server.
-    """
-
-    def __init__(self, profile: Union[str, BinaryIO, TextIO, Path, DeltaSharingProfile]):
-        if not isinstance(profile, DeltaSharingProfile):
-            profile = DeltaSharingProfile.read_from_file(profile)
-        self._profile = profile
-        self._rest_client = DataSharingRestClient(profile)
-
-    def __list_all_tables_in_share(self, share: Share) -> Sequence[Table]:
-        tables: List[Table] = []
-        page_token: Optional[str] = None
-        while True:
-            response = self._rest_client.list_all_tables(share=share, page_token=page_token)
-            tables.extend(response.tables)
-            page_token = response.next_page_token
-            if page_token is None or page_token == "":
-                return tables
-
-    def list_shares(self) -> Sequence[Share]:
-        """
-        List shares that can be accessed by you in a Delta Sharing Server.
-
-        :return: the shares that can be accessed.
-        """
-        shares: List[Share] = []
-        page_token: Optional[str] = None
-        while True:
-            response = self._rest_client.list_shares(page_token=page_token)
-            shares.extend(response.shares)
-            page_token = response.next_page_token
-            if page_token is None or page_token == "":
-                return shares
-
-    def list_schemas(self, share: Share) -> Sequence[Schema]:
-        """
-        List schemas in a share that can be accessed by you in a Delta Sharing Server.
-
-        :param share: the share to list.
-        :return: the schemas in a share.
-        """
-        schemas: List[Schema] = []
-        page_token: Optional[str] = None
-        while True:
-            response = self._rest_client.list_schemas(share=share, page_token=page_token)
-            schemas.extend(response.schemas)
-            page_token = response.next_page_token
-            if page_token is None or page_token == "":
-                return schemas
-
-    def list_tables(self, schema: Schema) -> Sequence[Table]:
-        """
-        List tables in a schema that can be accessed by you in a Delta Sharing Server.
-
-        :param schema: the schema to list.
-        :return: the tables in a schema.
-        """
-        tables: List[Table] = []
-        page_token: Optional[str] = None
-        while True:
-            response = self._rest_client.list_tables(schema=schema, page_token=page_token)
-            tables.extend(response.tables)
-            page_token = response.next_page_token
-            if page_token is None or page_token == "":
-                return tables
-
-    def list_all_tables(self) -> Sequence[Table]:
-        """
-        List all tables that can be accessed by you in a Delta Sharing Server.
-
-        :return: all tables that can be accessed.
-        """
-        shares = self.list_shares()
-        try:
-            return list(chain(*(self.__list_all_tables_in_share(share) for share in shares)))
-        except HTTPError as e:
-            if e.response.status_code == 404:
-                # The server doesn't support all-tables API. Fallback to the old APIs instead.
-                schemas = chain(*(self.list_schemas(share) for share in shares))
-                return list(chain(*(self.list_tables(schema) for schema in schemas)))
-            else:
-                raise e

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -149,11 +149,11 @@ class DataSharingRestClient:
     DELTA_FORMAT = "delta"
     PARQUET_FORMAT = "parquet"
 
-    def __init__(self, profile: DeltaSharingProfile, num_retries=10):
+    def __init__(self, profile: DeltaSharingProfile, num_retries=10, session: Optional[requests.Session] = None):
         self._profile = profile
         self._num_retries = num_retries
         self._sleeper = lambda sleep_ms: time.sleep(sleep_ms / 1000)
-        self.__auth_session(profile)
+        self.__auth_session(profile, session)
 
         self._session.headers.update(
             {
@@ -161,12 +161,16 @@ class DataSharingRestClient:
             }
         )
 
-    def __auth_session(self, profile):
-        self._session = requests.Session()
+    def __auth_session(self, profile, session: Optional[requests.Session] = None):
+        self._session = session or requests.Session()
         self._auth_credential_provider = (
-            AuthCredentialProviderFactory.create_auth_credential_provider(profile))
+            AuthCredentialProviderFactory.create_auth_credential_provider(profile)
+        )
         if urlparse(profile.endpoint).hostname == "localhost":
             self._session.verify = False
+
+    def get_session(self) -> requests.Session:
+        return self._session
 
     def set_sharing_capabilities_header(self):
         delta_sharing_capabilities = (

--- a/python/delta_sharing/sharing_client.py
+++ b/python/delta_sharing/sharing_client.py
@@ -1,0 +1,122 @@
+#
+# Copyright (C) 2025 The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from itertools import chain
+from typing import BinaryIO, List, Optional, Sequence, TextIO, Union
+from pathlib import Path
+import requests
+
+from delta_sharing.protocol import DeltaSharingProfile, Schema, Share, Table
+from delta_sharing.rest_client import DataSharingRestClient
+
+from requests.exceptions import HTTPError
+
+
+class SharingClient:
+    """
+    A Delta Sharing client to query shares/schemas/tables from a Delta Sharing Server.
+
+    :param profile: The path to the profile file or a DeltaSharingProfile object.
+    :param session: An optional requests.Session object to use for HTTP requests.
+                    You can use this to customize proxy settings, authentication, etc.
+    """
+    def __init__(self, profile: Union[str, BinaryIO, TextIO, Path, DeltaSharingProfile], session: Optional[requests.Session] = None):
+        if not isinstance(profile, DeltaSharingProfile):
+            profile = DeltaSharingProfile.read_from_file(profile)
+        self._profile = profile
+        self._rest_client = DataSharingRestClient(profile, session=session)
+
+    @property
+    def rest_client(self) -> DataSharingRestClient:
+        """
+        Get the underlying DataSharingRestClient used by this SharingClient.
+
+        :return: The DataSharingRestClient instance.
+        """
+        return self._rest_client
+
+    def __list_all_tables_in_share(self, share: Share) -> Sequence[Table]:
+        tables: List[Table] = []
+        page_token: Optional[str] = None
+        while True:
+            response = self._rest_client.list_all_tables(share=share, page_token=page_token)
+            tables.extend(response.tables)
+            page_token = response.next_page_token
+            if page_token is None or page_token == "":
+                return tables
+
+    def list_shares(self) -> Sequence[Share]:
+        """
+        List shares that can be accessed by you in a Delta Sharing Server.
+
+        :return: the shares that can be accessed.
+        """
+        shares: List[Share] = []
+        page_token: Optional[str] = None
+        while True:
+            response = self._rest_client.list_shares(page_token=page_token)
+            shares.extend(response.shares)
+            page_token = response.next_page_token
+            if page_token is None or page_token == "":
+                return shares
+
+    def list_schemas(self, share: Share) -> Sequence[Schema]:
+        """
+        List schemas in a share that can be accessed by you in a Delta Sharing Server.
+
+        :param share: the share to list.
+        :return: the schemas in a share.
+        """
+        schemas: List[Schema] = []
+        page_token: Optional[str] = None
+        while True:
+            response = self._rest_client.list_schemas(share=share, page_token=page_token)
+            schemas.extend(response.schemas)
+            page_token = response.next_page_token
+            if page_token is None or page_token == "":
+                return schemas
+
+    def list_tables(self, schema: Schema) -> Sequence[Table]:
+        """
+        List tables in a schema that can be accessed by you in a Delta Sharing Server.
+
+        :param schema: the schema to list.
+        :return: the tables in a schema.
+        """
+        tables: List[Table] = []
+        page_token: Optional[str] = None
+        while True:
+            response = self._rest_client.list_tables(schema=schema, page_token=page_token)
+            tables.extend(response.tables)
+            page_token = response.next_page_token
+            if page_token is None or page_token == "":
+                return tables
+
+    def list_all_tables(self) -> Sequence[Table]:
+        """
+        List all tables that can be accessed by you in a Delta Sharing Server.
+
+        :return: all tables that can be accessed.
+        """
+        shares = self.list_shares()
+        try:
+            return list(chain(*(self.__list_all_tables_in_share(share) for share in shares)))
+        except HTTPError as e:
+            if e.response.status_code == 404:
+                # The server doesn't support all-tables API. Fallback to the old APIs instead.
+                schemas = chain(*(self.list_schemas(share) for share in shares))
+                return list(chain(*(self.list_tables(schema) for schema in schemas)))
+            else:
+                raise e

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -14,11 +14,9 @@
 # limitations under the License.
 #
 import pytest
-
+import pandas as pd
 from datetime import date
 from typing import Optional, Sequence
-
-import pandas as pd
 
 from delta_sharing.protocol import AddFile, AddCdcFile, CdfOptions, Metadata, RemoveFile, Table
 from delta_sharing.reader import DeltaSharingReader
@@ -29,7 +27,6 @@ from delta_sharing.rest_client import (
 )
 from delta_sharing.tests.conftest import ENABLE_INTEGRATION, SKIP_MESSAGE
 
-
 def test_to_pandas_non_partitioned(tmp_path):
     pdf1 = pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
     pdf2 = pd.DataFrame({"a": [4, 5, 6], "b": ["d", "e", "f"]})
@@ -38,6 +35,9 @@ def test_to_pandas_non_partitioned(tmp_path):
     pdf2.to_parquet(tmp_path / "pdf2.parquet")
 
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_files_in_table(
             self,
             table: Table,
@@ -91,6 +91,9 @@ def test_to_pandas_non_partitioned(tmp_path):
         def autoresolve_query_format(self, table: Table):
             return "parquet"
 
+        def get_session(self):
+            return self._session
+
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.to_pandas()
     expected = pd.concat([pdf1, pdf2]).reset_index(drop=True)
@@ -123,6 +126,9 @@ def test_to_pandas_partitioned(tmp_path):
     pdf2.to_parquet(tmp_path / "pdf2.parquet")
 
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_files_in_table(
             self,
             table: Table,
@@ -170,6 +176,9 @@ def test_to_pandas_partitioned(tmp_path):
         def autoresolve_query_format(self, table: Table):
             return "parquet"
 
+        def get_session(self):
+            return self._session
+
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.to_pandas()
 
@@ -190,6 +199,9 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
     pdf2.to_parquet(tmp_path / "pdf2.parquet")
 
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_files_in_table(
             self,
             table: Table,
@@ -238,6 +250,9 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
         def autoresolve_query_format(self, table: Table):
             return "parquet"
 
+        def get_session(self):
+            return self._session
+
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.to_pandas()
 
@@ -253,6 +268,9 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_to_pandas_empty(rest_client: DataSharingRestClient):
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_files_in_table(
             self,
             table: Table,
@@ -301,6 +319,9 @@ def test_to_pandas_empty(rest_client: DataSharingRestClient):
 
         def autoresolve_query_format(self, table: Table):
             return "parquet"
+
+        def get_session(self):
+            return self._session
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock()  # type: ignore
@@ -356,6 +377,9 @@ def test_table_changes_to_pandas_non_partitioned(tmp_path):
     pdf4[DeltaSharingReader._commit_timestamp_col_name()] = timestamp4
 
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_table_changes(
             self, table: Table, cdfOptions: CdfOptions
         ) -> ListTableChangesResponse:
@@ -414,12 +438,14 @@ def test_table_changes_to_pandas_non_partitioned(tmp_path):
         def autoresolve_query_format(self, table: Table):
             return "parquet"
 
+        def get_session(self):
+            return self._session
+
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.table_changes_to_pandas(CdfOptions())
 
     expected = pd.concat([pdf1, pdf2, pdf3, pdf4]).reset_index(drop=True)
     pd.testing.assert_frame_equal(pdf, expected)
-
 
 def test_table_changes_to_pandas_partitioned(tmp_path):
     pdf1 = pd.DataFrame({"a": [1, 2, 3]})
@@ -442,6 +468,9 @@ def test_table_changes_to_pandas_partitioned(tmp_path):
     pdf2[DeltaSharingReader._commit_timestamp_col_name()] = timestamp
 
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_table_changes(
             self,
             table: Table,
@@ -482,6 +511,9 @@ def test_table_changes_to_pandas_partitioned(tmp_path):
                 lines=None
             )
 
+        def get_session(self):
+            return self._session
+
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.table_changes_to_pandas(CdfOptions())
 
@@ -491,6 +523,9 @@ def test_table_changes_to_pandas_partitioned(tmp_path):
 
 def test_table_changes_empty(tmp_path):
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_table_changes(
             self, table: Table, cdfOptions: CdfOptions
         ) -> ListTableChangesResponse:
@@ -510,6 +545,9 @@ def test_table_changes_empty(tmp_path):
                 actions=[],
                 lines=None
             )
+
+        def get_session(self):
+            return self._session
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.table_changes_to_pandas(CdfOptions())
@@ -565,6 +603,9 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
     pdf4[DeltaSharingReader._commit_timestamp_col_name()] = timestamp4
 
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_table_changes(
             self, table: Table, cdfOptions: CdfOptions
         ) -> ListTableChangesResponse:
@@ -575,7 +616,7 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
                 '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
                 '{"metadata":{},"name":"b","nullable":true,"type":"string"}'
                 '],"type":"struct"}'
-            ).replace('"',r'\"')
+            ).replace('"', r'\"')
             lines = [
                 f'''{{
                     "protocol": {{
@@ -674,6 +715,9 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
 
         def remove_delta_format_header(self):
             return
+
+        def get_session(self):
+            return self._session
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"),


### PR DESCRIPTION
# Description 

This PR introduces the ability for users to pass custom **`requests.Session`** objects to the **`SharingClient`** in the Delta Sharing Python library. This enhancement allows users to configure more complex session settings that cannot be achieved using environment variables alone, such as authenticated proxies, custom headers, SSL configurations, timeout settings, and other session-related configurations. This provides users with greater flexibility when working in complex network environments or when specific session configurations are required.

# Key Changes

## 1. **`SharingClient`** Class Update

The `SharingClient` class now accepts an optional **`session`** parameter in its constructor. This allows users to pass a custom **`requests.Session`** object when creating a **`SharingClient`**. If no session is provided, a new **`requests.Session`** will be created as before:

```
class SharingClient:
    def __init__(
        self,
        profile: Union[str, BinaryIO, TextIO, Path, DeltaSharingProfile],
        session: Optional[requests.Session] = None
    ):
        if not isinstance(profile, DeltaSharingProfile):
            profile = DeltaSharingProfile.read_from_file(profile)
        self._profile = profile
        self._rest_client = DataSharingRestClient(profile, session=session)
```


## 2. **`DataSharingRestClient`** Class Update

The **`DataSharingRestClient`** class now accepts an optional **`session`** parameter. The custom session is passed from **`SharingClient`** to **`DataSharingRestClient`**, ensuring all HTTP requests utilize the custom session.

```
class DataSharingRestClient:
    def __init__(
        self,
        profile: DeltaSharingProfile,
        num_retries=10,
        session: Optional[requests.Session] = None
    ):
        self._profile = profile
        self._num_retries = num_retries
        self._sleeper = lambda sleep_ms: time.sleep(sleep_ms / 1000)
        self.__auth_session(profile, session)

        self._session.headers.update(
            {
                "User-Agent": DataSharingRestClient.USER_AGENT,
            }
        )
```

The **`__auth_session`** method uses the provided session or creates a new one if none is provided:

```
def __auth_session(self, profile, session: Optional[requests.Session] = None):
    self._session = session or requests.Session()
    self._auth_credential_provider = (
        AuthCredentialProviderFactory.create_auth_credential_provider(profile)
    )
    if urlparse(profile.endpoint).hostname == "localhost":
        self._session.verify = False
  ```
  
## 3. High-Level Function Updates

The **`load_as_pandas`** and **`load_table_changes_as_pandas`** functions now accept an optional **`sharing_client`** parameter. If a **`sharing_client`** is provided, these functions will use its **`rest_client`** for making HTTP requests, ensuring the custom session is used.


  ```
  def load_as_pandas(
    url: str,
    limit: Optional[int] = None,
    version: Optional[int] = None,
    timestamp: Optional[str] = None,
    jsonPredicateHints: Optional[str] = None,
    use_delta_format: Optional[bool] = None,
    sharing_client: Optional[SharingClient] = None,
) -> pd.DataFrame:
    profile_json, share, schema, table = _parse_url(url)
    profile = DeltaSharingProfile.read_from_file(profile_json)
    rest_client = (sharing_client and sharing_client.rest_client) or DataSharingRestClient(profile)
    return DeltaSharingReader(
        table=Table(name=table, share=share, schema=schema),
        rest_client=rest_client,
        jsonPredicateHints=jsonPredicateHints,
        limit=limit,
        version=version,
        timestamp=timestamp,
        use_delta_format=use_delta_format
    ).to_pandas()
  ```
# Example Usage

This is a simplified example of how to use the updated **`SharingClient`** with a custom **`requests.Session`** to configure an authenticated proxy, custom headers, and other settings:

```
import requests
from delta_sharing import SharingClient, load_as_pandas

custom_session = requests.Session()

custom_session.proxies = {
    'http': 'http://username:password@proxyserver:port',
    'https': 'https://username:password@proxyserver:port',
}

custom_session.headers.update({'Custom-Header': 'CustomValue'})
custom_session.timeout = 30  # Timeout in seconds
custom_session.verify = '/path/to/custom/cert.pem'  # Path to SSL certificate

profile_path = '/path/to/delta_sharing_profile.share'
client = SharingClient(profile_path, session=custom_session)

shares = client.list_shares()

table_url = f"{profile_path}#share_name.schema_name.table_name"
df = load_as_pandas(table_url, sharing_client=client)

print(df.head())
``` 