### PR TITLE
Include source in maturin build of delta-kernel-rust-sharing-wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,18 @@ If this doesn’t work because of an issue downloading delta-kernel-rust-sharing
 - Check python3 version >= 3.8
 - Upgrade your pip3 to the latest version
 - Check the linux glibc version >= 2.31
+- [Install Rust](https://www.rust-lang.org/tools/install)
 
-If you cannot upgrade glibc or your OS is not supported by the delta-kernel-rust-sharing-wrapper pypi install  you will need to install the package manually.
-See https://pypi.org/project/delta-kernel-rust-sharing-wrapper/0.2.0/#files for supported OS.
+If you cannot upgrade glibc or PyPI does not have a pre-built wheel for delta-kernel-rust-sharing-wrapper for your environment, pip will have to build the package from source, which requires Rust to be installed.
+See https://pypi.org/project/delta-kernel-rust-sharing-wrapper/0.2.1/#files for environments that have a pre-built wheel.
 
-To install the delta-kernel-rust-sharing-wrapper package manually:
+You can also use an older version of the delta-sharing package which did not bake delta-kernel-rust-sharing-wrapper into the installation with the following:
 ```
-# you need to use the older version of the delta-sharing package which did not bake delta-kernel-rust-sharing-wrapper into the installation
 pip3 install delta-sharing==1.1.0 
+```
 
+You can also install the delta-kernel-rust-sharing-wrapper package manually:
+```
 cd [delta-sharing-root]/python/delta-kernel-rust-sharing-wrapper
 python3 -m venv .venv
 source .venv/bin/activate

--- a/python/README.md
+++ b/python/README.md
@@ -7,6 +7,7 @@ This is the Python client library for Delta Sharing, which lets you load shared 
 ## Installation and Usage
 
 1. Install using `pip install delta-sharing`.
+    a. On some environments, you may also need to [install Rust](https://www.rust-lang.org/tools/install). This is because the `delta-sharing` package depends on the `delta-kernel-rust-sharing-wrapper` package, which does not have a pre-built Python wheel for all environments. As a result, pip will have to build `delta-kernel-rust-sharing-wrapper` from source.
 2. To use the Python Connector, see [the project docs](https://github.com/delta-io/delta-sharing) for details.
 
 ## Documentation

--- a/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
+++ b/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
@@ -2,7 +2,7 @@
 name = "delta-kernel-rust-sharing-wrapper"
 edition = "2021"
 license = "Apache-2.0"
-version = "0.2.1"
+version = "0.2.2"
 
 [lib]
 name = "delta_kernel_rust_sharing_wrapper"


### PR DESCRIPTION
Running `maturin build --sdist` creates a source tarball. Uploading the source tarball to PyPI would allow for delta-kernel-rust-sharing-wrapper to be installed from pip even on platforms that do not explicitly have a wheel built for them. This PR updates the README accordingly.