### PR TITLE
[DTS-4838] Optimize Retry Logic: Reduce Attempts and Adaptive Sleep Intervals

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -180,6 +180,7 @@ class DeltaSharingRestClient(
     timeoutInSeconds: Int = 120,
     numRetries: Int = 3,
     maxRetryDuration: Long = Long.MaxValue,
+    retrySleepInterval: Long = 1000,
     sslTrustAll: Boolean = false,
     forStreaming: Boolean = false,
     responseFormat: String = DeltaSharingRestClient.RESPONSE_FORMAT_PARQUET,
@@ -1129,7 +1130,7 @@ class DeltaSharingRestClient(
   ): (Option[Long], Map[String, String], Seq[String]) = {
     // Reset dsQueryId before calling RetryUtils, and before prepareHeaders.
     dsQueryId = Some(UUID.randomUUID().toString().split('-').head)
-    RetryUtils.runWithExponentialBackoff(numRetries, maxRetryDuration) {
+    RetryUtils.runWithExponentialBackoff(numRetries, maxRetryDuration, retrySleepInterval) {
       val profile = profileProvider.getProfile
       val response = client.execute(
         getHttpHost(profile.endpoint),
@@ -1346,6 +1347,7 @@ object DeltaSharingRestClient extends Logging {
     val sslTrustAll = ConfUtils.sslTrustAll(sqlConf)
     val numRetries = ConfUtils.numRetries(sqlConf)
     val maxRetryDurationMillis = ConfUtils.maxRetryDurationMillis(sqlConf)
+    val retrySleepIntervalMillis = ConfUtils.retrySleepIntervalMillis(sqlConf)
     val timeoutInSeconds = ConfUtils.timeoutInSeconds(sqlConf)
     val queryTablePaginationEnabled = ConfUtils.queryTablePaginationEnabled(sqlConf)
     val maxFilesPerReq = ConfUtils.maxFilesPerQueryRequest(sqlConf)
@@ -1366,6 +1368,7 @@ object DeltaSharingRestClient extends Logging {
         classOf[Int],
         classOf[Int],
         classOf[Long],
+        classOf[Long],
         classOf[Boolean],
         classOf[Boolean],
         classOf[String],
@@ -1383,6 +1386,7 @@ object DeltaSharingRestClient extends Logging {
         java.lang.Integer.valueOf(timeoutInSeconds),
         java.lang.Integer.valueOf(numRetries),
         java.lang.Long.valueOf(maxRetryDurationMillis),
+        java.lang.Long.valueOf(retrySleepIntervalMillis),
         java.lang.Boolean.valueOf(sslTrustAll),
         java.lang.Boolean.valueOf(forStreaming),
         responseFormat,

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -178,7 +178,7 @@ private[sharing] case class ListAllTablesResponse(
 class DeltaSharingRestClient(
     profileProvider: DeltaSharingProfileProvider,
     timeoutInSeconds: Int = 120,
-    numRetries: Int = 10,
+    numRetries: Int = 3,
     maxRetryDuration: Long = Long.MaxValue,
     sslTrustAll: Boolean = false,
     forStreaming: Boolean = false,

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.internal.SQLConf
 object ConfUtils {
 
   val NUM_RETRIES_CONF = "spark.delta.sharing.network.numRetries"
-  val NUM_RETRIES_DEFAULT = 10
+  val NUM_RETRIES_DEFAULT = 3
 
   val MAX_RETRY_DURATION_CONF = "spark.delta.sharing.network.maxRetryDuration"
   val MAX_RETRY_DURATION_DEFAULT_MILLIS = 10L * 60L* 1000L /* 10 mins */

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -30,6 +30,9 @@ object ConfUtils {
   val MAX_RETRY_DURATION_CONF = "spark.delta.sharing.network.maxRetryDuration"
   val MAX_RETRY_DURATION_DEFAULT_MILLIS = 10L * 60L* 1000L /* 10 mins */
 
+  val RETRY_SLEEP_INTERVAL_CONF = "spark.delta.sharing.network.retrySleepInterval"
+  val RETRY_SLEEP_INTERVAL_DEFAULT_MILLIS = 1000L /* 1 second */
+
   val ASYNC_QUERY_POLL_INTERVAL_CONF = "spark.delta.sharing.network.asyncQueryRetryInterval"
   val ASYNC_QUERY_POLL_INTERVAL_DEFAULT_MILLIS = 10L * 1000L /* 10 seconds */
 
@@ -142,6 +145,21 @@ object ConfUtils {
       conf.getConfString(MAX_RETRY_DURATION_CONF, MAX_RETRY_DURATION_DEFAULT_MILLIS.toString).toLong
     validateNonNeg(maxDur, MAX_RETRY_DURATION_CONF)
     maxDur
+  }
+
+  def retrySleepIntervalMillis(conf: Configuration): Long = {
+    val interval = conf.getLong(RETRY_SLEEP_INTERVAL_CONF, RETRY_SLEEP_INTERVAL_DEFAULT_MILLIS)
+    validateNonNeg(interval, RETRY_SLEEP_INTERVAL_CONF)
+    interval
+  }
+
+  def retrySleepIntervalMillis(conf: SQLConf): Long = {
+    val interval =
+      conf.getConfString(
+        RETRY_SLEEP_INTERVAL_CONF,
+        RETRY_SLEEP_INTERVAL_DEFAULT_MILLIS.toString).toLong
+    validateNonNeg(interval, RETRY_SLEEP_INTERVAL_CONF)
+    interval
   }
 
   def asyncQueryPollIntervalMillis(conf: Configuration): Long = {

--- a/client/src/main/scala/io/delta/sharing/client/util/RetryUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/RetryUtils.scala
@@ -67,7 +67,7 @@ private[sharing] object RetryUtils extends Logging {
       case e: UnexpectedHttpStatus =>
         if (e.statusCode == 429) { // Too Many Requests
           true
-        } else if (e.statusCode >= 500 && e.statusCode < 600) { // Internal Error
+        } else if (e.statusCode == 503) { // Service Unavailable
           true
         } else {
           false

--- a/client/src/main/scala/io/delta/sharing/client/util/RetryUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/RetryUtils.scala
@@ -31,9 +31,10 @@ private[sharing] object RetryUtils extends Logging {
 
   def runWithExponentialBackoff[T](
       numRetries: Int,
-      maxDurationMillis: Long = Long.MaxValue)(func: => T): T = {
+      maxDurationMillis: Long = Long.MaxValue,
+      retrySleepInterval: Long = 1000)(func: => T): T = {
     var times = 0
-    var sleepMs = 100
+    var sleepMs = retrySleepInterval
     val startTime = System.currentTimeMillis()
     while (true) {
       times += 1
@@ -67,7 +68,7 @@ private[sharing] object RetryUtils extends Logging {
       case e: UnexpectedHttpStatus =>
         if (e.statusCode == 429) { // Too Many Requests
           true
-        } else if (e.statusCode == 503) { // Service Unavailable
+        } else if (e.statusCode >= 500 && e.statusCode < 600) { // Internal Error
           true
         } else {
           false

--- a/client/src/test/scala/io/delta/sharing/client/util/RetryUtilsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/RetryUtilsSuite.scala
@@ -29,7 +29,9 @@ import io.delta.sharing.spark.MissingEndStreamActionException
 class RetryUtilsSuite extends SparkFunSuite {
   test("shouldRetry") {
     assert(shouldRetry(new UnexpectedHttpStatus("error", 429)))
-    assert(shouldRetry(new UnexpectedHttpStatus("error", 500)))
+    assert(shouldRetry(new UnexpectedHttpStatus("error", 503)))
+    assert(!shouldRetry(new UnexpectedHttpStatus("error", 500)))
+    assert(!shouldRetry(new UnexpectedHttpStatus("error", 504)))
     assert(!shouldRetry(new UnexpectedHttpStatus("error", 404)))
     assert(!shouldRetry(new InterruptedException))
     assert(!shouldRetry(new InterruptedIOException))

--- a/client/src/test/scala/io/delta/sharing/client/util/RetryUtilsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/RetryUtilsSuite.scala
@@ -29,9 +29,7 @@ import io.delta.sharing.spark.MissingEndStreamActionException
 class RetryUtilsSuite extends SparkFunSuite {
   test("shouldRetry") {
     assert(shouldRetry(new UnexpectedHttpStatus("error", 429)))
-    assert(shouldRetry(new UnexpectedHttpStatus("error", 503)))
-    assert(!shouldRetry(new UnexpectedHttpStatus("error", 500)))
-    assert(!shouldRetry(new UnexpectedHttpStatus("error", 504)))
+    assert(shouldRetry(new UnexpectedHttpStatus("error", 500)))
     assert(!shouldRetry(new UnexpectedHttpStatus("error", 404)))
     assert(!shouldRetry(new InterruptedException))
     assert(!shouldRetry(new InterruptedIOException))
@@ -46,13 +44,13 @@ class RetryUtilsSuite extends SparkFunSuite {
     RetryUtils.sleeper = (sleepMs: Long) => sleeps += sleepMs
     // Retry case
     intercept[UnexpectedHttpStatus] {
-      runWithExponentialBackoff(10) {
+      runWithExponentialBackoff(5) {
         throw new UnexpectedHttpStatus("error", 429)
       }
     }
-    // Run 11 times should sleep 10 times
-    assert(sleeps.length == 10)
-    assert(sleeps == Seq(100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200))
+    // Run 6 times should sleep 5 times
+    assert(sleeps.length == 5)
+    assert(sleeps == Seq(1000, 2000, 4000, 8000, 16000))
     // No retry case
     sleeps.clear()
     intercept[RuntimeException] {
@@ -77,7 +75,7 @@ class RetryUtilsSuite extends SparkFunSuite {
     }
     // Should hit max duration after 2 retries.
     assert(sleeps.length == 3)
-    assert(sleeps == Seq(100, 200, 400))
+    assert(sleeps == Seq(1000, 2000, 4000))
     RetryUtils.sleeper = (sleepMs: Long) => Thread.sleep(sleepMs)
   }
 }


### PR DESCRIPTION
This PR introduces the following changes to the retry logic:

1. Reduced Retry Attempts: The number of retries is reduced from 10 to 3. If the Delta Sharing server returns an error, the client will either retry 3 times or retry for a maximum of 10 minutes, whichever occurs first. This adjustment allows the recipient to fail faster.
2. Introduced retry sleep interval: A sleep interval between retries has been introduced, with a default duration of 1000 milliseconds. The sleep time would double after each retry. 