### PR TITLE
Upgrade actions/cache to v4

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Cache Scala, SBT
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.sbt
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Cache Scala, SBT
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.sbt


### PR DESCRIPTION
@actions/cache v2 has been deprecated. No changes are needed as this upgrade is fully backwards compatible. See https://github.com/actions/toolkit/blob/main/packages/cache/README.md.