### PR TITLE
Support delta format for table protocol and metadata

### DIFF
--- a/python/delta_sharing/protocol.py
+++ b/python/delta_sharing/protocol.py
@@ -183,8 +183,8 @@ class Protocol:
             return Protocol(
                 min_reader_version=int(delta_protocol["minReaderVersion"]),
                 min_writer_version=int(delta_protocol["minWriterVersion"]),
-                reader_features=delta_protocol["readerFeatures"],
-                writer_features=delta_protocol["writerFeatures"],
+                reader_features=delta_protocol.get("readerFeatures", None),
+                writer_features=delta_protocol.get("writerFeatures", None),
             )
         else:
             return Protocol(min_reader_version=int(json["minReaderVersion"]))
@@ -234,7 +234,7 @@ class Metadata:
                 version=json.get("version", None),
                 size=json.get("size", None),
                 num_files=json.get("numFiles", None),
-                created_time=delta_metadata["createdTime"]
+                created_time=delta_metadata.get("createdTime", None)
             )
         else:
             configuration = json.get("configuration", {})

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -270,10 +270,13 @@ class DataSharingRestClient:
 
     @retry_with_exponential_backoff
     def query_table_metadata(self, table: Table) -> QueryTableMetadataResponse:
+        self.set_sharing_capabilities_header()
         with self._get_internal(
             f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/metadata",
             return_headers=True
         ) as values:
+            # removing the client-reader-features that were set to avoid diverging standard codepath
+            self.remove_sharing_capabilities_header()
             headers = values[0]
             # it's a bug in the server if it doesn't return delta-table-version in the header
             if DataSharingRestClient.DELTA_TABLE_VERSION_HEADER not in headers:

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -270,13 +270,10 @@ class DataSharingRestClient:
 
     @retry_with_exponential_backoff
     def query_table_metadata(self, table: Table) -> QueryTableMetadataResponse:
-        self.set_sharing_capabilities_header()
         with self._get_internal(
             f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/metadata",
             return_headers=True
         ) as values:
-            # removing the client-reader-features that were set to avoid diverging standard codepath
-            self.remove_sharing_capabilities_header()
             headers = values[0]
             # it's a bug in the server if it doesn't return delta-table-version in the header
             if DataSharingRestClient.DELTA_TABLE_VERSION_HEADER not in headers:

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -17,6 +17,7 @@ from datetime import date, datetime
 from typing import Optional, Sequence
 
 import pandas as pd
+from pyarrow import ExtensionType
 import pytest
 
 from delta_sharing.delta_sharing import (
@@ -265,12 +266,16 @@ def test_get_table_metadata(
 ):
     actual = get_table_metadata(f"{profile_path}#{fragments}")
     assert expected == actual
+    actual_using_parquet = get_table_metadata(f"{profile_path}#{fragments}", use_delta_format=False)
+    assert expected == actual_using_parquet
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_get_table_protocol(profile_path: str):
     actual = get_table_protocol(f"{profile_path}#share1.default.table1")
     assert Protocol(min_reader_version=1) == actual
+    actual_using_parquet = get_table_protocol(f"{profile_path}#share1.default.table1", use_delta_format=False)
+    assert Protocol(min_reader_version=1) == actual_using_parquet
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -175,10 +175,54 @@ def test_query_table_metadata_non_partitioned(rest_client: DataSharingRestClient
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
+def test_query_table_metadata_non_partitioned_delta(rest_client: DataSharingRestClient):
+    rest_client.set_sharing_capabilities_header()
+    response = rest_client.query_table_metadata(
+        Table(name="table1", share="share1", schema="default")
+    )
+    rest_client.remove_sharing_capabilities_header()
+    assert response.delta_table_version > 1
+    assert response.protocol == Protocol(min_reader_version=1)
+    assert response.metadata == Metadata(
+        id="ed96aa41-1d81-4b7f-8fb5-846878b4b0cf",
+        format=Format(provider="parquet", options={}),
+        schema_string=(
+            '{"type":"struct","fields":['
+            '{"name":"eventTime","type":"timestamp","nullable":true,"metadata":{}},'
+            '{"name":"date","type":"date","nullable":true,"metadata":{}}'
+            "]}"
+        ),
+        partition_columns=[],
+    )
+
+
+@pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_query_table_metadata_partitioned(rest_client: DataSharingRestClient):
     response = rest_client.query_table_metadata(
         Table(name="table2", share="share2", schema="default")
     )
+    assert response.delta_table_version > 1
+    assert response.protocol == Protocol(min_reader_version=1)
+    assert response.metadata == Metadata(
+        id="f8d5c169-3d01-4ca3-ad9e-7dc3355aedb2",
+        format=Format(provider="parquet", options={}),
+        schema_string=(
+            '{"type":"struct","fields":['
+            '{"name":"eventTime","type":"timestamp","nullable":true,"metadata":{}},'
+            '{"name":"date","type":"date","nullable":true,"metadata":{}}'
+            "]}"
+        ),
+        partition_columns=["date"],
+    )
+
+
+@pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
+def test_query_table_metadata_partitioned_delta(rest_client: DataSharingRestClient):
+    rest_client.set_sharing_capabilities_header()
+    response = rest_client.query_table_metadata(
+        Table(name="table2", share="share2", schema="default")
+    )
+    rest_client.remove_sharing_capabilities_header()
     assert response.delta_table_version > 1
     assert response.protocol == Protocol(min_reader_version=1)
     assert response.metadata == Metadata(
@@ -214,6 +258,77 @@ def test_query_table_metadata_partitioned_different_schemas(
             "]}"
         ),
         partition_columns=["date"],
+    )
+
+
+@pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
+def test_query_table_metadata_partitioned_different_schemas_delta(
+    rest_client: DataSharingRestClient,
+):
+    rest_client.set_sharing_capabilities_header()
+    response = rest_client.query_table_metadata(
+        Table(name="table3", share="share1", schema="default")
+    )
+    rest_client.remove_sharing_capabilities_header()
+    assert response.delta_table_version > 1
+    assert response.protocol == Protocol(min_reader_version=1)
+    assert response.metadata == Metadata(
+        id="7ba6d727-a578-4234-a138-953f790b427c",
+        format=Format(provider="parquet", options={}),
+        schema_string=(
+            '{"type":"struct","fields":['
+            '{"name":"eventTime","type":"timestamp","nullable":true,"metadata":{}},'
+            '{"name":"date","type":"date","nullable":true,"metadata":{}},'
+            '{"name":"type","type":"string","nullable":true,"metadata":{}}'
+            "]}"
+        ),
+        partition_columns=["date"],
+    )
+
+
+@pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
+def test_query_table_metadata_with_dv_cm_partitioned_delta(
+    rest_client: DataSharingRestClient,
+):
+    rest_client.set_sharing_capabilities_header()
+    response = rest_client.query_table_metadata(
+        Table(name="dv_and_cm_table", share="share8", schema="default")
+    )
+    rest_client.remove_sharing_capabilities_header()
+    assert response.delta_table_version > 1
+    assert response.protocol == Protocol(
+        min_reader_version=3,
+        min_writer_version=7,
+        reader_features=['deletionVectors', 'columnMapping'],
+        writer_features=['deletionVectors', 'invariants', 'columnMapping', 'changeDataFeed'],
+    )
+    assert response.metadata == Metadata(
+        id="88033a32-ec3c-4592-a606-9b58e2dc245d",
+        format=Format(provider="parquet", options={}),
+        schema_string=(
+            '{"type":"struct","fields":['
+            '{"name":"id","type":"long","nullable":false,"metadata":{'
+                '"delta.columnMapping.id":1,'
+                '"delta.columnMapping.physicalName":"col-62f51670-2c22-4bad-a172-c453ddf09673"'
+            '}},'
+            '{"name":"rand","type":"integer","nullable":false,"metadata":{'
+                '"delta.columnMapping.id":2,'
+                '"delta.columnMapping.physicalName":"col-c985ad35-5524-4e86-89b0-47d6b9012fce"'
+            '}},'
+            '{"name":"partition_col","type":"integer","nullable":false,"metadata":{'
+                '"delta.columnMapping.id":3,'
+                '"delta.columnMapping.physicalName":"col-0bd4d7ce-c925-4748-9259-c03586b29b63"'
+            '}}'
+            "]}"
+        ),
+        partition_columns=["partition_col"],
+        configuration={
+            'delta.columnMapping.maxColumnId': '3',
+            'delta.columnMapping.mode': 'name',
+            'delta.enableChangeDataFeed': 'true',
+            'delta.enableDeletionVectors': 'true',
+        },
+        created_time=1721350003845,
     )
 
 


### PR DESCRIPTION
This PR sets the capabilities header when querying table metadata. The delta protocol and metadata are parsed in a backwards-compatible fashion. Users can also explicitly set `use_delta_format` to False in case there are any old behaviors they need to keep using.