### PR TITLE
Fix RemoteDeltaLogSuite failure

### DIFF
--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -41,6 +41,7 @@ class TestDeltaSharingClient(
     timeoutInSeconds: Int = 120,
     numRetries: Int = 10,
     maxRetryDuration: Long = Long.MaxValue,
+    retrySleepInterval: Long = 1000,
     sslTrustAll: Boolean = false,
     forStreaming: Boolean = false,
     responseFormat: String = DeltaSharingOptions.RESPONSE_FORMAT_PARQUET,

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -39,7 +39,7 @@ import io.delta.sharing.spark.TestDeltaSharingClient.TESTING_TIMESTAMP
 class TestDeltaSharingClient(
     profileProvider: DeltaSharingProfileProvider = new TestDeltaSharingProfileProvider,
     timeoutInSeconds: Int = 120,
-    numRetries: Int = 10,
+    numRetries: Int = 3,
     maxRetryDuration: Long = Long.MaxValue,
     retrySleepInterval: Long = 1000,
     sslTrustAll: Boolean = false,


### PR DESCRIPTION
TestDeltaSharingClient is missing the additional parameter `retrySleepInterval` from PR: https://github.com/delta-io/delta-sharing/pull/653
