### PR TITLE
refactor: Resolve lint errors in python release script.

### DIFF
--- a/dev/python_release.sh
+++ b/dev/python_release.sh
@@ -1,31 +1,32 @@
-#!/bin/bash -e -pipe
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Switch to the project root directory
-cd $( dirname $0 )
-cd ..
+pushd "$(dirname "$0")/.."
 
 # Clean existing artifacts
-cd python
+pushd python
 python3 setup.py clean --all
 rm -rf delta_sharing.egg-info dist
-cd ..
+popd
 
 printf "Please type the python release version: "
-read VERSION
-echo $VERSION
+read -r VERSION
+echo "$VERSION"
 
 # Update the Python connector version
-sed -i '' "s/__version__ = \".*\"/__version__ = \"$VERSION\"/g"  python/delta_sharing/version.py
-git add python/delta_sharing/version.py
+sed -i'' "s/^__version__ = \".*\"$/__version__ = \"$VERSION\"/" ./python/delta_sharing/version.py
+git add ./python/delta_sharing/version.py
 # Use --allow-empty so that we can re-run this script even if the Python connector version has been updated
 git commit -m "Update Python connector version to $VERSION" --allow-empty
 
 # This creates a lightweight tag that points to the current commit.
-git tag py-v$VERSION
+git tag "py-v$VERSION"
 
 # Generate Python artifacts
-cd python/
+pushd python
 python3 setup.py sdist bdist_wheel
-cd ..
+popd
 
 echo "=== Generated all release artifacts ==="
+popd


### PR DESCRIPTION
Resolved some `shellcheck` warning/errors, and made the script more portable.
cc: @PatrickJin-db 