### PR TITLE
Update listAllTables test with timestampntz_cdf_table

### DIFF
--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -178,7 +178,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Table(name = "table_with_cm_name", schema = "default", share = "share8"),
         Table(name = "table_with_cm_id", schema = "default", share = "share8"),
         Table(name = "deletion_vectors_with_dvs_dv_property_on", schema = "default", share = "share8"),
-        Table(name = "dv_and_cm_table", schema = "default", share = "share8")
+        Table(name = "dv_and_cm_table", schema = "default", share = "share8"),
+        Table(name = "timestampntz_cdf_table", schema = "default", share = "share8")
       )
       assert(expected == client.listAllTables().toSet)
     } finally {


### PR DESCRIPTION
This table was added for python connector timestampntz support but the corresponding scala client test was not updated.