### PR TITLE
Upgrade Github workflow to use higher ubuntu version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: Build and Test
 on: [push, pull_request, workflow_dispatch]
 jobs:
   build-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       SPARK_LOCAL_IP: localhost
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -28,7 +28,7 @@ jobs:
       - run: ./build/sbt test
 
   python:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-kernel-wheels.yml
+++ b/.github/workflows/build-kernel-wheels.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04, macos-latest, windows-latest]
         python-version: [3.8]
         arch: [x86_64, arm64]
         exclude:


### PR DESCRIPTION
Ubuntu-20.04 is being deprecated in Github workflow. See https://github.com/actions/runner-images/issues/11101