### PR TITLE
Add Ubuntu 22.04 to python wheel build workflow

### DIFF
--- a/.github/workflows/build-kernel-wheels.yml
+++ b/.github/workflows/build-kernel-wheels.yml
@@ -21,7 +21,9 @@ jobs:
         exclude:
           - os: ubuntu-latest
             arch: arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
+            arch: arm64
+          - os: ubuntu-22.04
             arch: arm64
           - os: windows-latest
             arch: arm64
@@ -67,8 +69,15 @@ jobs:
           maturin build --release
         shell: bash
 
-      - name: Build wheel (x86_64 Linux Ubuntu 20.04)
-        if: matrix.os == 'ubuntu-20.04'
+      - name: Build wheel (x86_64 Linux Ubuntu 24.04)
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          cd python/delta-kernel-rust-sharing-wrapper
+          maturin build --release
+        shell: bash
+
+      - name: Build wheel (x86_64 Linux Ubuntu 22.04)
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           cd python/delta-kernel-rust-sharing-wrapper
           maturin build --release

--- a/.github/workflows/build-kernel-wheels.yml
+++ b/.github/workflows/build-kernel-wheels.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04, ubuntu-22.04, macos-latest, windows-latest]
         python-version: [3.8]
         arch: [x86_64, arm64]
         exclude:


### PR DESCRIPTION
Add Ubuntu 22.04 to python wheel build workflow, as plenty of DBR versions are still using 22.04, e.g. https://docs.databricks.com/aws/en/release-notes/runtime/15.4lts#system-environment 