### PR TITLE
Adding queryParamsHashId into tablePath for Snapshot/CDF/Streaming queries

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -101,6 +101,9 @@ object ConfUtils {
   val STRUCTURAL_SCHEMA_MATCH_CONF = "spark.delta.sharing.client.useStructuralSchemaMatch"
   val STRUCTURAL_SCHEMA_MATCH_DEFAULT = "false"
 
+  val SPARK_PARQUET_IO_CACHE_CONF = "spark.delta.sharing.client.sparkParquetIOCache.enabled"
+  val SPARK_PARQUET_IO_CACHE_DEFAULT = "false"
+
   def getProxyConfig(conf: Configuration): Option[ProxyConfig] = {
     val proxyHost = conf.get(PROXY_HOST, null)
     val proxyPortAsString = conf.get(PROXY_PORT, null)
@@ -309,6 +312,16 @@ object ConfUtils {
 
   def structuralSchemaMatchingEnabled(conf: SQLConf): Boolean =
     conf.getConfString(STRUCTURAL_SCHEMA_MATCH_CONF, STRUCTURAL_SCHEMA_MATCH_DEFAULT).toBoolean
+
+  def sparkParquetIOCacheEnabled(conf: Configuration): Boolean = {
+    conf.getBoolean(
+      SPARK_PARQUET_IO_CACHE_CONF, SPARK_PARQUET_IO_CACHE_DEFAULT.toBoolean)
+  }
+
+  def sparkParquetIOCacheEnabled(conf: SQLConf): Boolean = {
+    conf.getConfString(
+      SPARK_PARQUET_IO_CACHE_CONF, SPARK_PARQUET_IO_CACHE_DEFAULT).toBoolean
+  }
 
   private def toTimeInSeconds(timeStr: String, conf: String): Int = {
     val timeInSeconds = JavaUtils.timeStringAs(timeStr, TimeUnit.SECONDS)

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -770,11 +770,7 @@ case class DeltaSharingSource(
     val filteredActions = fileActions.filter{ indexedFile => indexedFile.getFileAction != null }
 
     if (options.readChangeFeed) {
-      return createCDFDataFrame(
-        filteredActions,
-        lastQueryTimestamp,
-        urlExpirationTimestamp
-      )
+      return createCDFDataFrame(filteredActions, lastQueryTimestamp, urlExpirationTimestamp)
     }
 
     createDataFrame(filteredActions, lastQueryTimestamp, urlExpirationTimestamp)

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.types.StructType
 
 import io.delta.sharing.client.model.{AddCDCFile, AddFile, AddFileForCDF, DeltaTableFiles, FileAction, RemoveFile}
 import io.delta.sharing.client.util.ConfUtils
-import io.delta.sharing.spark.util.{QueryUtils, SchemaUtils}
+import io.delta.sharing.spark.util.SchemaUtils
 
 /**
  * A case class to help with `Dataset` operations regarding Offset indexing, representing a
@@ -764,17 +764,15 @@ case class DeltaSharingSource(
     // version.
     val filteredActions = fileActions.filter{ indexedFile => indexedFile.getFileAction != null }
 
-    val queryParamsHashId = QueryUtils.getQueryParamsHashId(startVersion, startIndex, endOffset)
     if (options.readChangeFeed) {
       return createCDFDataFrame(
         filteredActions,
         lastQueryTimestamp,
-        urlExpirationTimestamp,
-        queryParamsHashId
+        urlExpirationTimestamp
       )
     }
 
-    createDataFrame(filteredActions, lastQueryTimestamp, urlExpirationTimestamp, queryParamsHashId)
+    createDataFrame(filteredActions, lastQueryTimestamp, urlExpirationTimestamp)
   }
 
   /**
@@ -798,24 +796,12 @@ case class DeltaSharingSource(
       add.id -> add.url
     }.toMap
 
-    // For streaming queries, we return a DataFrame.
-    // The FileIndex here is a one-time use object to help read Parquet contents.
     val params = new RemoteDeltaFileIndexParams(
       spark, initSnapshot, deltaLog.client.getProfileProvider, Some(queryParamsHashId))
     val fileIndex = new RemoteDeltaBatchFileIndex(params, addFilesList)
 
-    val tablePathWithParams = if (ConfUtils.sparkParquetIOCacheEnabled(spark.sessionState.conf)) {
-      // Ensure different query shapes against the same table have distinct entries
-      // in the pre-signed URL cache.
-      QueryUtils.getTablePathWithIdSuffix(
-        params.path.toString, params.queryParamsHashId.get
-      )
-    } else {
-      params.path.toString
-    }
-
     CachedTableManager.INSTANCE.register(
-      tablePathWithParams,
+      params.path.toString,
       idToUrl,
       Seq(new WeakReference(fileIndex)),
       params.profileProvider,
@@ -848,8 +834,7 @@ case class DeltaSharingSource(
   private def createCDFDataFrame(
       indexedFiles: Seq[IndexedFile],
       lastQueryTimestamp: Long,
-      urlExpirationTimestamp: Option[Long],
-      queryParamsHashId: String): DataFrame = {
+      urlExpirationTimestamp: Option[Long]): DataFrame = {
     val addFiles = ArrayBuffer[AddFileForCDF]()
     val cdfFiles = ArrayBuffer[AddCDCFile]()
     val removeFiles = ArrayBuffer[RemoveFile]()
@@ -866,8 +851,7 @@ case class DeltaSharingSource(
       new RemoteDeltaFileIndexParams(
         spark,
         initSnapshot,
-        deltaLog.client.getProfileProvider,
-        Some(queryParamsHashId)
+        deltaLog.client.getProfileProvider
       ),
       schema.fields.map(f => f.name),
       addFiles.toSeq,

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -766,7 +766,7 @@ case class DeltaSharingSource(
 
     // For streaming queries, build the query parameters hash using the start/end version.
     // All the files between start and end version are cached for a tablePath.
-    val queryParamsHashId = QueryUtils.getQueryParamsHashId(startVersion, startIndex, endOffset)
+    val queryParamsHashId = QueryUtils.getQueryParamsHashId(startVersion, endOffset)
 
     if (options.readChangeFeed) {
       // Streaming CDF

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -798,9 +798,14 @@ case class DeltaSharingSource(
       add.id -> add.url
     }.toMap
 
+    // For streaming queries, we return a DataFrame.
+    // The FileIndex here is a one-time use object to help read Parquet contents.
     val params = new RemoteDeltaFileIndexParams(
       spark, initSnapshot, deltaLog.client.getProfileProvider, Some(queryParamsHashId))
     val fileIndex = new RemoteDeltaBatchFileIndex(params, addFilesList)
+
+    // Ensure different query shapes against the same table have distinct entries
+    // in the pre-signed URL cache.
     val tablePathWithParams = QueryUtils.getTablePathWithIdSuffix(
       params.path.toString, params.queryParamsHashId.get
     )

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
@@ -107,6 +107,8 @@ object DeltaSharingCDFReader {
     refs.append(new WeakReference(fileIndex3))
     dfs.append(scanIndex(fileIndex3, schema, isStreaming))
 
+    // Ensure different query shapes against the same table have distinct entries
+    // in the pre-signed URL cache.
     val tablePathWithParams = QueryUtils.getTablePathWithIdSuffix(
       params.path.toString, params.queryParamsHashId.get
     )

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
@@ -23,6 +23,7 @@ import scala.collection.mutable.ListBuffer
 import org.apache.spark.delta.sharing.{CachedTableManager, TableRefreshResult}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, DeltaSharingScanUtils, Row, SparkSession, SQLContext}
+import org.apache.spark.sql.execution.LogicalRDD
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.sources.{BaseRelation, Filter, PrunedFilteredScan}

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -41,10 +41,10 @@ import io.delta.sharing.spark.util.QueryUtils
  * The `queryParamsHashId` is used to distinguish queries that share the same table path.
  * For streaming and CDF queries, all file actions are retrieved and cached from the server,
  * so `queryParamsHashId` only includes the start and end versions.
- * For normal queries, different Parquet files are retrieved and cached based on filters,
+ * For snapshot queries, different Parquet files are retrieved and cached based on filters,
  * resulting in unique `queryParamsHashId` values for each `FileIndex.listFiles` call.
  * Therefore, `queryParamsHashId` here is `Some()` for streaming and CDF queries, and `None`
- * for normal queries. For normal queries, the `queryParamsHashId` is constructed during
+ * for snapshot queries. For snapshot queries, the `queryParamsHashId` is constructed during
  * `listFiles` calls.
  */
 private[sharing] case class RemoteDeltaFileIndexParams(
@@ -193,10 +193,6 @@ private[sharing] case class RemoteDeltaSnapshotFileIndex(
   // Retrieves and caches all files for a version of the table.
   override def inputFiles: Array[String] = {
     val queryParamsHashId = QueryUtils.getQueryParamsHashId(
-      partitionFiltersString = "",
-      dataFiltersString = "",
-      jsonPredicateHints = "",
-      limitHint = "",
       version = params.snapshotAtAnalysis.version
     )
     params.snapshotAtAnalysis.filesForScan(Nil, None, None, this, queryParamsHashId)

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -204,12 +204,11 @@ private[sharing] case class RemoteDeltaSnapshotFileIndex(
   override def listFiles(
       partitionFilters: Seq[Expression],
       dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
-    val jsonPredicateHints = convertToJsonPredicate(partitionFilters, dataFilters)
     val (files, queryParamsHashId) =
       params.snapshotAtAnalysis.filesForScan(
         partitionFilters ++ dataFilters,
         limitHint,
-        jsonPredicateHints,
+        convertToJsonPredicate(partitionFilters, dataFilters),
         this
       )
     makePartitionDirectories(files, queryParamsHashId)

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -73,6 +73,7 @@ private[sharing] abstract class RemoteDeltaFileIndexBase(
       } else {
         params.profileProvider.getCustomTablePath(params.path.toString)
       }
+
     DeltaSharingFileSystem.encode(tablePathWithParams, f)
   }
 

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -25,7 +25,14 @@ import org.apache.spark.sql.execution.datasources.{FileIndex, PartitionDirectory
 import org.apache.spark.sql.types.{DataType, StructType}
 
 import io.delta.sharing.client.{DeltaSharingFileSystem, DeltaSharingProfileProvider}
-import io.delta.sharing.client.model.{AddCDCFile, AddFile, AddFileForCDF, CDFColumnInfo, FileAction, RemoveFile}
+import io.delta.sharing.client.model.{
+  AddCDCFile,
+  AddFile,
+  AddFileForCDF,
+  CDFColumnInfo,
+  FileAction,
+  RemoveFile
+}
 import io.delta.sharing.client.util.{ConfUtils, JsonUtils}
 import io.delta.sharing.filters.{AndOp, BaseOp, OpConverter}
 import io.delta.sharing.spark.util.QueryUtils

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -109,11 +109,7 @@ private[sharing] class RemoteDeltaLog(
       )
     }
 
-    val params = new RemoteDeltaFileIndexParams(
-      spark,
-      snapshotToUse,
-      client.getProfileProvider
-    )
+    val params = new RemoteDeltaFileIndexParams(spark, snapshotToUse, client.getProfileProvider)
     val fileIndex = new RemoteDeltaSnapshotFileIndex(params, None)
     if (ConfUtils.limitPushdownEnabled(spark.sessionState.conf)) {
       DeltaSharingLimitPushDown.setup(spark)

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -29,14 +29,28 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DeltaSharingScanUtils, Encoder, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Cast, Expression, Literal, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{
+  And,
+  Attribute,
+  Cast,
+  Expression,
+  Literal,
+  SubqueryExpression
+}
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 
 import io.delta.sharing.client.{DeltaSharingClient, DeltaSharingRestClient}
-import io.delta.sharing.client.model.{AddFile, CDFColumnInfo, DeltaTableMetadata, Metadata, Protocol, Table => DeltaSharingTable}
+import io.delta.sharing.client.model.{
+  AddFile,
+  CDFColumnInfo,
+  DeltaTableMetadata,
+  Metadata,
+  Protocol,
+  Table => DeltaSharingTable
+}
 import io.delta.sharing.client.util.ConfUtils
 import io.delta.sharing.spark.perf.DeltaSharingLimitPushDown
 import io.delta.sharing.spark.util.{QueryUtils, SchemaUtils}

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -279,7 +279,7 @@ class RemoteSnapshot(
       limitHint: Option[Long],
       jsonPredicateHints: Option[String],
       fileIndex: RemoteDeltaSnapshotFileIndex,
-      queryParamsHashId: Option[String]): Seq[AddFile] = {
+      queryParamsHashId: String): Seq[AddFile] = {
     implicit val enc = RemoteDeltaLog.addFileEncoder
 
     val partitionFilters = filters.flatMap { filter =>
@@ -297,15 +297,16 @@ class RemoteSnapshot(
       logDebug(s"Sending predicates $predicates to the server")
     }
 
-    val tablePathWithParams = if (ConfUtils.sparkParquetIOCacheEnabled(spark.sessionState.conf)) {
-      // Ensure different query shapes against the same table have distinct entries
-      // in the pre-signed URL cache.
-      QueryUtils.getTablePathWithIdSuffix(
-        fileIndex.params.path.toString, queryParamsHashId.getOrElse("")
-      )
-    } else {
-      fileIndex.params.path.toString
-    }
+    val tablePathWithParams =
+      if (ConfUtils.sparkParquetIOCacheEnabled(spark.sessionState.conf)) {
+        // Ensure different query shapes against the same table have distinct entries
+        // in the pre-signed URL cache.
+        QueryUtils.getTablePathWithIdSuffix(
+          fileIndex.params.path.toString, queryParamsHashId
+        )
+      } else {
+        fileIndex.params.path.toString
+      }
 
     val remoteFiles = {
       val implicits = spark.implicits

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -298,6 +298,8 @@ class RemoteSnapshot(
       logDebug(s"Sending predicates $predicates to the server")
     }
 
+    // Ensure different query shapes against the same table have distinct entries
+    // in the pre-signed URL cache.
     val tablePathWithParams = QueryUtils.getTablePathWithIdSuffix(
       fileIndex.params.path.toString, queryParamsHashId.getOrElse("")
     )

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -258,7 +258,7 @@ class RemoteSnapshot(
       limitHint: Option[Long],
       jsonPredicateHints: Option[String],
       fileIndex: RemoteDeltaSnapshotFileIndex
-      ): (Seq[AddFile], String) = {
+    ): (Seq[AddFile], String) = {
     implicit val enc = RemoteDeltaLog.addFileEncoder
 
     val partitionFilters = filters.flatMap { filter =>

--- a/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
@@ -24,7 +24,9 @@ import io.delta.sharing.spark.DeltaSharingSourceOffset
 
 object QueryUtils {
 
-  // Get a query hash id based on the query parameters for snapshot queries
+  // Get a query hash id based on the query parameters for regular queries
+  // limitHint is Option(), so it can be None
+  // version is always present.
   def getQueryParamsHashId(
       partitionFiltersString: String,
       dataFiltersString: String,
@@ -39,6 +41,15 @@ object QueryUtils {
   // Get a query hash id based on the query parameters for CDF queries
   def getQueryParamsHashId(cdfOptions: Map[String, String]): String = {
     Hashing.sha256().hashString(cdfOptions.toString, UTF_8).toString
+  }
+
+  // Get a query hash id based on the query parameters for streaming queries
+  def getQueryParamsHashId(
+     startVersion: Long,
+     startIndex: Long,
+     endOffset: DeltaSharingSourceOffset): String = {
+    val fullQueryString = s"${startVersion}_${startIndex}_${endOffset.toString}"
+    Hashing.sha256().hashString(fullQueryString, UTF_8).toString
   }
 
   // Add id as a suffix to table path, to uniquely identify a query

--- a/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
@@ -44,9 +44,8 @@ object QueryUtils {
   // Get a query hash id based on the query parameters for streaming queries
   def getQueryParamsHashId(
      startVersion: Long,
-     startIndex: Long,
      endOffset: DeltaSharingSourceOffset): String = {
-    val fullQueryString = s"${startVersion}_${startIndex}_${endOffset.toString}"
+    val fullQueryString = s"${startVersion}_${endOffset.toString}"
     Hashing.sha256().hashString(fullQueryString, UTF_8).toString
   }
 

--- a/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
@@ -24,14 +24,12 @@ import io.delta.sharing.spark.DeltaSharingSourceOffset
 
 object QueryUtils {
 
-  // Get a query hash id based on the query parameters for regular queries
-  // limitHint is Option(), so it can be None
-  // version is always present.
+  // Get a query hash id based on the query parameters for snapshot queries
   def getQueryParamsHashId(
-      partitionFiltersString: String,
-      dataFiltersString: String,
-      jsonPredicateHints: String,
-      limitHint: String,
+      partitionFiltersString: String = "",
+      dataFiltersString: String = "",
+      jsonPredicateHints: String = "",
+      limitHint: String = "",
       version: Long): String = {
     val fullQueryString = s"${partitionFiltersString}_${dataFiltersString}_" +
       s"${jsonPredicateHints}_${limitHint}_${version}"

--- a/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
@@ -24,9 +24,7 @@ import io.delta.sharing.spark.DeltaSharingSourceOffset
 
 object QueryUtils {
 
-  // Get a query hash id based on the query parameters for regular queries
-  // limitHint is Option(), so it can be None
-  // version is always present.
+  // Get a query hash id based on the query parameters for snapshot queries
   def getQueryParamsHashId(
       partitionFiltersString: String,
       dataFiltersString: String,
@@ -41,15 +39,6 @@ object QueryUtils {
   // Get a query hash id based on the query parameters for CDF queries
   def getQueryParamsHashId(cdfOptions: Map[String, String]): String = {
     Hashing.sha256().hashString(cdfOptions.toString, UTF_8).toString
-  }
-
-  // Get a query hash id based on the query parameters for streaming queries
-  def getQueryParamsHashId(
-     startVersion: Long,
-     startIndex: Long,
-     endOffset: DeltaSharingSourceOffset): String = {
-    val fullQueryString = s"${startVersion}_${startIndex}_${endOffset.toString}"
-    Hashing.sha256().hashString(fullQueryString, UTF_8).toString
   }
 
   // Add id as a suffix to table path, to uniquely identify a query

--- a/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
@@ -20,19 +20,18 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 import com.google.common.hash.Hashing
 
-import io.delta.sharing.spark.DeltaSharingSourceOffset
-
 object QueryUtils {
 
   // Get a query hash id based on the query parameters for snapshot queries
   def getQueryParamsHashId(
-      partitionFiltersString: String = "",
-      dataFiltersString: String = "",
-      jsonPredicateHints: String = "",
-      limitHint: String = "",
+      predicates: Seq[String],
+      limitHint: Option[Long],
+      jsonPredicateHints: Option[String],
       version: Long): String = {
-    val fullQueryString = s"${partitionFiltersString}_${dataFiltersString}_" +
-      s"${jsonPredicateHints}_${limitHint}_${version}"
+    val predicateStr = predicates.mkString(",")
+    val limitStr = limitHint.map(_.toString).getOrElse("none")
+    val jsonHintsStr = jsonPredicateHints.getOrElse("none")
+    val fullQueryString = s"${predicateStr}_${jsonHintsStr}_${limitStr}_${version}"
     Hashing.sha256().hashString(fullQueryString, UTF_8).toString
   }
 
@@ -44,8 +43,8 @@ object QueryUtils {
   // Get a query hash id based on the query parameters for streaming queries
   def getQueryParamsHashId(
      startVersion: Long,
-     endOffset: DeltaSharingSourceOffset): String = {
-    val fullQueryString = s"${startVersion}_${endOffset.toString}"
+     endVersion: Long): String = {
+    val fullQueryString = s"${startVersion}_${endVersion}"
     Hashing.sha256().hashString(fullQueryString, UTF_8).toString
   }
 

--- a/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
@@ -41,7 +41,7 @@ object QueryUtils {
     Hashing.sha256().hashString(cdfOptions.toString, UTF_8).toString
   }
 
-  // Get a query hash id based on the query parameters for CDF streaming queries
+  // Get a query hash id based on the query parameters for streaming queries
   def getQueryParamsHashId(
      startVersion: Long,
      startIndex: Long,

--- a/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark.util
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+import com.google.common.hash.Hashing
+
+import io.delta.sharing.spark.DeltaSharingSourceOffset
+
+object QueryUtils {
+
+  // Get a query hash id based on the query parameters for regular queries
+  def getQueryParamsHashId(
+      partitionFiltersString: String,
+      dataFiltersString: String,
+      jsonPredicateHints: String,
+      limitHint: String,
+      version: Long): String = {
+    val fullQueryString = s"${partitionFiltersString}_${dataFiltersString}_" +
+      s"${jsonPredicateHints}_${limitHint}_${version}"
+    Hashing.sha256().hashString(fullQueryString, UTF_8).toString
+  }
+
+  // Get a query hash id based on the query parameters for CDF queries
+  def getQueryParamsHashId(cdfOptions: Map[String, String]): String = {
+    Hashing.sha256().hashString(cdfOptions.toString, UTF_8).toString
+  }
+
+  // Get a query hash id based on the query parameters for CDF streaming queries
+  def getQueryParamsHashId(
+     startVersion: Long,
+     startIndex: Long,
+     endOffset: DeltaSharingSourceOffset): String = {
+    val fullQueryString = s"${startVersion}_${startIndex}_${endOffset.toString}"
+    Hashing.sha256().hashString(fullQueryString, UTF_8).toString
+  }
+
+  // Add id as a suffix to table path, to uniquely identify a query
+  def getTablePathWithIdSuffix(tablePath: String, id: String): String = {
+    s"${tablePath}_${id}"
+  }
+}

--- a/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/util/QueryUtils.scala
@@ -25,6 +25,8 @@ import io.delta.sharing.spark.DeltaSharingSourceOffset
 object QueryUtils {
 
   // Get a query hash id based on the query parameters for regular queries
+  // limitHint is Option(), so it can be None
+  // version is always present.
   def getQueryParamsHashId(
       partitionFiltersString: String,
       dataFiltersString: String,

--- a/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -74,6 +74,7 @@ class CachedTableManager(
   }
 
   // Returning how many entries are in the cache.
+  // This method is mainly for testing purpose.
   def size(): Int = {
     cache.size
   }

--- a/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -73,6 +73,11 @@ class CachedTableManager(
     thread
   }
 
+  // Returning how many entries are in the cache.
+  def size(): Int = {
+    cache.size
+  }
+
   def isValidUrlExpirationTime(expiration: Option[Long]): Boolean = {
     // refreshThresholdMs is the buffer time for the refresh RPC.
     // It could also help the client from keeping refreshing endlessly.

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -577,3 +577,10 @@ class DeltaSharingSourceSuite extends QueryTest
     }
   }
 }
+
+class DeltaSharingSourceWithCacheSuite extends DeltaSharingSourceSuite {
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set("spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
+  }
+}

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -578,7 +578,7 @@ class DeltaSharingSourceSuite extends QueryTest
   }
 }
 
-class DeltaSharingSourceWithCacheSuite extends DeltaSharingSourceSuite {
+class DeltaSharingSourceWithParquetIOCacheEnabledSuite extends DeltaSharingSourceSuite {
   override def beforeAll(): Unit = {
     super.beforeAll()
     spark.conf.set("spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -567,7 +567,7 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
   }
 }
 
-class DeltaSharingWithCacheSuite extends DeltaSharingSuite {
+class DeltaSharingWithParquetIOCacheEnabledSuite extends DeltaSharingSuite {
   override def beforeAll(): Unit = {
     super.beforeAll()
     spark.conf.set("spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -566,3 +566,10 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
     }
   }
 }
+
+class DeltaSharingWithCacheSuite extends DeltaSharingSuite {
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set("spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
+  }
+}

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -85,10 +85,10 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     // The client should get json for jsonPredicateHints.
     val expectedJson =
       """{"op":"equal",
-        |"children":[
-        |  {"op":"column","name":"id","valueType":"int"},
-        |  {"op":"literal","value":"23","valueType":"int"}]
-        |}""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")
+         |"children":[
+         |  {"op":"column","name":"id","valueType":"int"},
+         |  {"op":"literal","value":"23","valueType":"int"}]
+         |}""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")
 
     fileIndex.listFiles(Seq(sqlEq), Seq.empty)
     assert(TestDeltaSharingClient.limits === Seq(2L))
@@ -349,7 +349,8 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     // CDF queries cache all file actions for a table from a start version to an end version.
     // No need to count filters into queryParamsHashId.
     val queryParamsHashId = QueryUtils.getQueryParamsHashId(
-      Map("startingVersion" -> "0", "endingVersion" -> "100")
+      Map(DeltaSharingOptions.CDF_START_VERSION -> "0",
+        DeltaSharingOptions.CDF_END_VERSION -> "100")
     )
     val params = RemoteDeltaFileIndexParams(
       spark, snapshot, client.getProfileProvider, Some(queryParamsHashId))

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -320,13 +320,7 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     assert(listFilesResult(0).files(2).getPath.toString == s"delta-sharing:/${tablePath}/f3/0")
 
     // Check delta sharing path for inputFiles
-    val queryParamsHashId2 = QueryUtils.getQueryParamsHashId(
-      "",
-      "",
-      "",
-      "",
-      version.get
-    )
+    val queryParamsHashId2 = QueryUtils.getQueryParamsHashId(version = version.get)
     val tablePath2 = QueryUtils.getTablePathWithIdSuffix(
       fileIndex.params.profileProvider.getCustomTablePath(fileIndex.params.path.toString),
       queryParamsHashId2

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -423,7 +423,6 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     val startVersion = 1L
     val queryParamsHashId = QueryUtils.getQueryParamsHashId(
       startVersion = startVersion,
-      startIndex = 0L,
       endOffset = DeltaSharingSourceOffset(
         sourceVersion = startVersion,
         tableId = UUID.randomUUID().toString,

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -122,7 +122,14 @@ class TestDeltaSharingClient(
         AddFile("f3.parquet", "f3", Map.empty, 0, version = 1, timestamp = 1600000000L),
         AddFile("f4.parquet", "f4", Map.empty, 0, version = 1, timestamp = 1600000000L)
       ).take(limit.getOrElse(4L).toInt)
-    } else {
+    } else if (jsonPredicateHints.exists(_.contains("greaterThan"))) {
+      Seq(
+        AddFile("f1.parquet", "f1", Map.empty, 0),
+        AddFile("f2.parquet", "f2", Map.empty, 0),
+        AddFile("f3.parquet", "f3", Map.empty, 0)
+      ).take(limit.getOrElse(3L).toInt)
+    }
+    else {
       Seq(
         AddFile("f1.parquet", "f1", Map.empty, 0),
         AddFile("f2.parquet", "f2", Map.empty, 0),


### PR DESCRIPTION
This change updates the keying strategy of the existing pre-signed URL cache (which stores fileId -> fileUrl mappings) to account for different query shapes on the same table. Previously, the cache key only included the table path, so a new query with different parameters could overwrite existing cache entries. This update ensures correctness by incorporating the full query context into the cache key.

**Query Parameters by Query Type:**

**Snapshot Queries:**
- Filters
- Limit
- Table version

**Change Data Feed (CDF) Queries:**

- A Map[String, String] of CDF options, including:
  - Starting version
  - Ending version

Filters are excluded from the key, as files are fetched for the entire version range and filtered in memory. CDF queries also do not support limits.

**Streaming Queries:**

Streaming parquet files
- Starting version
- Ending version (If applicable)

Streaming CDF files
- Same as CDF queries

Similar to CDF, filters and limits are excluded from the key, since filtering is applied in memory after fetching all relevant files.

This update prevents cache collisions between distinct query shapes on the same table and ensures accurate file-to-URL resolution for all supported query types.