### PR TITLE
Fix logging when refreshRes.expirationTimestamp is None

### DIFF
--- a/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -203,8 +203,8 @@ class CachedTableManager(
       if (expirationTimestamp - System.currentTimeMillis() < refreshThresholdMs) {
         val refreshRes = customRefresher(refreshToken)
         logInfo(s"Refreshed urls during cache register with old expiration " +
-          s"${new java.util.Date(expirationTimestamp)}, " +
-          s"new expiration ${new java.util.Date(refreshRes.expirationTimestamp.get)}, " +
+          s"${new java.util.Date(expirationTimestamp)}, new expiration " +
+          s"${refreshRes.expirationTimestamp.map(new java.util.Date(_)).getOrElse("None")}, " +
           s"lines ${refreshRes.idToUrl.size}")
 
         if (isValidUrlExpirationTime(refreshRes.expirationTimestamp)) {


### PR DESCRIPTION
It is possible that refreshRes.expirationTimestamp is None. When it is None, None.get throws an exception and causing register to fail.