### PR TITLE
[Backport-1.2]: Parse Error Message in Client in EndStreamAction

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.SparkSession
 import io.delta.sharing.client.auth.{AuthConfig, AuthCredentialProviderFactory}
 import io.delta.sharing.client.model._
 import io.delta.sharing.client.util.{ConfUtils, JsonUtils, RetryUtils, UnexpectedHttpStatus}
-import io.delta.sharing.spark.MissingEndStreamActionException
+import io.delta.sharing.spark.{DeltaSharingServerException, MissingEndStreamActionException}
 
 /** An interface to fetch Delta metadata from remote server. */
 trait DeltaSharingClient {
@@ -1363,6 +1363,10 @@ object DeltaSharingRestClient extends Logging {
         logInfo(
           s"Successfully verified endStreamAction in the response" + queryIdForLogging
         )
+        if(lastEndStreamAction.errorMessage != null) {
+          throw new DeltaSharingServerException("Request failed during streaming response " +
+          s"with error message ${lastEndStreamAction.errorMessage}")
+        }
       case Some(false) =>
         logWarning(s"Client sets ${DELTA_SHARING_INCLUDE_END_STREAM_ACTION}=true in the " +
           s"header, but the server responded with the header set to false(" +

--- a/client/src/main/scala/io/delta/sharing/client/model.scala
+++ b/client/src/main/scala/io/delta/sharing/client/model.scala
@@ -128,7 +128,8 @@ private[sharing] case class Protocol(minReaderVersion: Int) extends Action {
 private[sharing] case class EndStreamAction(
     refreshToken: String,
     nextPageToken: String,
-    minUrlExpirationTimestamp: java.lang.Long)
+    minUrlExpirationTimestamp: java.lang.Long,
+    errorMessage: String = null)
   extends Action {
   override def wrap: SingleAction = SingleAction(endStreamAction = this)
 }

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
@@ -20,6 +20,8 @@ import org.apache.spark.sql.types.StructType
 
 class MissingEndStreamActionException(message: String) extends IllegalStateException(message)
 
+class DeltaSharingServerException(message: String) extends RuntimeException(message)
+
 object DeltaSharingErrors {
   def nonExistentDeltaSharingTable(tableId: String): Throwable = {
     new IllegalStateException(s"Delta sharing table ${tableId} doesn't exist. " +

--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -157,7 +157,8 @@ case class RemoveFile(
 case class EndStreamAction(
     refreshToken: String,
     nextPageToken: String,
-    minUrlExpirationTimestamp: java.lang.Long
+    minUrlExpirationTimestamp: java.lang.Long,
+    errorMessage: String = null
   ) extends Action {
   override def wrap: SingleAction = SingleAction(endStreamAction = this)
 }


### PR DESCRIPTION
### Purpose:
Add functionality to parse error endStreamAction within the open source client.

### Tests:
Add unit tests to ensure that error within EndStreamAction is properly parsed.

End to End Testing on 16.3 with branch 1.2
<img width="1364" alt="Screenshot 2025-05-06 at 3 32 56 PM" src="https://github.com/user-attachments/assets/b8f65c3d-fdb8-420c-a0bd-c17c74f265fa" />

