### PR TITLE
Use query parameter hash ID instead of timestamp suffix for table path

### DIFF
--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -807,7 +807,7 @@ case class DeltaSharingSource(
         // Ensure different query shapes against the same table have distinct entries
         // in the pre-signed URL cache.
         QueryUtils.getTablePathWithIdSuffix(
-          params.path.toString, params.queryParamsHashId.get
+          params.path.toString, queryParamsHashId
         )
       } else {
         params.path.toString

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -29,28 +29,14 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DeltaSharingScanUtils, Encoder, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.{
-  And,
-  Attribute,
-  Cast,
-  Expression,
-  Literal,
-  SubqueryExpression
-}
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Cast, Expression, Literal, SubqueryExpression}
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 
 import io.delta.sharing.client.{DeltaSharingClient, DeltaSharingRestClient}
-import io.delta.sharing.client.model.{
-  AddFile,
-  CDFColumnInfo,
-  DeltaTableMetadata,
-  Metadata,
-  Protocol,
-  Table => DeltaSharingTable
-}
+import io.delta.sharing.client.model.{AddFile, CDFColumnInfo, DeltaTableMetadata, Metadata, Protocol, Table => DeltaSharingTable}
 import io.delta.sharing.client.util.ConfUtils
 import io.delta.sharing.spark.perf.DeltaSharingLimitPushDown
 import io.delta.sharing.spark.util.{QueryUtils, SchemaUtils}
@@ -169,9 +155,13 @@ private[sharing] object RemoteDeltaLog {
       schema = parsedPath.schema,
       share = parsedPath.share
     )
+    val updatedPath = new Path(
+      if (ConfUtils.sparkParquetIOCacheEnabled(SparkSession.active.sessionState.conf)) path
+      else path + getFormattedTimestampWithUUID
+    )
     new RemoteDeltaLog(
       deltaSharingTable,
-      new Path(path + getFormattedTimestampWithUUID),
+      updatedPath,
       client,
       initDeltaTableMetadata
     )

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -155,6 +155,8 @@ private[sharing] object RemoteDeltaLog {
       schema = parsedPath.schema,
       share = parsedPath.share
     )
+    // Use a clean path and add a query parameter suffix later,
+    // or append a timestamp UUID suffix to ensure the uniqueness of the table path.
     val updatedPath = new Path(
       if (ConfUtils.sparkParquetIOCacheEnabled(SparkSession.active.sessionState.conf)) path
       else path + getFormattedTimestampWithUUID

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -31,8 +31,8 @@ import org.apache.spark.sql.types.{
   StructType,
   TimestampType
 }
-import org.scalatest.time.SpanSugar._
 
+import io.delta.sharing.client.util.ConfUtils
 import io.delta.sharing.spark.TestUtils._
 
 class DeltaSharingSourceSuite extends QueryTest
@@ -121,8 +121,14 @@ class DeltaSharingSourceSuite extends QueryTest
       "ignoreDeletes" -> "true",
       "startingVersion" -> "latest"
     ))
-    // #share8.default.cdf_table_cdf_enabled_<yyyyMMdd_HHmmss>_<UUID>
-    assert(source.deltaLog.path.toString.split("_").size == 7)
+    if (ConfUtils.sparkParquetIOCacheEnabled(SparkSession.active.sessionState.conf)) {
+      // <profile>#share8.default.cdf_table_cdf_enabled
+      assert(source.deltaLog.path.toString.split("#")(1) == "share8.default.cdf_table_cdf_enabled")
+    }
+    else {
+      // <profile>#share8.default.cdf_table_cdf_enabled_<yyyyMMdd_HHmmss>_<UUID>
+      assert(source.deltaLog.path.toString.split("#")(1).split("_").size == 7)
+    }
     val latestOffset = source.latestOffset(null, source.getDefaultReadLimit)
     assert(latestOffset == null)
   }


### PR DESCRIPTION
This change removes the timestamp suffix from the table path, as it causes the path to differ for every query. To enable cache sharing across multiple queries on the same table, we now use a query parameter hash ID instead.