### PR TITLE
Fix Column compatibility issue with Spark 4.0

### DIFF
--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -18,21 +18,14 @@ package io.delta.sharing.spark
 
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{Column, SparkSession}
+import org.apache.spark.sql.{Column, DeltaSharingScanUtils, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{And, Cast, Expression, GenericInternalRow, Literal}
 import org.apache.spark.sql.execution.datasources.{FileIndex, PartitionDirectory}
 import org.apache.spark.sql.types.{DataType, StructType}
 
 import io.delta.sharing.client.{DeltaSharingFileSystem, DeltaSharingProfileProvider}
-import io.delta.sharing.client.model.{
-  AddCDCFile,
-  AddFile,
-  AddFileForCDF,
-  CDFColumnInfo,
-  FileAction,
-  RemoveFile
-}
+import io.delta.sharing.client.model.{AddCDCFile, AddFile, AddFileForCDF, CDFColumnInfo, FileAction, RemoveFile}
 import io.delta.sharing.client.util.{ConfUtils, JsonUtils}
 import io.delta.sharing.filters.{AndOp, BaseOp, OpConverter}
 import io.delta.sharing.spark.util.QueryUtils
@@ -127,7 +120,9 @@ private[sharing] abstract class RemoteDeltaFileIndexBase(
       params.spark.sessionState.conf.resolver,
       partitionFilters,
       params.spark.sessionState.conf.sessionLocalTimeZone)
-    new Column(rewrittenFilters.reduceLeftOption(And).getOrElse(Literal(true)))
+    DeltaSharingScanUtils.toColumn(
+      rewrittenFilters.reduceLeftOption(And).getOrElse(Literal(true))
+    )
   }
 
   // Converts the specified SQL expressions to a json predicate.


### PR DESCRIPTION
Depends on https://github.com/delta-io/delta-sharing/pull/712

Issue:
Caused by: NoSuchMethodError: 'void org.apache.spark.sql.Column.(org.apache.spark.sql.catalyst.expressions.Expression)'
https://github.com/delta-io/delta-sharing/blob/main/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala#L130

It used to be Expression, but now it is ColumnNode.
https://github.com/apache/spark/blob/98c44d0c10104f12821ae8a46a3873b0ffa5c8d3/sql/api/src/main/scala/org/apache/spark/sql/Column.scala#L140

Instead of using new Column, calling DeltaSharingScanUtils which uses class.apply