### PR TITLE
Fix misnamed field in endStreamAction in server model

### DIFF
--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -158,7 +158,7 @@ case class EndStreamAction(
     refreshToken: String,
     nextPageToken: String,
     minUrlExpirationTimestamp: java.lang.Long,
-    endStreamAction: String = null
+    errorMessage: String = null
   ) extends Action {
   override def wrap: SingleAction = SingleAction(endStreamAction = this)
 }


### PR DESCRIPTION
In the previous [PR](https://github.com/delta-io/delta-sharing/pull/711), the field for `errorMessage` was misnamed as `endStreamAction` in the server model. This is a fast follow to fix this change. This field is currently added in the server model to maintain consistency in the format of `EndStreamAction`, however it isn't actively used in any code path. See my comment from the original PR for more context:

> I have added the same field within the Server implementation. However due to the difference in [the way](https://github.com/delta-io/delta-sharing/blob/branch-1.2/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala#L613) the server process streaming requests, we need to figure whether we want to implement this for the open source server and the best way to do this. (Note, this implementation is backwards compatible, meaning we don't have to implement this for the open source server and the behavior with open server would stay the same)