### PR TITLE
[Backport-1.3]: Fix misnamed field in server endStreamAction

### DIFF
--- a/server/src/main/scala/io/delta/sharing/server/model.scala
+++ b/server/src/main/scala/io/delta/sharing/server/model.scala
@@ -158,7 +158,7 @@ case class EndStreamAction(
     refreshToken: String,
     nextPageToken: String,
     minUrlExpirationTimestamp: java.lang.Long,
-    endStreamAction: String = null
+    errorMessage: String = null
   ) extends Action {
   override def wrap: SingleAction = SingleAction(endStreamAction = this)
 }


### PR DESCRIPTION
When making the branch cut for 1.3. The implementation [PR](https://github.com/delta-io/delta-sharing/pull/711) for endStreamAction with error message was already merged in. However, the [PR](https://github.com/delta-io/delta-sharing/pull/715) to fix the field was not merged in. This is a backport to fix that misnamed field.

To also confirm. I have tested branch-1.3 on DBR 17.x. Here is the result. The error message is showing but it is a little different. Want to make sure this is okay since it seems to wrapped by a runtime exception.

![image](https://github.com/user-attachments/assets/83e5e64d-3d5f-4a09-9aa5-5b89c7350237)
