### PR TITLE
Handle race condition between a refresh thread and register threads

### DIFF
--- a/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -195,7 +195,7 @@ class CachedTableManager(
           case table: CachedTable =>
             handleCachedTableRefresh(tablePath, table)
           case table: QuerySpecificCachedTable =>
-            handleQuerySpecificCachedTableRefresh(tablePath, table)
+            handleQuerySpecificCachedTableRefresh(tablePath)
           case _ =>
             // We should never have a table that is not CachedTable or QuerySpecificCachedTable
             // Also, refresh happens in a background thread, throw an exception doesn't help.

--- a/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -325,11 +325,27 @@ class CachedTableManager(
                 logInfo(s"Removing table $tablePath as the pre-signed URL has expired.")
                 null
               } else {
-                querySpecificCachedTable
+                // Update query states
+                new QuerySpecificCachedTable(
+                  querySpecificCachedTable.expiration,
+                  querySpecificCachedTable.idToUrl,
+                  querySpecificCachedTable.lastAccess,
+                  querySpecificCachedTable.refreshToken,
+                  querySpecificCachedTable.refresher,
+                  validStates
+                )
               }
           }
         } else {
-          querySpecificCachedTable
+          // Update query states
+          new QuerySpecificCachedTable(
+            querySpecificCachedTable.expiration,
+            querySpecificCachedTable.idToUrl,
+            querySpecificCachedTable.lastAccess,
+            querySpecificCachedTable.refreshToken,
+            querySpecificCachedTable.refresher,
+            validStates
+          )
         }
 
       case _ =>

--- a/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -144,6 +144,19 @@ class CachedTableManager(
     cache.size
   }
 
+  // Returns the number of query states in the cache for a given table path.
+  // This method is mainly for testing purpose.
+  def getQueryStateSize(tablePath: String): Int = {
+    val cachedTable = cache.get(tablePath)
+    if (cachedTable == null) {
+      throw new IllegalStateException(s"table $tablePath was removed")
+    }
+    cachedTable match {
+      case table: QuerySpecificCachedTable => table.queryStates.size
+      case _ => 0
+    }
+  }
+
   def isValidUrlExpirationTime(expiration: Option[Long]): Boolean = {
     // refreshThresholdMs is the buffer time for the refresh RPC.
     // It could also help the client from keeping refreshing endlessly.
@@ -261,56 +274,68 @@ class CachedTableManager(
   }
 
   /** Refreshes a `QuerySpecificCachedTable` if necessary. */
-  private def handleQuerySpecificCachedTableRefresh(
-    tablePath: String,
-    querySpecificCachedTable: QuerySpecificCachedTable): Unit = {
-    // Filter out query states where at least one reference is still valid (not garbage collected).
-    val validStates = querySpecificCachedTable.queryStates.filter {
-      case (_, (refs, _)) => refs.exists(_.get != null)
-    }
+  private def handleQuerySpecificCachedTableRefresh(tablePath: String): Unit = {
+    // Use `computeIfPresent` to ensure atomicity of the operation and prevent interference
+    // with concurrent register threads.
+    cache.computeIfPresent(tablePath, (_, cachedTable) => cachedTable match {
+      case querySpecificCachedTable: QuerySpecificCachedTable =>
+        // Filter out query states where at least one reference is still valid (not garbage
+        // collected).
+        val validStates = querySpecificCachedTable.queryStates.filter {
+          case (_, (refs, _)) => refs.exists(_.get != null)
+        }
 
-    if (validStates.isEmpty) {
-      // If all the references are gone, we will remove the table from the cache.
-      logInfo(s"Removing table $tablePath as no valid query mappings remain.")
-      cache.remove(tablePath, querySpecificCachedTable)
-    } else if (
-      querySpecificCachedTable.expiration - System.currentTimeMillis() < refreshThresholdMs
-    ) {
-      // If the pre-signed URLs are going to expire, we will refresh them.
-      val (_, (_, refresherWrapper)) = validStates.head
-      try {
-        // Run the refresh function with the wrapper to get the new pre-signed URLs
-        val refreshRes = refresherWrapper(
-          querySpecificCachedTable.refreshToken,
-          querySpecificCachedTable.refresher
-        )
-        logDifferencesBetweenUrls(refreshRes.idToUrl, querySpecificCachedTable.idToUrl)
-
-        val newQuerySpecificCachedTable = new QuerySpecificCachedTable(
-          expiration =
-            if (isValidUrlExpirationTime(refreshRes.expirationTimestamp)) {
-              refreshRes.expirationTimestamp.get
-            } else {
-              preSignedUrlExpirationMs + System.currentTimeMillis()
-            },
-          idToUrl = refreshRes.idToUrl,
-          lastAccess = querySpecificCachedTable.lastAccess,
-          refreshToken = refreshRes.refreshToken,
-          refresher = querySpecificCachedTable.refresher,
-          queryStates = validStates
-        )
-        cache.replace(tablePath, querySpecificCachedTable, newQuerySpecificCachedTable)
-        logInfo(s"Updated pre-signed URLs for $tablePath with size ${refreshRes.idToUrl.size}, " +
-          s"validStates: ${validStates.size}.")
-      } catch {
-        case NonFatal(e) =>
-          logError(s"Failed to refresh pre-signed URLs for table $tablePath", e)
-          if (querySpecificCachedTable.expiration < System.currentTimeMillis()) {
-            logInfo(s"Removing table $tablePath as the pre-signed URL has expired.")
-            cache.remove(tablePath, querySpecificCachedTable)
+        if (validStates.isEmpty) {
+          // If all the references are gone, we will remove the table from the cache.
+          logInfo(s"Removing table $tablePath as no valid query mappings remain.")
+          null
+        } else if (
+          querySpecificCachedTable.expiration - System.currentTimeMillis() < refreshThresholdMs
+        ) {
+          // If the pre signed urls are going to expire, we will refresh them.
+          try {
+            val (_, (_, refresherWrapper)) = validStates.head
+            // Run the refresh function with the wrapper to get the new pre-signed URLs
+            val refreshRes = refresherWrapper(
+              querySpecificCachedTable.refreshToken,
+              querySpecificCachedTable.refresher
+            )
+            logDifferencesBetweenUrls(refreshRes.idToUrl, querySpecificCachedTable.idToUrl)
+            logInfo(
+              s"Updated pre-signed URLs for $tablePath with size ${refreshRes.idToUrl.size}, " +
+                s"validStates: ${validStates.size}."
+            )
+            new QuerySpecificCachedTable(
+              expiration =
+                if (isValidUrlExpirationTime(refreshRes.expirationTimestamp)) {
+                  refreshRes.expirationTimestamp.get
+                } else {
+                  preSignedUrlExpirationMs + System.currentTimeMillis()
+                },
+              idToUrl = refreshRes.idToUrl,
+              lastAccess = querySpecificCachedTable.lastAccess,
+              refreshToken = refreshRes.refreshToken,
+              refresher = querySpecificCachedTable.refresher,
+              queryStates = validStates
+            )
+          } catch {
+            case NonFatal(e) =>
+              logError(s"Failed to refresh pre-signed URLs for table $tablePath", e)
+              if (querySpecificCachedTable.expiration < System.currentTimeMillis()) {
+                logInfo(s"Removing table $tablePath as the pre-signed URL has expired.")
+                null
+              } else {
+                querySpecificCachedTable
+              }
           }
-      }
-    }
+        } else {
+          querySpecificCachedTable
+        }
+
+      case _ =>
+        logWarning(s"Unexpected table type for $tablePath. Expected QuerySpecificCachedTable.")
+        cachedTable
+    })
   }
 
   /** Returns `PreSignedUrl` from the cache. */

--- a/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
+++ b/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
@@ -325,17 +325,17 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
     val fileId = "file1"
     val url = "https://test.com/file1"
     val queryId = "query1"
-    
+
     val refresherWrapper: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => refresher(token)
-    
+
     val refresher: Option[String] => TableRefreshResult = _ =>
       TableRefreshResult(
         Map(fileId -> url), Some(System.currentTimeMillis() + preSignedUrlExpirationMs), None)
-    
+
     val profileProvider = createProfileProvider(queryId, refresherWrapper)
     val ref = new WeakReference[AnyRef](new Object())
-    
+
     val expectedExpiration = System.currentTimeMillis() + preSignedUrlExpirationMs
     manager.register(
       tablePath,
@@ -346,7 +346,7 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
       expectedExpiration,
       None
     )
-    
+
     val (retrievedUrl, actualExpiration) = manager.getPreSignedUrl(tablePath, fileId)
     assert(retrievedUrl === url)
     // The actual expiration should be at least as large as the expected expiration
@@ -362,22 +362,22 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
     val fileId = "file1"
     val initialUrl = "https://test.com/file1"
     val refreshedUrl = "https://test.com/file1-refreshed"
-    
+
     // Track which wrapper was used for refresh
     var lastUsedWrapper: String = "none"
-    
+
     val refresherWrapper1: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => {
         lastUsedWrapper = "wrapper1"
         refresher(token)
       }
-    
+
     val refresherWrapper2: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => {
         lastUsedWrapper = "wrapper2"
         refresher(token)
       }
-    
+
     // Single shared refresh function
     val refresher: Option[String] => TableRefreshResult = _ => {
       val newExpiration = System.currentTimeMillis() + refreshThresholdMs + 100
@@ -386,12 +386,12 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
         Some(newExpiration),
         None)
     }
-    
+
     // Register first query with short expiration
     val queryId1 = "query1"
     val profileProvider1 = createProfileProvider(queryId1, refresherWrapper1)
     val ref1 = new WeakReference[AnyRef](new Object())
-    
+
     manager.register(
       tablePath,
       Map(fileId -> initialUrl),
@@ -401,12 +401,12 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
       System.currentTimeMillis() + refreshThresholdMs + 100, // Short expiration
       None
     )
-    
+
     // Register second query with short expiration
     val queryId2 = "query2"
     val profileProvider2 = createProfileProvider(queryId2, refresherWrapper2)
     val ref2 = new WeakReference[AnyRef](new Object())
-    
+
     manager.register(
       tablePath,
       Map(fileId -> initialUrl),
@@ -418,33 +418,33 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
     )
 
     assert(manager.size == 1)
-    
+
     // Sleep to let the URLs expire
     Thread.sleep(200)
-    
+
     // Trigger refresh - only one wrapper should be used
     manager.refresh()
-    
+
     // Verify only one wrapper was used
     assert(lastUsedWrapper === "wrapper1" || lastUsedWrapper === "wrapper2")
-    
+
     // Get URL - should be from the shared refresher
     val (retrievedUrl, _) = manager.getPreSignedUrl(tablePath, fileId)
     assert(retrievedUrl === refreshedUrl)
-    
+
     // Clear first query's reference
     ref1.clear()
-    
+
     // Sleep again to let the URLs expire
     Thread.sleep(200)
-    
+
     // Trigger refresh again - now only second wrapper should be used
     manager.refresh()
-    
+
     // Verify second wrapper was used
     assert(manager.size == 1)
     assert(lastUsedWrapper === "wrapper2")
-    
+
     // URL should still be accessible
     val (retrievedUrl2, _) = manager.getPreSignedUrl(tablePath, fileId)
     assert(retrievedUrl2 === refreshedUrl)
@@ -470,23 +470,23 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
     val initialUrl2 = "https://test.com/file2"
     val refreshedUrl1 = "https://test.com/file1-refreshed"
     val refreshedUrl2 = "https://test.com/file2-refreshed"
-    
+
     // Track refresh states for each table
     var table1RefreshCount = 0
     var table2RefreshCount = 0
-    
+
     val refresherWrapper1: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => {
         table1RefreshCount += 1
         refresher(token)
       }
-    
+
     val refresherWrapper2: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => {
         table2RefreshCount += 1
         refresher(token)
       }
-    
+
     // Different refresh functions for different tables
     val refresher1: Option[String] => TableRefreshResult = _ => {
       val newExpiration = System.currentTimeMillis() + refreshThresholdMs + 100
@@ -495,7 +495,7 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
         Some(newExpiration),
         None)
     }
-    
+
     val refresher2: Option[String] => TableRefreshResult = _ => {
       val newExpiration = System.currentTimeMillis() + refreshThresholdMs + 100
       TableRefreshResult(
@@ -503,12 +503,12 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
         Some(newExpiration),
         None)
     }
-    
+
     // Register first query for first table with short expiration
     val queryId1 = "query1"
     val profileProvider1 = createProfileProvider(queryId1, refresherWrapper1)
     val ref1 = new WeakReference[AnyRef](new Object())
-    
+
     manager.register(
       tablePath1,
       Map(fileId -> initialUrl1),
@@ -518,12 +518,12 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
       System.currentTimeMillis() + refreshThresholdMs + 100, // Short expiration
       None
     )
-    
+
     // Register second query for second table with short expiration
     val queryId2 = "query2"
     val profileProvider2 = createProfileProvider(queryId2, refresherWrapper2)
     val ref2 = new WeakReference[AnyRef](new Object())
-    
+
     manager.register(
       tablePath2,
       Map(fileId -> initialUrl2),
@@ -533,46 +533,46 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
       System.currentTimeMillis() + refreshThresholdMs + 100, // Short expiration
       None
     )
-    
+
     assert(manager.size == 2)
-    
+
     // Sleep to let the URLs expire
     Thread.sleep(200)
-    
+
     // Trigger refresh - both tables should be refreshed since URLs have expired
     manager.refresh()
-    
+
     // Verify both tables were refreshed
     assert(table1RefreshCount === 1)
     assert(table2RefreshCount === 1)
-    
+
     // Get URLs - should be from their respective refreshers
     val (retrievedUrl1, _) = manager.getPreSignedUrl(tablePath1, fileId)
     val (retrievedUrl2, _) = manager.getPreSignedUrl(tablePath2, fileId)
     assert(retrievedUrl1 === refreshedUrl1)
     assert(retrievedUrl2 === refreshedUrl2)
-    
+
     // Clear first query's reference
     ref1.clear()
-    
+
     // Sleep again to let the URLs expire
     Thread.sleep(200)
-    
+
     // Trigger refresh again - only second table should be refreshed
     manager.refresh()
-    
+
     // Verify only second table was refreshed again
     assert(table1RefreshCount === 1) // Should not change
     assert(table2RefreshCount === 2) // Should increment
-    
+
     // First table should be removed from cache
     assert(manager.size == 1)
-    
+
     // First table's URL should no longer be accessible
     intercept[IllegalStateException] {
       manager.getPreSignedUrl(tablePath1, fileId)
     }
-    
+
     // Second table's URL should still be accessible
     val (retrievedUrl2Again, _) = manager.getPreSignedUrl(tablePath2, fileId)
     assert(retrievedUrl2Again === refreshedUrl2)
@@ -587,20 +587,20 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
     val fileId = "file1"
     val initialUrl = "https://test.com/file1"
     val refreshedUrl = "https://test.com/file1-refreshed"
-    
+
     val refresherWrapper: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => refresher(token)
-    
+
     val refresher: Option[String] => TableRefreshResult = _ =>
       TableRefreshResult(
         Map(fileId -> refreshedUrl),
         Some(System.currentTimeMillis() + preSignedUrlExpirationMs),
         None
       )
-    
+
     val profileProvider = createProfileProvider("query1", refresherWrapper)
     val ref = new WeakReference[AnyRef](new Object())
-    
+
     // Register with expired timestamp
     manager.register(
       tablePath,
@@ -611,7 +611,7 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
       System.currentTimeMillis(), // Already expired
       None
     )
-    
+
     // Verify URL was refreshed immediately
     val (retrievedUrl, _) = manager.getPreSignedUrl(tablePath, fileId)
     assert(retrievedUrl === refreshedUrl)
@@ -627,10 +627,10 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
     val initialUrl = "https://test.com/file1"
     val refreshedUrl = "https://test.com/file1-refreshed"
     val refreshToken = "token123"
-    
+
     val refresherWrapper: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => refresher(token)
-    
+
     var receivedTokens = Seq.empty[Option[String]]
     val refresher: Option[String] => TableRefreshResult = token => {
       receivedTokens = receivedTokens :+ token
@@ -640,10 +640,10 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
         Some(refreshToken)
       )
     }
-    
+
     val profileProvider = createProfileProvider("query1", refresherWrapper)
     val ref = new WeakReference[AnyRef](new Object())
-    
+
     // Register with no refresh token and short expiration to trigger refresh
     manager.register(
       tablePath,
@@ -654,21 +654,21 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
       System.currentTimeMillis() + refreshThresholdMs + 100,
       None
     )
-    
+
     // Sleep to let the URLs expire
     Thread.sleep(200)
-    
+
     // First refresh - should receive None as token
     manager.refresh()
     assert(receivedTokens === Seq(None))
-    
+
     // Sleep again to let the URLs expire
     Thread.sleep(200)
-    
+
     // Second refresh - should receive the token from first refresh
     manager.refresh()
     assert(receivedTokens === Seq(None, Some(refreshToken)))
-    
+
     // Verify we got the refreshed URL
     val (retrievedUrl, _) = manager.getPreSignedUrl(tablePath, fileId)
     assert(retrievedUrl === refreshedUrl)

--- a/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
+++ b/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
@@ -728,21 +728,13 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
     val (retrievedUrl1, _) = manager.getPreSignedUrl(tablePath, fileId)
     assert(retrievedUrl1 === initialUrl)
 
-    // We only refresh cache entry when urls are going to expire
+    // Clear some references
     refs.take(5).foreach(_.clear())
     manager.refresh()
     assert(manager.size == 1)
-    assert(manager.getQueryStateSize(tablePath) == 10) // still 10
+    assert(manager.getQueryStateSize(tablePath) == 5)
     val (retrievedUrl2, _) = manager.getPreSignedUrl(tablePath, fileId)
     assert(retrievedUrl2 === initialUrl)
-
-    // Sleep to let the URLs expire
-    Thread.sleep(200)
-    manager.refresh()
-    assert(manager.size == 1)
-    assert(manager.getQueryStateSize(tablePath) == 5) // reduced to 5
-    val (retrievedUrl3, _) = manager.getPreSignedUrl(tablePath, fileId)
-    assert(retrievedUrl3 === refreshedUrl)
 
     // Clear all references
     refs.foreach(_.clear())


### PR DESCRIPTION
In the previous `CacheTable` implementation, each query was registered as a separate cache entry, which inherently avoided race conditions. However, the new `QuerySpecificCachedTable` groups identical queries under the same cache entry. This change requires us to ensure thread safety during both registration and refresh operations.

Key details:

- A single background refresh thread is responsible for updating the cache.

- There can be multiple concurrent registration threads, each triggered by queries on the same table path.

- To ensure safe concurrent access, we must guard against race conditions between register and refresh logic.

### Thread-Safety Mechanisms
`registerQuerySpecificCachedTable` uses `cache.compute(tablePath, (_, existingTable) -> ...)` to ensure atomic updates when multiple registration threads attempt to initialize or update the cache entry concurrently.

To prevent race conditions between the refresh thread and registration threads, we introduce `cache.computeIfPresent(tablePath, (_, cachedTable) -> ...)` inside `handleQuerySpecificCachedTableRefresh`. This ensures that refresh operations only apply to existing entries in a thread-safe manner.