### PR TITLE
Switch SPARK_PARQUET_IO_CACHE_CONF to use driver level conf

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -19,12 +19,11 @@ package io.delta.sharing.client.util
 import java.util.concurrent.TimeUnit
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.spark.SparkConf
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.internal.SQLConf
 
 object ConfUtils {
-
-  import org.apache.spark.SparkConf
 
   val NUM_RETRIES_CONF = "spark.delta.sharing.network.numRetries"
   val NUM_RETRIES_DEFAULT = 3

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -24,6 +24,8 @@ import org.apache.spark.sql.internal.SQLConf
 
 object ConfUtils {
 
+  import org.apache.spark.SparkConf
+
   val NUM_RETRIES_CONF = "spark.delta.sharing.network.numRetries"
   val NUM_RETRIES_DEFAULT = 3
 
@@ -318,8 +320,9 @@ object ConfUtils {
       SPARK_PARQUET_IO_CACHE_CONF, SPARK_PARQUET_IO_CACHE_DEFAULT.toBoolean)
   }
 
-  def sparkParquetIOCacheEnabled(conf: SQLConf): Boolean = {
-    conf.getConfString(
+  // SparkConf is driver level configuration
+  def sparkParquetIOCacheEnabled(conf: SparkConf): Boolean = {
+    conf.get(
       SPARK_PARQUET_IO_CACHE_CONF, SPARK_PARQUET_IO_CACHE_DEFAULT).toBoolean
   }
 

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -803,7 +803,7 @@ case class DeltaSharingSource(
     val fileIndex = new RemoteDeltaBatchFileIndex(params, addFilesList)
 
     val tablePathWithParams =
-      if (ConfUtils.sparkParquetIOCacheEnabled(spark.sessionState.conf)) {
+      if (ConfUtils.sparkParquetIOCacheEnabled(spark.sparkContext.getConf)) {
         // Ensure different query shapes against the same table have distinct entries
         // in the pre-signed URL cache.
         QueryUtils.getTablePathWithIdSuffix(

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
@@ -23,7 +23,6 @@ import scala.collection.mutable.ListBuffer
 import org.apache.spark.delta.sharing.{CachedTableManager, TableRefreshResult}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, DeltaSharingScanUtils, Row, SparkSession, SQLContext}
-import org.apache.spark.sql.execution.LogicalRDD
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.sources.{BaseRelation, Filter, PrunedFilteredScan}
@@ -110,7 +109,7 @@ object DeltaSharingCDFReader {
     dfs.append(scanIndex(fileIndex3, schema, isStreaming))
 
     val tablePathWithParams =
-      if (ConfUtils.sparkParquetIOCacheEnabled(params.spark.sessionState.conf)) {
+      if (ConfUtils.sparkParquetIOCacheEnabled(params.spark.sparkContext.getConf)) {
         // Ensure different query shapes against the same table have distinct entries
         // in the pre-signed URL cache.
         QueryUtils.getTablePathWithIdSuffix(

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -70,7 +70,7 @@ private[sharing] abstract class RemoteDeltaFileIndexBase(
   // file ID, which are used to retrieve the file URL from the pre-signed URL cache.
   protected def toDeltaSharingPath(f: FileAction, queryParamsHashId: String): Path = {
     val tablePathWithParams =
-      if (ConfUtils.sparkParquetIOCacheEnabled(params.spark.sessionState.conf)) {
+      if (ConfUtils.sparkParquetIOCacheEnabled(params.spark.sparkContext.getConf)) {
         // Adding `queryParamHashId` to the path ensures unique entries in the pre-signed URL cache
         // for different query shapes, distinguishing queries sharing the same table path.
         QueryUtils.getTablePathWithIdSuffix(

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -158,7 +158,7 @@ private[sharing] object RemoteDeltaLog {
     // Use a clean path and add a query parameter suffix later,
     // or append a timestamp UUID suffix to ensure the uniqueness of the table path.
     val updatedPath = new Path(
-      if (ConfUtils.sparkParquetIOCacheEnabled(SparkSession.active.sessionState.conf)) path
+      if (ConfUtils.sparkParquetIOCacheEnabled(SparkSession.active.sparkContext.getConf)) path
       else path + getFormattedTimestampWithUUID
     )
     new RemoteDeltaLog(
@@ -294,7 +294,7 @@ class RemoteSnapshot(
         predicates, limitHint, jsonPredicateHints, tableFiles.version
       )
       val tablePathWithParams =
-        if (ConfUtils.sparkParquetIOCacheEnabled(spark.sessionState.conf)) {
+        if (ConfUtils.sparkParquetIOCacheEnabled(spark.sparkContext.getConf)) {
           QueryUtils.getTablePathWithIdSuffix(
             fileIndex.params.path.toString, queryParamsHashId
           )

--- a/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -462,7 +462,7 @@ class CachedTableManager(
     val customTablePath = profileProvider.getCustomTablePath(tablePath)
 
     val parquetIOCacheEnabled = try {
-      ConfUtils.sparkParquetIOCacheEnabled(SparkSession.active.sessionState.conf)
+      ConfUtils.sparkParquetIOCacheEnabled(SparkSession.active.sparkContext.getConf)
     } catch {
       case _: Exception =>
         // This is a safeguard in case SparkSession is not available
@@ -478,7 +478,11 @@ class CachedTableManager(
         refresher = refresher,
         expirationTimestamp = expirationTimestamp,
         refreshToken = refreshToken,
-        profileProvider)
+        profileProvider = profileProvider
+      )
+    } else if (parquetIOCacheEnabled) {
+      logWarning(s"Query ID is missing for table $customTablePath. " +
+      s"Query-specific caching is disabled, which may lead to refresh issues.")
     }
 
     val customRefresher = profileProvider.getCustomRefresher(refresher)

--- a/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
+++ b/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
@@ -20,7 +20,6 @@ import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.test.SharedSparkSession
 import org.scalatest.time.SpanSugar._
 
@@ -45,26 +44,6 @@ private class TestQuerySpecificProfileProviderWithQueryState(
 }
 
 class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
-  private val preSignedUrlExpirationMs = TimeUnit.HOURS.toMillis(1)
-  private val refreshCheckIntervalMs = TimeUnit.MINUTES.toMillis(1)
-  private val refreshThresholdMs = TimeUnit.MINUTES.toMillis(15)
-  private val expireAfterAccessMs = TimeUnit.HOURS.toMillis(1)
-
-  private def createManager(): CachedTableManager = {
-    new CachedTableManager(
-      preSignedUrlExpirationMs,
-      refreshCheckIntervalMs,
-      refreshThresholdMs,
-      expireAfterAccessMs
-    )
-  }
-
-  private def createProfileProvider(
-      queryId: String,
-      refresherWrapper: QuerySpecificCachedTable.RefresherWrapper): DeltaSharingProfileProvider = {
-    new TestQuerySpecificProfileProviderWithQueryState(queryId, refresherWrapper)
-  }
-
   test("cache") {
     val manager = new CachedTableManager(
       preSignedUrlExpirationMs = 10,
@@ -315,27 +294,56 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
       manager.stop()
     }
   }
+}
+
+class CachedTableManagerWithParquetIOCacheEnabledSuite
+  extends SparkFunSuite
+  with SharedSparkSession {
+  import org.apache.spark.SparkConf
+
+  // Spark configuration is set during Spark session initialization and remains immutable afterward.
+  override def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
+  }
+
+  private val preSignedUrlExpirationMs = TimeUnit.HOURS.toMillis(1)
+  private val refreshCheckIntervalMs = TimeUnit.MINUTES.toMillis(1)
+  private val refreshThresholdMs = TimeUnit.MINUTES.toMillis(15)
+  private val expireAfterAccessMs = TimeUnit.HOURS.toMillis(1)
+
+  private def createManager(): CachedTableManager = {
+    new CachedTableManager(
+      preSignedUrlExpirationMs,
+      refreshCheckIntervalMs,
+      refreshThresholdMs,
+      expireAfterAccessMs
+    )
+  }
+
+  private def createProfileProvider(
+    queryId: String,
+    refresherWrapper: QuerySpecificCachedTable.RefresherWrapper): DeltaSharingProfileProvider = {
+    new TestQuerySpecificProfileProviderWithQueryState(queryId, refresherWrapper)
+  }
 
   test("QuerySpecificCachedTable - basic registration and retrieval") {
-    val spark = SparkSession.active
-    spark.sessionState.conf.setConfString(
-      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
     val manager = createManager()
     val tablePath = "test_table"
     val fileId = "file1"
     val url = "https://test.com/file1"
     val queryId = "query1"
-    
+
     val refresherWrapper: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => refresher(token)
-    
+
     val refresher: Option[String] => TableRefreshResult = _ =>
       TableRefreshResult(
         Map(fileId -> url), Some(System.currentTimeMillis() + preSignedUrlExpirationMs), None)
-    
+
     val profileProvider = createProfileProvider(queryId, refresherWrapper)
     val ref = new WeakReference[AnyRef](new Object())
-    
+
     val expectedExpiration = System.currentTimeMillis() + preSignedUrlExpirationMs
     manager.register(
       tablePath,
@@ -346,7 +354,7 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
       expectedExpiration,
       None
     )
-    
+
     val (retrievedUrl, actualExpiration) = manager.getPreSignedUrl(tablePath, fileId)
     assert(retrievedUrl === url)
     // The actual expiration should be at least as large as the expected expiration
@@ -354,30 +362,27 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
   }
 
   test("QuerySpecificCachedTable - multiple queries share same table") {
-    val spark = SparkSession.active
-    spark.sessionState.conf.setConfString(
-      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
     val manager = createManager()
     val tablePath = "test_table"
     val fileId = "file1"
     val initialUrl = "https://test.com/file1"
     val refreshedUrl = "https://test.com/file1-refreshed"
-    
+
     // Track which wrapper was used for refresh
     var lastUsedWrapper: String = "none"
-    
+
     val refresherWrapper1: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => {
         lastUsedWrapper = "wrapper1"
         refresher(token)
       }
-    
+
     val refresherWrapper2: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => {
         lastUsedWrapper = "wrapper2"
         refresher(token)
       }
-    
+
     // Single shared refresh function
     val refresher: Option[String] => TableRefreshResult = _ => {
       val newExpiration = System.currentTimeMillis() + refreshThresholdMs + 100
@@ -386,12 +391,12 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
         Some(newExpiration),
         None)
     }
-    
+
     // Register first query with short expiration
     val queryId1 = "query1"
     val profileProvider1 = createProfileProvider(queryId1, refresherWrapper1)
     val ref1 = new WeakReference[AnyRef](new Object())
-    
+
     manager.register(
       tablePath,
       Map(fileId -> initialUrl),
@@ -401,12 +406,12 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
       System.currentTimeMillis() + refreshThresholdMs + 100, // Short expiration
       None
     )
-    
+
     // Register second query with short expiration
     val queryId2 = "query2"
     val profileProvider2 = createProfileProvider(queryId2, refresherWrapper2)
     val ref2 = new WeakReference[AnyRef](new Object())
-    
+
     manager.register(
       tablePath,
       Map(fileId -> initialUrl),
@@ -418,33 +423,33 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
     )
 
     assert(manager.size == 1)
-    
+
     // Sleep to let the URLs expire
     Thread.sleep(200)
-    
+
     // Trigger refresh - only one wrapper should be used
     manager.refresh()
-    
+
     // Verify only one wrapper was used
     assert(lastUsedWrapper === "wrapper1" || lastUsedWrapper === "wrapper2")
-    
+
     // Get URL - should be from the shared refresher
     val (retrievedUrl, _) = manager.getPreSignedUrl(tablePath, fileId)
     assert(retrievedUrl === refreshedUrl)
-    
+
     // Clear first query's reference
     ref1.clear()
-    
+
     // Sleep again to let the URLs expire
     Thread.sleep(200)
-    
+
     // Trigger refresh again - now only second wrapper should be used
     manager.refresh()
-    
+
     // Verify second wrapper was used
     assert(manager.size == 1)
     assert(lastUsedWrapper === "wrapper2")
-    
+
     // URL should still be accessible
     val (retrievedUrl2, _) = manager.getPreSignedUrl(tablePath, fileId)
     assert(retrievedUrl2 === refreshedUrl)
@@ -459,9 +464,6 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
   }
 
   test("QuerySpecificCachedTable - multiple queries on different tables with refresh states") {
-    val spark = SparkSession.active
-    spark.sessionState.conf.setConfString(
-      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
     val manager = createManager()
     val tablePath1 = "test_table1"
     val tablePath2 = "test_table2"
@@ -470,23 +472,23 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
     val initialUrl2 = "https://test.com/file2"
     val refreshedUrl1 = "https://test.com/file1-refreshed"
     val refreshedUrl2 = "https://test.com/file2-refreshed"
-    
+
     // Track refresh states for each table
     var table1RefreshCount = 0
     var table2RefreshCount = 0
-    
+
     val refresherWrapper1: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => {
         table1RefreshCount += 1
         refresher(token)
       }
-    
+
     val refresherWrapper2: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => {
         table2RefreshCount += 1
         refresher(token)
       }
-    
+
     // Different refresh functions for different tables
     val refresher1: Option[String] => TableRefreshResult = _ => {
       val newExpiration = System.currentTimeMillis() + refreshThresholdMs + 100
@@ -495,7 +497,7 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
         Some(newExpiration),
         None)
     }
-    
+
     val refresher2: Option[String] => TableRefreshResult = _ => {
       val newExpiration = System.currentTimeMillis() + refreshThresholdMs + 100
       TableRefreshResult(
@@ -503,12 +505,12 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
         Some(newExpiration),
         None)
     }
-    
+
     // Register first query for first table with short expiration
     val queryId1 = "query1"
     val profileProvider1 = createProfileProvider(queryId1, refresherWrapper1)
     val ref1 = new WeakReference[AnyRef](new Object())
-    
+
     manager.register(
       tablePath1,
       Map(fileId -> initialUrl1),
@@ -518,12 +520,12 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
       System.currentTimeMillis() + refreshThresholdMs + 100, // Short expiration
       None
     )
-    
+
     // Register second query for second table with short expiration
     val queryId2 = "query2"
     val profileProvider2 = createProfileProvider(queryId2, refresherWrapper2)
     val ref2 = new WeakReference[AnyRef](new Object())
-    
+
     manager.register(
       tablePath2,
       Map(fileId -> initialUrl2),
@@ -533,74 +535,71 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
       System.currentTimeMillis() + refreshThresholdMs + 100, // Short expiration
       None
     )
-    
+
     assert(manager.size == 2)
-    
+
     // Sleep to let the URLs expire
     Thread.sleep(200)
-    
+
     // Trigger refresh - both tables should be refreshed since URLs have expired
     manager.refresh()
-    
+
     // Verify both tables were refreshed
     assert(table1RefreshCount === 1)
     assert(table2RefreshCount === 1)
-    
+
     // Get URLs - should be from their respective refreshers
     val (retrievedUrl1, _) = manager.getPreSignedUrl(tablePath1, fileId)
     val (retrievedUrl2, _) = manager.getPreSignedUrl(tablePath2, fileId)
     assert(retrievedUrl1 === refreshedUrl1)
     assert(retrievedUrl2 === refreshedUrl2)
-    
+
     // Clear first query's reference
     ref1.clear()
-    
+
     // Sleep again to let the URLs expire
     Thread.sleep(200)
-    
+
     // Trigger refresh again - only second table should be refreshed
     manager.refresh()
-    
+
     // Verify only second table was refreshed again
     assert(table1RefreshCount === 1) // Should not change
     assert(table2RefreshCount === 2) // Should increment
-    
+
     // First table should be removed from cache
     assert(manager.size == 1)
-    
+
     // First table's URL should no longer be accessible
     intercept[IllegalStateException] {
       manager.getPreSignedUrl(tablePath1, fileId)
     }
-    
+
     // Second table's URL should still be accessible
     val (retrievedUrl2Again, _) = manager.getPreSignedUrl(tablePath2, fileId)
     assert(retrievedUrl2Again === refreshedUrl2)
   }
 
   test("QuerySpecificCachedTable - expiration handling") {
-    val spark = SparkSession.active
-    spark.sessionState.conf.setConfString(
-      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
     val manager = createManager()
     val tablePath = "test_table"
     val fileId = "file1"
     val initialUrl = "https://test.com/file1"
     val refreshedUrl = "https://test.com/file1-refreshed"
-    
+
     val refresherWrapper: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => refresher(token)
-    
+
     val refresher: Option[String] => TableRefreshResult = _ =>
       TableRefreshResult(
         Map(fileId -> refreshedUrl),
         Some(System.currentTimeMillis() + preSignedUrlExpirationMs),
         None
       )
-    
+
     val profileProvider = createProfileProvider("query1", refresherWrapper)
     val ref = new WeakReference[AnyRef](new Object())
-    
+
     // Register with expired timestamp
     manager.register(
       tablePath,
@@ -611,26 +610,23 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
       System.currentTimeMillis(), // Already expired
       None
     )
-    
+
     // Verify URL was refreshed immediately
     val (retrievedUrl, _) = manager.getPreSignedUrl(tablePath, fileId)
     assert(retrievedUrl === refreshedUrl)
   }
 
   test("QuerySpecificCachedTable - refresh token handling") {
-    val spark = SparkSession.active
-    spark.sessionState.conf.setConfString(
-      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
     val manager = createManager()
     val tablePath = "test_table"
     val fileId = "file1"
     val initialUrl = "https://test.com/file1"
     val refreshedUrl = "https://test.com/file1-refreshed"
     val refreshToken = "token123"
-    
+
     val refresherWrapper: QuerySpecificCachedTable.RefresherWrapper =
       (token, refresher) => refresher(token)
-    
+
     var receivedTokens = Seq.empty[Option[String]]
     val refresher: Option[String] => TableRefreshResult = token => {
       receivedTokens = receivedTokens :+ token
@@ -640,10 +636,10 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
         Some(refreshToken)
       )
     }
-    
+
     val profileProvider = createProfileProvider("query1", refresherWrapper)
     val ref = new WeakReference[AnyRef](new Object())
-    
+
     // Register with no refresh token and short expiration to trigger refresh
     manager.register(
       tablePath,
@@ -654,21 +650,21 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
       System.currentTimeMillis() + refreshThresholdMs + 100,
       None
     )
-    
+
     // Sleep to let the URLs expire
     Thread.sleep(200)
-    
+
     // First refresh - should receive None as token
     manager.refresh()
     assert(receivedTokens === Seq(None))
-    
+
     // Sleep again to let the URLs expire
     Thread.sleep(200)
-    
+
     // Second refresh - should receive the token from first refresh
     manager.refresh()
     assert(receivedTokens === Seq(None, Some(refreshToken)))
-    
+
     // Verify we got the refreshed URL
     val (retrievedUrl, _) = manager.getPreSignedUrl(tablePath, fileId)
     assert(retrievedUrl === refreshedUrl)

--- a/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
+++ b/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.delta.sharing
 import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.scalatest.time.SpanSugar._
 
@@ -299,8 +299,6 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
 class CachedTableManagerWithParquetIOCacheEnabledSuite
   extends SparkFunSuite
   with SharedSparkSession {
-  import org.apache.spark.SparkConf
-
   // Spark configuration is set during Spark session initialization and remains immutable afterward.
   override def sparkConf: SparkConf = {
     super.sparkConf

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -121,7 +121,7 @@ class DeltaSharingSourceSuite extends QueryTest
       "ignoreDeletes" -> "true",
       "startingVersion" -> "latest"
     ))
-    if (ConfUtils.sparkParquetIOCacheEnabled(SparkSession.active.sessionState.conf)) {
+    if (ConfUtils.sparkParquetIOCacheEnabled(SparkSession.active.sparkContext.getConf)) {
       // <profile>#share8.default.cdf_table_cdf_enabled
       assert(source.deltaLog.path.toString.split("#")(1) == "share8.default.cdf_table_cdf_enabled")
     }
@@ -585,8 +585,10 @@ class DeltaSharingSourceSuite extends QueryTest
 }
 
 class DeltaSharingSourceWithParquetIOCacheEnabledSuite extends DeltaSharingSourceSuite {
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    spark.conf.set("spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
+  import org.apache.spark.SparkConf
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
   }
 }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -24,7 +24,14 @@ import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SparkSession}
 import org.apache.spark.sql.connector.read.streaming.ReadMaxFiles
 import org.apache.spark.sql.streaming.{DataStreamReader, StreamingQueryException, Trigger}
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{DateType, IntegerType, StringType, StructField, StructType, TimestampType}
+import org.apache.spark.sql.types.{
+  DateType,
+  IntegerType,
+  StringType,
+  StructField,
+  StructType,
+  TimestampType
+}
 
 import io.delta.sharing.client.util.ConfUtils
 import io.delta.sharing.spark.TestUtils._

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -19,18 +19,12 @@ package io.delta.sharing.spark
 import scala.collection.JavaConverters._
 
 import org.apache.commons.io.FileUtils
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SparkSession}
 import org.apache.spark.sql.connector.read.streaming.ReadMaxFiles
 import org.apache.spark.sql.streaming.{DataStreamReader, StreamingQueryException, Trigger}
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{
-  DateType,
-  IntegerType,
-  StringType,
-  StructField,
-  StructType,
-  TimestampType
-}
+import org.apache.spark.sql.types.{DateType, IntegerType, StringType, StructField, StructType, TimestampType}
 
 import io.delta.sharing.client.util.ConfUtils
 import io.delta.sharing.spark.TestUtils._
@@ -585,8 +579,6 @@ class DeltaSharingSourceSuite extends QueryTest
 }
 
 class DeltaSharingSourceWithParquetIOCacheEnabledSuite extends DeltaSharingSourceSuite {
-  import org.apache.spark.SparkConf
-
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set("spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -22,6 +22,7 @@ import scala.util.Random
 
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.test.SharedSparkSession
@@ -568,8 +569,6 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
 }
 
 class DeltaSharingWithParquetIOCacheEnabledSuite extends DeltaSharingSuite {
-  import org.apache.spark.SparkConf
-
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set("spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -568,8 +568,10 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
 }
 
 class DeltaSharingWithParquetIOCacheEnabledSuite extends DeltaSharingSuite {
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    spark.conf.set("spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
+  import org.apache.spark.SparkConf
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
   }
 }

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -21,7 +21,7 @@ import java.nio.file.Files
 
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
-import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkException, SparkFunSuite}
 import org.apache.spark.delta.sharing.CachedTableManager
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference => SqlAttributeReference, EqualTo => SqlEqualTo, GreaterThan => SqlGreaterThan, Literal => SqlLiteral}
@@ -663,8 +663,6 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
 }
 
 class RemoteDeltaLogWithParquetIOCacheEnabledSuite extends SparkFunSuite with SharedSparkSession {
-  import org.apache.spark.SparkConf
-
   // Spark configuration is set during Spark session initialization and remains immutable afterward.
   override def sparkConf: SparkConf = {
     super.sparkConf

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -39,10 +39,6 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     try {
       val client = new TestDeltaSharingClient()
       client.clear()
-
-      val spark = SparkSession.active
-      spark.sessionState.conf.setConfString(
-        "spark.delta.sharing.client.sparkParquetIOCache.enabled", "false")
     } finally {
       super.afterEach()
     }
@@ -100,348 +96,6 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     client.clear()
     fileIndex.listFiles(Seq(sqlEq), Seq.empty)
     assert(TestDeltaSharingClient.jsonPredicateHints.size === 0)
-  }
-
-  test("read file urls from pre-signed url cache with queryParamsHashId") {
-    val spark = SparkSession.active
-    spark.sessionState.conf.setConfString("spark.delta.sharing.jsonPredicateHints.enabled", "true")
-    spark.sessionState.conf.setConfString(
-      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
-    val client = new TestDeltaSharingClient()
-
-    // check snapshot
-    val limit = 4L
-    val jsonPredicate = "jsonPredicate1"
-    val snapshot = new RemoteSnapshot(new Path("test"), client, Table("fe", "fi", "fo"))
-    val params = RemoteDeltaFileIndexParams(spark, snapshot, client.getProfileProvider)
-    val fileIndex = RemoteDeltaSnapshotFileIndex(params, Some(limit))
-    val (actions, queryParamsHashId) = snapshot.filesForScan(
-      Nil, Some(limit), Some(jsonPredicate), fileIndex)
-    assert(TestDeltaSharingClient.limits === Seq(limit))
-    assert(TestDeltaSharingClient.jsonPredicateHints === Seq("jsonPredicate1"))
-    assert(actions.size == limit)
-
-    actions.map { action =>
-      // Make sure we can read file urls for each file action.
-      val tablePath = QueryUtils.getTablePathWithIdSuffix(
-        params.profileProvider.getCustomTablePath(params.path.toString),
-        queryParamsHashId
-      )
-      val (url, expiration) = CachedTableManager.INSTANCE.getPreSignedUrl(tablePath, action.id)
-      assert(!url.isEmpty)
-      assert(expiration > 0)
-    }
-  }
-
-  test("distinct queries against the same table have different cache entries") {
-    val spark = SparkSession.active
-    spark.sessionState.conf.setConfString("spark.delta.sharing.jsonPredicateHints.enabled", "true")
-    spark.sessionState.conf.setConfString(
-      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
-    val client = new TestDeltaSharingClient()
-    val limit = 4L
-    val snapshot = new RemoteSnapshot(new Path("test"), client, Table("fe", "fi", "fo"))
-    val params = RemoteDeltaFileIndexParams(spark, snapshot, client.getProfileProvider)
-    val fileIndex = RemoteDeltaSnapshotFileIndex(params, Some(limit))
-    val cacheSizeBegin = CachedTableManager.INSTANCE.size
-
-    // Send query 1 without predicates.
-    val partitionDirectories1 = fileIndex.listFiles(Seq.empty, Seq.empty)
-    assert(TestDeltaSharingClient.limits === Seq(limit))
-    // For every file returned in listFiles, we should be able to get the pre-signed url.
-    val fileIds1: Seq[String] = partitionDirectories1.flatMap { partitionDirectory =>
-      assert(partitionDirectory.files.size == limit)
-      partitionDirectory.files.map { file =>
-        val path = DeltaSharingFileSystem.decode(file.getPath)
-        val (url, expiration) =
-          CachedTableManager.INSTANCE.getPreSignedUrl(path.tablePath, path.fileId)
-        assert(!url.isEmpty)
-        assert(expiration > 0)
-        path.fileId
-      }
-    }
-    client.clear
-
-    // Send query 2 with predicates.
-    val sqlEq = SqlGreaterThan(
-      SqlAttributeReference("id", IntegerType)(),
-      SqlLiteral(20, IntegerType)
-    )
-    // The client should get json for jsonPredicateHints.
-    val expectedJson =
-      """{"op":"greaterThan",
-         |"children":[
-         |  {"op":"column","name":"id","valueType":"int"},
-         |  {"op":"literal","value":"20","valueType":"int"}]
-         |}""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")
-
-    val partitionDirectories2 = fileIndex.listFiles(Seq(sqlEq), Seq.empty)
-    assert(TestDeltaSharingClient.limits === Seq(limit))
-    assert(TestDeltaSharingClient.jsonPredicateHints.size === 1)
-    val receivedJson = TestDeltaSharingClient.jsonPredicateHints(0)
-    assert(receivedJson == expectedJson)
-    // For every file returned in listFiles, we should be able to get the pre-signed url.
-    val fileIds2: Seq[String] = partitionDirectories2.flatMap { partitionDirectory =>
-      partitionDirectory.files.map { file =>
-        val path = DeltaSharingFileSystem.decode(file.getPath)
-        val (url, expiration) =
-          CachedTableManager.INSTANCE.getPreSignedUrl(path.tablePath, path.fileId)
-        assert(!url.isEmpty)
-        assert(expiration > 0)
-        path.fileId
-      }
-    }
-    // Different cacheEntry for different predicates.
-    assert(fileIds1 != fileIds2)
-    assert(CachedTableManager.INSTANCE.size == cacheSizeBegin +2)
-  }
-
-  test("identical queries against the same table share same cache entries") {
-    val spark = SparkSession.active
-    spark.sessionState.conf.setConfString("spark.delta.sharing.jsonPredicateHints.enabled", "true")
-    spark.sessionState.conf.setConfString(
-      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
-    val client = new TestDeltaSharingClient()
-    val limit = 4L
-    val snapshot = new RemoteSnapshot(new Path("test"), client, Table("fe", "fi", "fo"))
-    val params = RemoteDeltaFileIndexParams(spark, snapshot, client.getProfileProvider)
-    val fileIndex = RemoteDeltaSnapshotFileIndex(params, Some(limit))
-    val sqlEq = SqlGreaterThan(
-      SqlAttributeReference("id", IntegerType)(),
-      SqlLiteral(21, IntegerType)
-    )
-    val expectedJson =
-      """{"op":"greaterThan",
-        |"children":[
-        |  {"op":"column","name":"id","valueType":"int"},
-        |  {"op":"literal","value":"21","valueType":"int"}]
-        |}""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")
-    val cacheSizeBegin = CachedTableManager.INSTANCE.size
-
-    // Send query 1 with predicates.
-    val partitionDirectories1 = fileIndex.listFiles(Seq(sqlEq), Seq.empty)
-    assert(TestDeltaSharingClient.limits === Seq(limit))
-    assert(TestDeltaSharingClient.jsonPredicateHints.size === 1)
-    val receivedJson = TestDeltaSharingClient.jsonPredicateHints(0)
-    assert(receivedJson == expectedJson)
-    // For every file returned in listFiles, we should be able to get the pre-signed url.
-    val fileIds1: Seq[String] = partitionDirectories1.flatMap { partitionDirectory =>
-      partitionDirectory.files.map { file =>
-        val path = DeltaSharingFileSystem.decode(file.getPath)
-        val (url, expiration) =
-          CachedTableManager.INSTANCE.getPreSignedUrl(path.tablePath, path.fileId)
-        assert(!url.isEmpty)
-        assert(expiration > 0)
-        path.fileId
-      }
-    }
-    client.clear
-
-    // Send query 2 with same predicates.
-    val partitionDirectories2 = fileIndex.listFiles(Seq(sqlEq), Seq.empty)
-    assert(TestDeltaSharingClient.limits === Seq(limit))
-    assert(TestDeltaSharingClient.jsonPredicateHints.size === 1)
-    val receivedJson2 = TestDeltaSharingClient.jsonPredicateHints(0)
-    assert(receivedJson2 == expectedJson)
-    // For every file returned in listFiles, we should be able to get the pre-signed url.
-    val fileIds2: Seq[String] = partitionDirectories2.flatMap { partitionDirectory =>
-      partitionDirectory.files.map { file =>
-        val path = DeltaSharingFileSystem.decode(file.getPath)
-        val (url, expiration) =
-          CachedTableManager.INSTANCE.getPreSignedUrl(path.tablePath, path.fileId)
-        assert(!url.isEmpty)
-        assert(expiration > 0)
-        path.fileId
-      }
-    }
-
-    // Same cacheEntry for same predicates.
-    assert(fileIds1 == fileIds2)
-    assert(CachedTableManager.INSTANCE.size == cacheSizeBegin +1)
-    client.clear
-  }
-
-  test("listing files from RemoteDeltaFileIndexParams") {
-    val spark = SparkSession.active
-    spark.sessionState.conf.setConfString("spark.delta.sharing.jsonPredicateHints.enabled", "true")
-    spark.sessionState.conf.setConfString(
-      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
-    val client = new TestDeltaSharingClient()
-    val version = Some(1L)
-    val limit = Some(3L)
-    val snapshot = new RemoteSnapshot(
-      new Path("test"),
-      client,
-      Table("fe", "fi", "fo"),
-      versionAsOf = version
-    )
-    val fileIndex = {
-      val params = RemoteDeltaFileIndexParams(spark, snapshot, client.getProfileProvider)
-      RemoteDeltaSnapshotFileIndex(params, limit)
-    }
-    val partitionFilters = Seq(
-      SqlGreaterThan(
-        SqlAttributeReference("id", IntegerType)(),
-        SqlLiteral(21, IntegerType)
-      )
-    )
-    val jsonPredicateHints =
-      """{"op":"greaterThan",
-        |"children":[
-        |  {"op":"column","name":"id","valueType":"int"},
-        |  {"op":"literal","value":"21","valueType":"int"}]
-        |}""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")
-
-    // Check delta sharing path for listFiles
-    val queryParamsHashId = QueryUtils.getQueryParamsHashId(
-      Seq.empty,
-      limit,
-      Some(jsonPredicateHints),
-      version.get
-    )
-    val tablePath = QueryUtils.getTablePathWithIdSuffix(
-      fileIndex.params.profileProvider.getCustomTablePath(fileIndex.params.path.toString),
-      queryParamsHashId
-    )
-    val listFilesResult = fileIndex.listFiles(partitionFilters, Seq.empty)
-    assert(listFilesResult.size == 1)
-    assert(listFilesResult(0).files.size == limit.get)
-    assert(listFilesResult(0).files(0).getPath.toString == s"delta-sharing:/${tablePath}/f1/0")
-    assert(listFilesResult(0).files(1).getPath.toString == s"delta-sharing:/${tablePath}/f2/0")
-    assert(listFilesResult(0).files(2).getPath.toString == s"delta-sharing:/${tablePath}/f3/0")
-
-    // Check delta sharing path for inputFiles
-    val queryParamsHashId2 = QueryUtils.getQueryParamsHashId(
-      Nil,
-      None,
-      None,
-      version.get)
-    val tablePath2 = QueryUtils.getTablePathWithIdSuffix(
-      fileIndex.params.profileProvider.getCustomTablePath(fileIndex.params.path.toString),
-      queryParamsHashId2
-    )
-    val inputFileList = fileIndex.inputFiles.toList
-    assert(inputFileList.size == 4)
-    assert(inputFileList(0) == s"delta-sharing:/${tablePath2}/f1/0")
-    assert(inputFileList(1) == s"delta-sharing:/${tablePath2}/f2/0")
-    assert(inputFileList(2) == s"delta-sharing:/${tablePath2}/f3/0")
-    assert(inputFileList(3) == s"delta-sharing:/${tablePath2}/f4/0")
-  }
-
-  test("listing files from cdf file index") {
-    val spark = SparkSession.active
-    spark.sessionState.conf.setConfString(
-      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
-    val path = new Path("test")
-    val table = Table("fe", "fi", "fo")
-    val client = new TestDeltaSharingClient()
-    val snapshot = new RemoteSnapshot(path, client, table)
-    // CDF queries cache all file actions for a table from a start version to an end version.
-    // No need to count filters into queryParamsHashId.
-    val queryParamsHashId = QueryUtils.getQueryParamsHashId(
-      Map(DeltaSharingOptions.CDF_START_VERSION -> "0",
-        DeltaSharingOptions.CDF_END_VERSION -> "100")
-    )
-    val params = RemoteDeltaFileIndexParams(
-      spark, snapshot, client.getProfileProvider, Some(queryParamsHashId))
-    val tablePath = QueryUtils.getTablePathWithIdSuffix(
-      params.profileProvider.getCustomTablePath(params.path.toString),
-      queryParamsHashId
-    )
-    val deltaTableFiles = client.getCDFFiles(table, Map.empty, false)
-
-    // Test CDFAddFileIndex
-    val addFilesIndex = new RemoteDeltaCDFAddFileIndex(params, deltaTableFiles.addFiles)
-    val addListFilesResult = addFilesIndex.listFiles(Seq.empty, Seq.empty)
-
-    assert(addListFilesResult.size == 1)
-    assert(addListFilesResult(0).files.size == 1)
-    assert(addListFilesResult(0).files(0).getPath.toString ==
-      s"delta-sharing:/${tablePath}/cdf_add1/100")
-
-    val addInputFileList = addFilesIndex.inputFiles.toList
-    assert(addInputFileList.size == 1)
-    assert(addInputFileList(0) == s"delta-sharing:/${tablePath}/cdf_add1/100")
-
-    // Test CDCFileIndex
-    val cdcIndex = new RemoteDeltaCDCFileIndex(params, deltaTableFiles.cdfFiles)
-    val cdcListFilesResult = cdcIndex.listFiles(Seq.empty, Seq.empty)
-    assert(cdcListFilesResult.size == 2)
-    // The partition dirs can be returned in any order.
-    val (cdcP1, cdcP2) = if (cdcListFilesResult(0).files.size == 1) {
-      (cdcListFilesResult(0), cdcListFilesResult(1))
-    } else {
-      (cdcListFilesResult(1), cdcListFilesResult(0))
-    }
-    assert(cdcP1.files.size == 1)
-    assert(cdcP1.files(0).getPath.toString == s"delta-sharing:/${tablePath}/cdf_cdc1/200")
-    assert(cdcP2.files.size == 2)
-    assert(cdcP2.files(0).getPath.toString == s"delta-sharing:/${tablePath}/cdf_cdc2/300")
-    assert(cdcP2.files(1).getPath.toString == s"delta-sharing:/${tablePath}/cdf_cdc3/310")
-
-    val cdcInputFileList = cdcIndex.inputFiles.toList
-    assert(cdcInputFileList.size == 3)
-    assert(cdcInputFileList(0) == s"delta-sharing:/${tablePath}/cdf_cdc1/200")
-    assert(cdcInputFileList(1) == s"delta-sharing:/${tablePath}/cdf_cdc2/300")
-    assert(cdcInputFileList(2) == s"delta-sharing:/${tablePath}/cdf_cdc3/310")
-
-    // Test CDFRemoveFileIndex
-    val removeFilesIndex = new RemoteDeltaCDFRemoveFileIndex(params, deltaTableFiles.removeFiles)
-    val removeListFilesResult = removeFilesIndex.listFiles(Seq.empty, Seq.empty)
-    assert(removeListFilesResult.size == 2)
-    val p1 = removeListFilesResult(0)
-    assert(p1.files.size == 1)
-    val p2 = removeListFilesResult(1)
-    assert(p2.files.size == 1)
-    // The partition dirs can be returned in any order.
-    assert(
-      (p1.files(0).getPath.toString == s"delta-sharing:/${tablePath}/cdf_rem1/400" &&
-        p2.files(0).getPath.toString == s"delta-sharing:/${tablePath}/cdf_rem2/420") ||
-        (p2.files(0).getPath.toString == s"delta-sharing:/${tablePath}/cdf_rem1/400" &&
-          p1.files(0).getPath.toString == s"delta-sharing:/${tablePath}/cdf_rem2/420")
-    )
-    val removeInputFileList = removeFilesIndex.inputFiles.toList
-    assert(removeInputFileList.size == 2)
-    assert(removeInputFileList(0) == s"delta-sharing:/${tablePath}/cdf_rem1/400")
-    assert(removeInputFileList(1) == s"delta-sharing:/${tablePath}/cdf_rem2/420")
-  }
-
-  test("listing files from RemoteDeltaBatchFileIndex") {
-    val spark = SparkSession.active
-    spark.sessionState.conf.setConfString(
-      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
-    val path = new Path("test")
-    val table = Table("fe", "fi", "fo")
-    val client = new TestDeltaSharingClient()
-    val snapshot = new RemoteSnapshot(path, client, table)
-    // Streaming queries cache all AddFiles from a start version to an end version.
-    val startVersion = 1L
-    val queryParamsHashId = QueryUtils.getQueryParamsHashId(startVersion, startVersion + 1L)
-    val params = RemoteDeltaFileIndexParams(
-      spark, snapshot, client.getProfileProvider, Some(queryParamsHashId))
-    val tablePath = QueryUtils.getTablePathWithIdSuffix(
-      params.profileProvider.getCustomTablePath(params.path.toString),
-      queryParamsHashId
-    )
-    val deltaTableFiles = client.getFiles(table, Nil, None, Some(startVersion), None, None, None)
-
-    // Test BatchFileIndex list files
-    val batchFilesIndex = new RemoteDeltaBatchFileIndex(params, deltaTableFiles.files)
-    val listFilesResult = batchFilesIndex.listFiles(Seq.empty, Seq.empty)
-    assert(listFilesResult.size == 1)
-    assert(listFilesResult(0).files.size == 4)
-    assert(listFilesResult(0).files(0).getPath.toString == s"delta-sharing:/${tablePath}/f1/0")
-    assert(listFilesResult(0).files(1).getPath.toString == s"delta-sharing:/${tablePath}/f2/0")
-    assert(listFilesResult(0).files(2).getPath.toString == s"delta-sharing:/${tablePath}/f3/0")
-    assert(listFilesResult(0).files(3).getPath.toString == s"delta-sharing:/${tablePath}/f4/0")
-
-    // Test BatchFileIndex input files
-    val inputFileList = batchFilesIndex.inputFiles.toList
-    assert(inputFileList.size == 4)
-    assert(inputFileList(0) == s"delta-sharing:/${tablePath}/f1/0")
-    assert(inputFileList(1) == s"delta-sharing:/${tablePath}/f2/0")
-    assert(inputFileList(2) == s"delta-sharing:/${tablePath}/f3/0")
-    assert(inputFileList(3) == s"delta-sharing:/${tablePath}/f4/0")
   }
 
   test("jsonPredicateV2Hints test") {
@@ -999,21 +653,376 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
          |}""".stripMargin, UTF_8)
     val tablePath = s"${testProfileFile.getCanonicalPath}#share.schema.table"
 
-    spark.sessionState.conf.setConfString(
-      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
-    // Same as the table path
-    val deltaLog1 = RemoteDeltaLog(tablePath)
-    assert(deltaLog1.path.toString == tablePath)
-    val snapshot1 = deltaLog1.snapshot()
-    assert(snapshot1.getTablePath.toString == tablePath)
-
-    spark.sessionState.conf.setConfString(
-      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "false")
     // Append timestamp suffix
     // <profile>#share.schema.table_yyyyMMdd_HHmmss_uuid
     val deltaLog2 = RemoteDeltaLog(tablePath)
     assert(deltaLog2.path.toString.split("#")(1).split("_").length == 4)
     val snapshot2 = deltaLog2.snapshot()
     assert(snapshot2.getTablePath.toString.split("#")(1).split("_").length == 4)
+  }
+}
+
+class RemoteDeltaLogWithParquetIOCacheEnabledSuite extends SparkFunSuite with SharedSparkSession {
+  import org.apache.spark.SparkConf
+
+  // Spark configuration is set during Spark session initialization and remains immutable afterward.
+  override def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
+  }
+
+  override def afterEach(): Unit = {
+    try {
+      val client = new TestDeltaSharingClient()
+      client.clear()
+    } finally {
+      super.afterEach()
+    }
+  }
+
+  test("read file urls from pre-signed url cache with queryParamsHashId") {
+    val spark = SparkSession.active
+    spark.sessionState.conf.setConfString("spark.delta.sharing.jsonPredicateHints.enabled", "true")
+    val client = new TestDeltaSharingClient()
+
+    // check snapshot
+    val limit = 4L
+    val jsonPredicate = "jsonPredicate1"
+    val snapshot = new RemoteSnapshot(new Path("test"), client, Table("fe", "fi", "fo"))
+    val params = RemoteDeltaFileIndexParams(spark, snapshot, client.getProfileProvider)
+    val fileIndex = RemoteDeltaSnapshotFileIndex(params, Some(limit))
+    val (actions, queryParamsHashId) = snapshot.filesForScan(
+      Nil, Some(limit), Some(jsonPredicate), fileIndex)
+    assert(TestDeltaSharingClient.limits === Seq(limit))
+    assert(TestDeltaSharingClient.jsonPredicateHints === Seq("jsonPredicate1"))
+    assert(actions.size == limit)
+
+    actions.map { action =>
+      // Make sure we can read file urls for each file action.
+      val tablePath = QueryUtils.getTablePathWithIdSuffix(
+        params.profileProvider.getCustomTablePath(params.path.toString),
+        queryParamsHashId
+      )
+      val (url, expiration) = CachedTableManager.INSTANCE.getPreSignedUrl(tablePath, action.id)
+      assert(!url.isEmpty)
+      assert(expiration > 0)
+    }
+  }
+
+  test("distinct queries against the same table have different cache entries") {
+    val spark = SparkSession.active
+    spark.sessionState.conf.setConfString("spark.delta.sharing.jsonPredicateHints.enabled", "true")
+    val client = new TestDeltaSharingClient()
+    val limit = 4L
+    val snapshot = new RemoteSnapshot(new Path("test"), client, Table("fe", "fi", "fo"))
+    val params = RemoteDeltaFileIndexParams(spark, snapshot, client.getProfileProvider)
+    val fileIndex = RemoteDeltaSnapshotFileIndex(params, Some(limit))
+    val cacheSizeBegin = CachedTableManager.INSTANCE.size
+
+    // Send query 1 without predicates.
+    val partitionDirectories1 = fileIndex.listFiles(Seq.empty, Seq.empty)
+    assert(TestDeltaSharingClient.limits === Seq(limit))
+    // For every file returned in listFiles, we should be able to get the pre-signed url.
+    val fileIds1: Seq[String] = partitionDirectories1.flatMap { partitionDirectory =>
+      assert(partitionDirectory.files.size == limit)
+      partitionDirectory.files.map { file =>
+        val path = DeltaSharingFileSystem.decode(file.getPath)
+        val (url, expiration) =
+          CachedTableManager.INSTANCE.getPreSignedUrl(path.tablePath, path.fileId)
+        assert(!url.isEmpty)
+        assert(expiration > 0)
+        path.fileId
+      }
+    }
+    client.clear
+
+    // Send query 2 with predicates.
+    val sqlEq = SqlGreaterThan(
+      SqlAttributeReference("id", IntegerType)(),
+      SqlLiteral(20, IntegerType)
+    )
+    // The client should get json for jsonPredicateHints.
+    val expectedJson =
+      """{"op":"greaterThan",
+        |"children":[
+        |  {"op":"column","name":"id","valueType":"int"},
+        |  {"op":"literal","value":"20","valueType":"int"}]
+        |}""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")
+
+    val partitionDirectories2 = fileIndex.listFiles(Seq(sqlEq), Seq.empty)
+    assert(TestDeltaSharingClient.limits === Seq(limit))
+    assert(TestDeltaSharingClient.jsonPredicateHints.size === 1)
+    val receivedJson = TestDeltaSharingClient.jsonPredicateHints(0)
+    assert(receivedJson == expectedJson)
+    // For every file returned in listFiles, we should be able to get the pre-signed url.
+    val fileIds2: Seq[String] = partitionDirectories2.flatMap { partitionDirectory =>
+      partitionDirectory.files.map { file =>
+        val path = DeltaSharingFileSystem.decode(file.getPath)
+        val (url, expiration) =
+          CachedTableManager.INSTANCE.getPreSignedUrl(path.tablePath, path.fileId)
+        assert(!url.isEmpty)
+        assert(expiration > 0)
+        path.fileId
+      }
+    }
+    // Different cacheEntry for different predicates.
+    assert(fileIds1 != fileIds2)
+    assert(CachedTableManager.INSTANCE.size == cacheSizeBegin +2)
+  }
+
+  test("identical queries against the same table share same cache entries") {
+    val spark = SparkSession.active
+    spark.sessionState.conf.setConfString("spark.delta.sharing.jsonPredicateHints.enabled", "true")
+    val client = new TestDeltaSharingClient()
+    val limit = 4L
+    val snapshot = new RemoteSnapshot(new Path("test"), client, Table("fe", "fi", "fo"))
+    val params = RemoteDeltaFileIndexParams(spark, snapshot, client.getProfileProvider)
+    val fileIndex = RemoteDeltaSnapshotFileIndex(params, Some(limit))
+    val sqlEq = SqlGreaterThan(
+      SqlAttributeReference("id", IntegerType)(),
+      SqlLiteral(21, IntegerType)
+    )
+    val expectedJson =
+      """{"op":"greaterThan",
+        |"children":[
+        |  {"op":"column","name":"id","valueType":"int"},
+        |  {"op":"literal","value":"21","valueType":"int"}]
+        |}""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")
+    val cacheSizeBegin = CachedTableManager.INSTANCE.size
+
+    // Send query 1 with predicates.
+    val partitionDirectories1 = fileIndex.listFiles(Seq(sqlEq), Seq.empty)
+    assert(TestDeltaSharingClient.limits === Seq(limit))
+    assert(TestDeltaSharingClient.jsonPredicateHints.size === 1)
+    val receivedJson = TestDeltaSharingClient.jsonPredicateHints(0)
+    assert(receivedJson == expectedJson)
+    // For every file returned in listFiles, we should be able to get the pre-signed url.
+    val fileIds1: Seq[String] = partitionDirectories1.flatMap { partitionDirectory =>
+      partitionDirectory.files.map { file =>
+        val path = DeltaSharingFileSystem.decode(file.getPath)
+        val (url, expiration) =
+          CachedTableManager.INSTANCE.getPreSignedUrl(path.tablePath, path.fileId)
+        assert(!url.isEmpty)
+        assert(expiration > 0)
+        path.fileId
+      }
+    }
+    client.clear
+
+    // Send query 2 with same predicates.
+    val partitionDirectories2 = fileIndex.listFiles(Seq(sqlEq), Seq.empty)
+    assert(TestDeltaSharingClient.limits === Seq(limit))
+    assert(TestDeltaSharingClient.jsonPredicateHints.size === 1)
+    val receivedJson2 = TestDeltaSharingClient.jsonPredicateHints(0)
+    assert(receivedJson2 == expectedJson)
+    // For every file returned in listFiles, we should be able to get the pre-signed url.
+    val fileIds2: Seq[String] = partitionDirectories2.flatMap { partitionDirectory =>
+      partitionDirectory.files.map { file =>
+        val path = DeltaSharingFileSystem.decode(file.getPath)
+        val (url, expiration) =
+          CachedTableManager.INSTANCE.getPreSignedUrl(path.tablePath, path.fileId)
+        assert(!url.isEmpty)
+        assert(expiration > 0)
+        path.fileId
+      }
+    }
+
+    // Same cacheEntry for same predicates.
+    assert(fileIds1 == fileIds2)
+    assert(CachedTableManager.INSTANCE.size == cacheSizeBegin +1)
+    client.clear
+  }
+
+  test("listing files from RemoteDeltaFileIndexParams") {
+    val spark = SparkSession.active
+    spark.sessionState.conf.setConfString("spark.delta.sharing.jsonPredicateHints.enabled", "true")
+    val client = new TestDeltaSharingClient()
+    val version = Some(1L)
+    val limit = Some(3L)
+    val snapshot = new RemoteSnapshot(
+      new Path("test"),
+      client,
+      Table("fe", "fi", "fo"),
+      versionAsOf = version
+    )
+    val fileIndex = {
+      val params = RemoteDeltaFileIndexParams(spark, snapshot, client.getProfileProvider)
+      RemoteDeltaSnapshotFileIndex(params, limit)
+    }
+    val partitionFilters = Seq(
+      SqlGreaterThan(
+        SqlAttributeReference("id", IntegerType)(),
+        SqlLiteral(21, IntegerType)
+      )
+    )
+    val jsonPredicateHints =
+      """{"op":"greaterThan",
+        |"children":[
+        |  {"op":"column","name":"id","valueType":"int"},
+        |  {"op":"literal","value":"21","valueType":"int"}]
+        |}""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")
+
+    // Check delta sharing path for listFiles
+    val queryParamsHashId = QueryUtils.getQueryParamsHashId(
+      Seq.empty,
+      limit,
+      Some(jsonPredicateHints),
+      version.get
+    )
+    val tablePath = QueryUtils.getTablePathWithIdSuffix(
+      fileIndex.params.profileProvider.getCustomTablePath(fileIndex.params.path.toString),
+      queryParamsHashId
+    )
+    val listFilesResult = fileIndex.listFiles(partitionFilters, Seq.empty)
+    assert(listFilesResult.size == 1)
+    assert(listFilesResult(0).files.size == limit.get)
+    assert(listFilesResult(0).files(0).getPath.toString == s"delta-sharing:/${tablePath}/f1/0")
+    assert(listFilesResult(0).files(1).getPath.toString == s"delta-sharing:/${tablePath}/f2/0")
+    assert(listFilesResult(0).files(2).getPath.toString == s"delta-sharing:/${tablePath}/f3/0")
+
+    // Check delta sharing path for inputFiles
+    val queryParamsHashId2 = QueryUtils.getQueryParamsHashId(
+      Nil,
+      None,
+      None,
+      version.get)
+    val tablePath2 = QueryUtils.getTablePathWithIdSuffix(
+      fileIndex.params.profileProvider.getCustomTablePath(fileIndex.params.path.toString),
+      queryParamsHashId2
+    )
+    val inputFileList = fileIndex.inputFiles.toList
+    assert(inputFileList.size == 4)
+    assert(inputFileList(0) == s"delta-sharing:/${tablePath2}/f1/0")
+    assert(inputFileList(1) == s"delta-sharing:/${tablePath2}/f2/0")
+    assert(inputFileList(2) == s"delta-sharing:/${tablePath2}/f3/0")
+    assert(inputFileList(3) == s"delta-sharing:/${tablePath2}/f4/0")
+  }
+
+  test("listing files from cdf file index") {
+    val path = new Path("test")
+    val table = Table("fe", "fi", "fo")
+    val client = new TestDeltaSharingClient()
+    val snapshot = new RemoteSnapshot(path, client, table)
+    // CDF queries cache all file actions for a table from a start version to an end version.
+    // No need to count filters into queryParamsHashId.
+    val queryParamsHashId = QueryUtils.getQueryParamsHashId(
+      Map(DeltaSharingOptions.CDF_START_VERSION -> "0",
+        DeltaSharingOptions.CDF_END_VERSION -> "100")
+    )
+    val params = RemoteDeltaFileIndexParams(
+      spark, snapshot, client.getProfileProvider, Some(queryParamsHashId))
+    val tablePath = QueryUtils.getTablePathWithIdSuffix(
+      params.profileProvider.getCustomTablePath(params.path.toString),
+      queryParamsHashId
+    )
+    val deltaTableFiles = client.getCDFFiles(table, Map.empty, false)
+
+    // Test CDFAddFileIndex
+    val addFilesIndex = new RemoteDeltaCDFAddFileIndex(params, deltaTableFiles.addFiles)
+    val addListFilesResult = addFilesIndex.listFiles(Seq.empty, Seq.empty)
+
+    assert(addListFilesResult.size == 1)
+    assert(addListFilesResult(0).files.size == 1)
+    assert(addListFilesResult(0).files(0).getPath.toString ==
+      s"delta-sharing:/${tablePath}/cdf_add1/100")
+
+    val addInputFileList = addFilesIndex.inputFiles.toList
+    assert(addInputFileList.size == 1)
+    assert(addInputFileList(0) == s"delta-sharing:/${tablePath}/cdf_add1/100")
+
+    // Test CDCFileIndex
+    val cdcIndex = new RemoteDeltaCDCFileIndex(params, deltaTableFiles.cdfFiles)
+    val cdcListFilesResult = cdcIndex.listFiles(Seq.empty, Seq.empty)
+    assert(cdcListFilesResult.size == 2)
+    // The partition dirs can be returned in any order.
+    val (cdcP1, cdcP2) = if (cdcListFilesResult(0).files.size == 1) {
+      (cdcListFilesResult(0), cdcListFilesResult(1))
+    } else {
+      (cdcListFilesResult(1), cdcListFilesResult(0))
+    }
+    assert(cdcP1.files.size == 1)
+    assert(cdcP1.files(0).getPath.toString == s"delta-sharing:/${tablePath}/cdf_cdc1/200")
+    assert(cdcP2.files.size == 2)
+    assert(cdcP2.files(0).getPath.toString == s"delta-sharing:/${tablePath}/cdf_cdc2/300")
+    assert(cdcP2.files(1).getPath.toString == s"delta-sharing:/${tablePath}/cdf_cdc3/310")
+
+    val cdcInputFileList = cdcIndex.inputFiles.toList
+    assert(cdcInputFileList.size == 3)
+    assert(cdcInputFileList(0) == s"delta-sharing:/${tablePath}/cdf_cdc1/200")
+    assert(cdcInputFileList(1) == s"delta-sharing:/${tablePath}/cdf_cdc2/300")
+    assert(cdcInputFileList(2) == s"delta-sharing:/${tablePath}/cdf_cdc3/310")
+
+    // Test CDFRemoveFileIndex
+    val removeFilesIndex = new RemoteDeltaCDFRemoveFileIndex(params, deltaTableFiles.removeFiles)
+    val removeListFilesResult = removeFilesIndex.listFiles(Seq.empty, Seq.empty)
+    assert(removeListFilesResult.size == 2)
+    val p1 = removeListFilesResult(0)
+    assert(p1.files.size == 1)
+    val p2 = removeListFilesResult(1)
+    assert(p2.files.size == 1)
+    // The partition dirs can be returned in any order.
+    assert(
+      (p1.files(0).getPath.toString == s"delta-sharing:/${tablePath}/cdf_rem1/400" &&
+        p2.files(0).getPath.toString == s"delta-sharing:/${tablePath}/cdf_rem2/420") ||
+        (p2.files(0).getPath.toString == s"delta-sharing:/${tablePath}/cdf_rem1/400" &&
+          p1.files(0).getPath.toString == s"delta-sharing:/${tablePath}/cdf_rem2/420")
+    )
+    val removeInputFileList = removeFilesIndex.inputFiles.toList
+    assert(removeInputFileList.size == 2)
+    assert(removeInputFileList(0) == s"delta-sharing:/${tablePath}/cdf_rem1/400")
+    assert(removeInputFileList(1) == s"delta-sharing:/${tablePath}/cdf_rem2/420")
+  }
+
+  test("listing files from RemoteDeltaBatchFileIndex") {
+    val path = new Path("test")
+    val table = Table("fe", "fi", "fo")
+    val client = new TestDeltaSharingClient()
+    val snapshot = new RemoteSnapshot(path, client, table)
+    // Streaming queries cache all AddFiles from a start version to an end version.
+    val startVersion = 1L
+    val queryParamsHashId = QueryUtils.getQueryParamsHashId(startVersion, startVersion + 1L)
+    val params = RemoteDeltaFileIndexParams(
+      spark, snapshot, client.getProfileProvider, Some(queryParamsHashId))
+    val tablePath = QueryUtils.getTablePathWithIdSuffix(
+      params.profileProvider.getCustomTablePath(params.path.toString),
+      queryParamsHashId
+    )
+    val deltaTableFiles = client.getFiles(table, Nil, None, Some(startVersion), None, None, None)
+
+    // Test BatchFileIndex list files
+    val batchFilesIndex = new RemoteDeltaBatchFileIndex(params, deltaTableFiles.files)
+    val listFilesResult = batchFilesIndex.listFiles(Seq.empty, Seq.empty)
+    assert(listFilesResult.size == 1)
+    assert(listFilesResult(0).files.size == 4)
+    assert(listFilesResult(0).files(0).getPath.toString == s"delta-sharing:/${tablePath}/f1/0")
+    assert(listFilesResult(0).files(1).getPath.toString == s"delta-sharing:/${tablePath}/f2/0")
+    assert(listFilesResult(0).files(2).getPath.toString == s"delta-sharing:/${tablePath}/f3/0")
+    assert(listFilesResult(0).files(3).getPath.toString == s"delta-sharing:/${tablePath}/f4/0")
+
+    // Test BatchFileIndex input files
+    val inputFileList = batchFilesIndex.inputFiles.toList
+    assert(inputFileList.size == 4)
+    assert(inputFileList(0) == s"delta-sharing:/${tablePath}/f1/0")
+    assert(inputFileList(1) == s"delta-sharing:/${tablePath}/f2/0")
+    assert(inputFileList(2) == s"delta-sharing:/${tablePath}/f3/0")
+    assert(inputFileList(3) == s"delta-sharing:/${tablePath}/f4/0")
+  }
+
+  test("RemoteDeltaLog path") {
+    // Create a dummy table path
+    val testProfileFile = Files.createTempFile("delta-test", ".share").toFile
+    FileUtils.writeStringToFile(testProfileFile,
+      s"""{
+         |  "shareCredentialsVersion": 1,
+         |  "endpoint": "http://localhost:12345/delta-sharing",
+         |  "bearerToken": "xxxxx"
+         |}""".stripMargin, UTF_8)
+    val tablePath = s"${testProfileFile.getCanonicalPath}#share.schema.table"
+
+    // Same as the table path
+    val deltaLog1 = RemoteDeltaLog(tablePath)
+    assert(deltaLog1.path.toString == tablePath)
+    val snapshot1 = deltaLog1.snapshot()
+    assert(snapshot1.getTablePath.toString == tablePath)
   }
 }


### PR DESCRIPTION
To prevent query registration failures when toggling the flag in DBR, we need to use a driver-level configuration instead of a session-level one. 

This is because, at the time the flag is flipped, the pre-signed URL cache is global, and there may still be existing CacheTable entries for the same table. Attempting to register a new QuerySpecificCachedTable in this state can fail due to class type mismatches. 

To ensure consistency, the flag should only take effect upon Spark cluster restart.