### PR TITLE
Reduce memory usage in delta format code paths

### DIFF
--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -182,7 +182,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Table(name = "table_with_cm_id", schema = "default", share = "share8"),
         Table(name = "deletion_vectors_with_dvs_dv_property_on", schema = "default", share = "share8"),
         Table(name = "dv_and_cm_table", schema = "default", share = "share8"),
-        Table(name = "timestampntz_cdf_table", schema = "default", share = "share8")
+        Table(name = "timestampntz_cdf_table", schema = "default", share = "share8"),
+        Table(name = "12k_rows", schema = "default", share = "share8")
       )
       assert(expected == client.listAllTables().toSet)
     } finally {

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -129,7 +129,8 @@ def load_as_pandas(
       metadata will be used to determine whether to use delta or parquet format.
     :param convert_in_batches: Whether to convert the parquet files to pandas one batch at a time
       rather than one file at a time. This may reduce memory consumption at the cost of taking
-      longer and downloading more data.
+      longer or downloading more data, with parquet format queries being more likely to see
+      improvements.
     :return: A pandas DataFrame representing the shared table.
     """
     profile_json, share, schema, table = _parse_url(url)
@@ -248,7 +249,8 @@ def load_table_changes_as_pandas(
       format.
     :param convert_in_batches: Whether to convert the parquet files to pandas one batch at a time
       rather than one file at a time. This may reduce memory consumption at the cost of taking
-      longer and downloading more data.
+      longer or downloading more data, with parquet format queries being more likely to see
+      improvements.
     :return: A pandas DataFrame representing the shared table.
     """
     profile_json, share, schema, table = _parse_url(url)

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -133,8 +133,15 @@ class DeltaSharingReader:
             schema = scan.execute(interface).schema
             return pd.DataFrame(columns=schema.names)
 
-        table = pa.Table.from_batches(scan.execute(interface))
-        result = table.to_pandas()
+        batches = scan.execute(interface)
+        pdfs = [batch.to_pandas() for batch in batches]
+        
+        result = pd.concat(
+            pdfs,
+            axis=0,
+            ignore_index=True,
+            copy=False,
+        )
 
         # Apply residual limit that was not handled from server pushdown
         result = result.head(self._limit)

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -327,16 +327,48 @@ def test_to_pandas_large_table_batch_convert(tmp_path):
             return "parquet"
 
     expected = pd.concat([pdf1, pdf2]).reset_index(drop=True)
+    expected_100k = pdf1.head(100000)
+    expected_300k = pd.concat([pdf1, pdf2.head(100000)]).reset_index(drop=True)
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.to_pandas()
     pd.testing.assert_frame_equal(pdf, expected)
 
     reader = DeltaSharingReader(
+        Table("table_name", "share_name", "schema_name"), RestClientMock(), limit=100000
+    )
+    pdf = reader.to_pandas()
+    pd.testing.assert_frame_equal(pdf, expected_100k)
+
+    reader = DeltaSharingReader(
+        Table("table_name", "share_name", "schema_name"), RestClientMock(), limit=300000
+    )
+    pdf = reader.to_pandas()
+    pd.testing.assert_frame_equal(pdf, expected_300k)
+
+    reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True
     )
     pdf = reader.to_pandas()
     pd.testing.assert_frame_equal(pdf, expected)
+
+    reader = DeltaSharingReader(
+        Table("table_name", "share_name", "schema_name"),
+        RestClientMock(),
+        limit=100000,
+        convert_in_batches=True,
+    )
+    pdf = reader.to_pandas()
+    pd.testing.assert_frame_equal(pdf, expected_100k)
+
+    reader = DeltaSharingReader(
+        Table("table_name", "share_name", "schema_name"),
+        RestClientMock(),
+        limit=300000,
+        convert_in_batches=True,
+    )
+    pdf = reader.to_pandas()
+    pd.testing.assert_frame_equal(pdf, expected_300k)
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -207,6 +207,12 @@ object TestResource {
             "default",
             java.util.Arrays.asList(
               TableConfig(
+                "12k_rows",
+                s"s3a://${AWS.bucket}/delta-exchange-test/12k_rows",
+                "00000000-0000-0000-0000-000000000096",
+                historyShared = true
+              ),
+              TableConfig(
                 "timestampntz_cdf_table",
                 s"s3a://${AWS.bucket}/delta-exchange-test/timestampntz_cdf_table",
                 "00000000-0000-0000-0000-000000000096",


### PR DESCRIPTION
Reduces memory consumption when using delta-kernel-rs by converting each batch into a pandas dataframe and concatenating the results together, rather than creating a pyarrow table from all the batches and converting that table with all the results. The pyarrow table usually remains in memory during the conversion to pandas, so it is best to convert smaller batches to pandas rather than the entire table.

This change is gated behind the `convert_in_batches` param.

Tested with integration test.

Also added some unit tests for #737 involving parquet format batch convert + limit.