### PR TITLE
Support OAuth 'audience' in Python Delta Sharing Client

### DIFF
--- a/python/delta_sharing/_internal_auth.py
+++ b/python/delta_sharing/_internal_auth.py
@@ -115,12 +115,13 @@ class OAuthClientCredentials:
 
 class OAuthClient:
     def __init__(
-        self, token_endpoint: str, client_id: str, client_secret: str, scope: Optional[str] = None
+        self, token_endpoint: str, client_id: str, client_secret: str, scope: Optional[str] = None, audience: Optional[str] = None
     ):
         self.token_endpoint = token_endpoint
         self.client_id = client_id
         self.client_secret = client_secret
         self.scope = scope
+        self.audience = audience
 
     def client_credentials(self) -> OAuthClientCredentials:
         credentials = base64.b64encode(
@@ -131,7 +132,7 @@ class OAuthClient:
             "authorization": f"Basic {credentials}",
             "content-type": "application/x-www-form-urlencoded",
         }
-        body = f"grant_type=client_credentials{f'&scope={self.scope}' if self.scope else ''}"
+        body = f"grant_type=client_credentials{f'&scope={self.scope}' if self.scope else ''}{f'&audience={self.audience}' if self.audience else ''}"
         response = requests.post(self.token_endpoint, headers=headers, data=body)
         response.raise_for_status()
         return self.parse_oauth_token_response(response.text)
@@ -241,6 +242,7 @@ class AuthCredentialProviderFactory:
             client_id=profile.client_id,
             client_secret=profile.client_secret,
             scope=profile.scope,
+            audience=profile.audience,
         )
         provider = OAuthClientCredentialsAuthProvider(
             oauth_client=oauth_client, auth_config=AuthConfig()

--- a/python/delta_sharing/protocol.py
+++ b/python/delta_sharing/protocol.py
@@ -36,6 +36,7 @@ class DeltaSharingProfile:
     username: Optional[str] = None
     password: Optional[str] = None
     scope: Optional[str] = None
+    audience: Optional[str] = None
 
     def __post_init__(self):
         if self.share_credentials_version > DeltaSharingProfile.CURRENT:
@@ -90,6 +91,7 @@ class DeltaSharingProfile:
                     client_id=json["clientId"],
                     client_secret=json["clientSecret"],
                     scope=json.get("scope"),
+                    audience=json.get("audience"),
                 )
             elif type == "bearer_token":
                 return DeltaSharingProfile(

--- a/python/delta_sharing/tests/test_auth.py
+++ b/python/delta_sharing/tests/test_auth.py
@@ -74,6 +74,7 @@ def test_oauth_client_credentials_auth_provider_exchange_token():
     profile.client_id = "client-id"
     profile.client_secret = "client-secret"
     profile.scope = None
+    profile.audience = None
 
     provider = OAuthClientCredentialsAuthProvider(oauth_client)
     mock_session = MagicMock(spec=Session)
@@ -97,6 +98,7 @@ def test_oauth_client_credentials_auth_provider_reuse_token():
     profile.client_id = "client-id"
     profile.client_secret = "client-secret"
     profile.scope = None
+    profile.audience = None
 
     provider = OAuthClientCredentialsAuthProvider(oauth_client)
     mock_session = MagicMock(spec=Session)
@@ -120,6 +122,7 @@ def test_oauth_client_credentials_auth_provider_refresh_token():
     profile.client_id = "client-id"
     profile.client_secret = "client-secret"
     profile.scope = None
+    profile.audience = None
 
     provider = OAuthClientCredentialsAuthProvider(oauth_client)
     mock_session = MagicMock(spec=Session)
@@ -147,6 +150,7 @@ def test_oauth_client_credentials_auth_provider_needs_refresh():
     profile.client_id = "client-id"
     profile.client_secret = "client-secret"
     profile.scope = None
+    profile.audience = None
 
     provider = OAuthClientCredentialsAuthProvider(oauth_client)
 
@@ -171,6 +175,7 @@ def test_oauth_client_credentials_auth_provider_is_expired():
     profile.client_id = "client-id"
     profile.client_secret = "client-secret"
     profile.scope = None
+    profile.audience = None
 
     provider = OAuthClientCredentialsAuthProvider(oauth_client)
     assert not provider.is_expired()
@@ -183,6 +188,7 @@ def test_oauth_client_credentials_auth_provider_get_expiration_time():
     profile.client_id = "client-id"
     profile.client_secret = "client-secret"
     profile.scope = None
+    profile.audience = None
 
     provider = OAuthClientCredentialsAuthProvider(oauth_client)
     assert provider.get_expiration_time() is None


### PR DESCRIPTION
This PR merges the changes required in python Delta Sharing Client to use the 'audience' parameter with OAuth providers which require it as a mandatory field for their Client Credentials (oauth/token) flow

Related Issue: #730 
Signed-off-by: Vasco Henriques <vascohenriques@icloud.com>