### PR TITLE
Reduce memory usage in parquet format code path

### DIFF
--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -113,6 +113,7 @@ def load_as_pandas(
     timestamp: Optional[str] = None,
     jsonPredicateHints: Optional[str] = None,
     use_delta_format: Optional[bool] = None,
+    convert_in_batches: bool = False,
 ) -> pd.DataFrame:
     """
     Load the shared table using the given url as a pandas DataFrame.
@@ -124,6 +125,11 @@ def load_as_pandas(
     :param version: an optional non-negative int. Load the snapshot of table at version
     :param jsonPredicateHints: Predicate hints to be applied to the table. For more details see:
       https://github.com/delta-io/delta-sharing/blob/main/PROTOCOL.md#json-predicates-for-filtering
+    :param use_delta_format: Whether to use delta format or parquet format. If not set, table
+      metadata will be used to determine whether to use delta or parquet format.
+    :param convert_in_batches: Whether to convert the parquet files to pandas one batch at a time
+      rather than one file at a time. This may reduce memory consumption at the cost of taking
+      longer and downloading more data.
     :return: A pandas DataFrame representing the shared table.
     """
     profile_json, share, schema, table = _parse_url(url)
@@ -136,6 +142,7 @@ def load_as_pandas(
         version=version,
         timestamp=timestamp,
         use_delta_format=use_delta_format,
+        convert_in_batches=convert_in_batches,
     ).to_pandas()
 
 
@@ -224,6 +231,7 @@ def load_table_changes_as_pandas(
     starting_timestamp: Optional[str] = None,
     ending_timestamp: Optional[str] = None,
     use_delta_format: Optional[bool] = None,
+    convert_in_batches: bool = False,
 ) -> pd.DataFrame:
     """
     Load the table changes of shared table as a pandas DataFrame using the given url.
@@ -236,6 +244,11 @@ def load_table_changes_as_pandas(
     :param ending_version: The ending version of table changes.
     :param starting_timestamp: The starting timestamp of table changes.
     :param ending_timestamp: The ending timestamp of table changes.
+    :param use_delta_format: Whether to use delta format or parquet format. Default is parquet
+      format.
+    :param convert_in_batches: Whether to convert the parquet files to pandas one batch at a time
+      rather than one file at a time. This may reduce memory consumption at the cost of taking
+      longer and downloading more data.
     :return: A pandas DataFrame representing the shared table.
     """
     profile_json, share, schema, table = _parse_url(url)
@@ -244,6 +257,7 @@ def load_table_changes_as_pandas(
         table=Table(name=table, share=share, schema=schema),
         rest_client=DataSharingRestClient(profile),
         use_delta_format=use_delta_format,
+        convert_in_batches=convert_in_batches,
     ).table_changes_to_pandas(
         CdfOptions(
             starting_version=starting_version,


### PR DESCRIPTION
This PR contains two optimizations:
1. When converting from arrow to pandas, read batches of rows at a time instead of entire parquet files. This change should eliminate pyarrow overhead almost entirely, which may be up to 40-50% reduction in memory usage.
2. Set `split_blocks=False`. I believe `split_blocks=True` was initially introduced in case it might help with memory usage during the arrow to pandas conversion. However, it should be set to false for three reasons:
-  In my testing, it doesn't affect the memory usage much (if at all).
-  We are converting small batches at a time now, so the memory usage of the conversion is negligible now (expect maybe if the table contains an extremely large number of columns)
-  As per the [documentation](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas), `split_blocks=True` may cause pandas consolidations when other operations are done on the dataframe later on. In some of my test tables, this has indeed introduced unnecessary consolidations and actually increased memory usage.

Because change 1 may result in worse performance, this change is gated behind the param `convert_in_batches`, which is false by default.

Also updated the docstrings of `load_as_pandas` and `load_table_changes_as_pandas`.

Tested with unit tests.