### PR TITLE
Release Python Connector 1.3.3

### DIFF
--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -179,7 +179,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         Table(name = "table_with_cm_id", schema = "default", share = "share8"),
         Table(name = "deletion_vectors_with_dvs_dv_property_on", schema = "default", share = "share8"),
         Table(name = "dv_and_cm_table", schema = "default", share = "share8"),
-        Table(name = "timestampntz_cdf_table", schema = "default", share = "share8")
+        Table(name = "timestampntz_cdf_table", schema = "default", share = "share8"),
+        Table(name = "12k_rows", schema = "default", share = "share8")
       )
       assert(expected == client.listAllTables().toSet)
     } finally {

--- a/dev/python_release.sh
+++ b/dev/python_release.sh
@@ -1,31 +1,32 @@
-#!/bin/bash -e -pipe
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Switch to the project root directory
-cd $( dirname $0 )
-cd ..
+pushd "$(dirname "$0")/.."
 
 # Clean existing artifacts
-cd python
+pushd python
 python3 setup.py clean --all
 rm -rf delta_sharing.egg-info dist
-cd ..
+popd
 
 printf "Please type the python release version: "
-read VERSION
-echo $VERSION
+read -r VERSION
+echo "$VERSION"
 
 # Update the Python connector version
-sed -i '' "s/__version__ = \".*\"/__version__ = \"$VERSION\"/g"  python/delta_sharing/version.py
-git add python/delta_sharing/version.py
+sed -i'' "s/^__version__ = \".*\"$/__version__ = \"$VERSION\"/" ./python/delta_sharing/version.py
+git add ./python/delta_sharing/version.py
 # Use --allow-empty so that we can re-run this script even if the Python connector version has been updated
 git commit -m "Update Python connector version to $VERSION" --allow-empty
 
 # This creates a lightweight tag that points to the current commit.
-git tag py-v$VERSION
+git tag "py-v$VERSION"
 
 # Generate Python artifacts
-cd python/
+pushd python
 python3 setup.py sdist bdist_wheel
-cd ..
+popd
 
 echo "=== Generated all release artifacts ==="
+popd

--- a/python/delta_sharing/_internal_auth.py
+++ b/python/delta_sharing/_internal_auth.py
@@ -35,12 +35,16 @@ from delta_sharing.protocol import (
 
 
 class AuthConfig:
-    def __init__(self, token_exchange_max_retries=5,
-                 token_exchange_max_retry_duration_in_seconds=60,
-                 token_renewal_threshold_in_seconds=600):
+    def __init__(
+        self,
+        token_exchange_max_retries=5,
+        token_exchange_max_retry_duration_in_seconds=60,
+        token_renewal_threshold_in_seconds=600,
+    ):
         self.token_exchange_max_retries = token_exchange_max_retries
         self.token_exchange_max_retry_duration_in_seconds = (
-            token_exchange_max_retry_duration_in_seconds)
+            token_exchange_max_retry_duration_in_seconds
+        )
         self.token_renewal_threshold_in_seconds = token_renewal_threshold_in_seconds
 
 
@@ -90,7 +94,10 @@ class BasicAuthProvider(AuthCredentialProvider):
 
     def add_auth_header(self, session: requests.Session) -> None:
         session.auth = (self.username, self.password)
-        session.post(self.endpoint, data={"grant_type": "client_credentials"},)
+        session.post(
+            self.endpoint,
+            data={"grant_type": "client_credentials"},
+        )
 
     def is_expired(self) -> bool:
         return False
@@ -107,11 +114,9 @@ class OAuthClientCredentials:
 
 
 class OAuthClient:
-    def __init__(self,
-                 token_endpoint: str,
-                 client_id: str,
-                 client_secret: str,
-                 scope: Optional[str] = None):
+    def __init__(
+        self, token_endpoint: str, client_id: str, client_secret: str, scope: Optional[str] = None
+    ):
         self.token_endpoint = token_endpoint
         self.client_id = client_id
         self.client_secret = client_secret
@@ -119,11 +124,12 @@ class OAuthClient:
 
     def client_credentials(self) -> OAuthClientCredentials:
         credentials = base64.b64encode(
-            f"{self.client_id}:{self.client_secret}".encode('utf-8')).decode('utf-8')
+            f"{self.client_id}:{self.client_secret}".encode("utf-8")
+        ).decode("utf-8")
         headers = {
-            'accept': 'application/json',
-            'authorization': f'Basic {credentials}',
-            'content-type': 'application/x-www-form-urlencoded'
+            "accept": "application/json",
+            "authorization": f"Basic {credentials}",
+            "content-type": "application/x-www-form-urlencoded",
         }
         body = f"grant_type=client_credentials{f'&scope={self.scope}' if self.scope else ''}"
         response = requests.post(self.token_endpoint, headers=headers, data=body)
@@ -136,9 +142,9 @@ class OAuthClient:
         # Parsing the response per oauth spec
         # https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
         json_node = json.loads(response)
-        if 'access_token' not in json_node or not isinstance(json_node['access_token'], str):
+        if "access_token" not in json_node or not isinstance(json_node["access_token"], str):
             raise RuntimeError("Missing 'access_token' field in OAuth token response")
-        if 'expires_in' not in json_node:
+        if "expires_in" not in json_node:
             raise RuntimeError("Missing 'expires_in' field in OAuth token response")
         try:
             # OAuth spec requires 'expires_in' to be an integer, e.g., 3600.
@@ -153,15 +159,13 @@ class OAuthClient:
             #   -d "client_id=$CLIENT_ID" \
             #   -d "client_secret=$CLIENT_SECRET" \
             #   -d "scope=https://graph.microsoft.com/.default"
-            expires_in = int(json_node['expires_in'])  # Convert to int if it's a string
+            expires_in = int(json_node["expires_in"])  # Convert to int if it's a string
         except ValueError:
             raise RuntimeError(
                 "'expires_in' field must be an integer or a string convertible to integer"
             )
         return OAuthClientCredentials(
-            json_node['access_token'],
-            expires_in,
-            int(datetime.now().timestamp())
+            json_node["access_token"], expires_in, int(datetime.now().timestamp())
         )
 
 
@@ -172,7 +176,7 @@ class OAuthClientCredentialsAuthProvider(AuthCredentialProvider):
         self.current_token: Optional[OAuthClientCredentials] = None
         self.lock = threading.RLock()
 
-    def add_auth_header(self,session: requests.Session) -> None:
+    def add_auth_header(self, session: requests.Session) -> None:
         token = self.maybe_refresh_token()
         with self.lock:
             session.headers.update(
@@ -199,9 +203,7 @@ class OAuthClientCredentialsAuthProvider(AuthCredentialProvider):
 
 
 class AuthCredentialProviderFactory:
-    __oauth_auth_provider_cache : Dict[
-        DeltaSharingProfile,
-        OAuthClientCredentialsAuthProvider] = {}
+    __oauth_auth_provider_cache: Dict[DeltaSharingProfile, OAuthClientCredentialsAuthProvider] = {}
 
     @staticmethod
     def create_auth_credential_provider(profile: DeltaSharingProfile):
@@ -210,14 +212,17 @@ class AuthCredentialProviderFactory:
                 return AuthCredentialProviderFactory.__oauth_client_credentials(profile)
             elif profile.type == "basic":
                 return AuthCredentialProviderFactory.__auth_basic(profile)
-        elif (profile.share_credentials_version == 1 and
-              (profile.type is None or profile.type == "bearer_token")):
+        elif profile.share_credentials_version == 1 and (
+            profile.type is None or profile.type == "bearer_token"
+        ):
             return AuthCredentialProviderFactory.__auth_bearer_token(profile)
 
         # any other scenario is unsupported
-        raise RuntimeError(f"unsupported profile.type: {profile.type}"
-                           f" profile.share_credentials_version"
-                           f" {profile.share_credentials_version}")
+        raise RuntimeError(
+            f"unsupported profile.type: {profile.type}"
+            f" profile.share_credentials_version"
+            f" {profile.share_credentials_version}"
+        )
 
     @staticmethod
     def __oauth_client_credentials(profile):
@@ -235,11 +240,10 @@ class AuthCredentialProviderFactory:
             token_endpoint=profile.token_endpoint,
             client_id=profile.client_id,
             client_secret=profile.client_secret,
-            scope=profile.scope
+            scope=profile.scope,
         )
         provider = OAuthClientCredentialsAuthProvider(
-            oauth_client=oauth_client,
-            auth_config=AuthConfig()
+            oauth_client=oauth_client, auth_config=AuthConfig()
         )
         AuthCredentialProviderFactory.__oauth_auth_provider_cache[profile] = provider
         return provider

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -51,10 +51,7 @@ def _parse_url(url: str) -> Tuple[str, str, str, str]:
     return (profile, share, schema, table)
 
 
-def get_table_version(
-    url: str,
-    starting_timestamp: Optional[str] = None
-) -> int:
+def get_table_version(url: str, starting_timestamp: Optional[str] = None) -> int:
     """
     Get the shared table version using the given url.
 
@@ -66,8 +63,7 @@ def get_table_version(
     profile = DeltaSharingProfile.read_from_file(profile_json)
     rest_client = DataSharingRestClient(profile)
     response = rest_client.query_table_version(
-        Table(name=table, share=share, schema=schema),
-        starting_timestamp
+        Table(name=table, share=share, schema=schema), starting_timestamp
     )
     return response.delta_table_version
 
@@ -139,14 +135,12 @@ def load_as_pandas(
         limit=limit,
         version=version,
         timestamp=timestamp,
-        use_delta_format=use_delta_format
+        use_delta_format=use_delta_format,
     ).to_pandas()
 
 
 def load_as_spark(
-    url: str,
-    version: Optional[int] = None,
-    timestamp: Optional[str] = None
+    url: str, version: Optional[int] = None, timestamp: Optional[str] = None
 ) -> "PySparkDataFrame":  # noqa: F821
     """
     Load the shared table using the given url as a Spark DataFrame. `PySpark` must be installed,
@@ -182,7 +176,7 @@ def load_table_changes_as_spark(
     starting_version: Optional[int] = None,
     ending_version: Optional[int] = None,
     starting_timestamp: Optional[str] = None,
-    ending_timestamp: Optional[str] = None
+    ending_timestamp: Optional[str] = None,
 ) -> "PySparkDataFrame":  # noqa: F821
     """
     Load the table changes of a shared table as a Spark DataFrame using the given url.
@@ -203,7 +197,8 @@ def load_table_changes_as_spark(
         from pyspark.sql import SparkSession
     except ImportError:
         raise ImportError(
-            "Unable to import pyspark. `load_table_changes_as_spark` requires PySpark.")
+            "Unable to import pyspark. `load_table_changes_as_spark` requires PySpark."
+        )
 
     spark = SparkSession.getActiveSession()
     assert spark is not None, (
@@ -228,7 +223,7 @@ def load_table_changes_as_pandas(
     ending_version: Optional[int] = None,
     starting_timestamp: Optional[str] = None,
     ending_timestamp: Optional[str] = None,
-    use_delta_format: Optional[bool] = None
+    use_delta_format: Optional[bool] = None,
 ) -> pd.DataFrame:
     """
     Load the table changes of shared table as a pandas DataFrame using the given url.
@@ -248,16 +243,18 @@ def load_table_changes_as_pandas(
     return DeltaSharingReader(
         table=Table(name=table, share=share, schema=schema),
         rest_client=DataSharingRestClient(profile),
-        use_delta_format=use_delta_format
-    ).table_changes_to_pandas(CdfOptions(
-        starting_version=starting_version,
-        ending_version=ending_version,
-        starting_timestamp=starting_timestamp,
-        ending_timestamp=ending_timestamp,
-        # when using delta format, we need to get metadata changes and
-        # handle them properly when replaying the delta log
-        include_historical_metadata=use_delta_format
-    ))
+        use_delta_format=use_delta_format,
+    ).table_changes_to_pandas(
+        CdfOptions(
+            starting_version=starting_version,
+            ending_version=ending_version,
+            starting_timestamp=starting_timestamp,
+            ending_timestamp=ending_timestamp,
+            # when using delta format, we need to get metadata changes and
+            # handle them properly when replaying the delta log
+            include_historical_metadata=use_delta_format,
+        )
+    )
 
 
 class SharingClient:

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -129,7 +129,8 @@ def load_as_pandas(
       metadata will be used to determine whether to use delta or parquet format.
     :param convert_in_batches: Whether to convert the parquet files to pandas one batch at a time
       rather than one file at a time. This may reduce memory consumption at the cost of taking
-      longer and downloading more data.
+      longer or downloading more data, with parquet format queries being more likely to see
+      improvements.
     :return: A pandas DataFrame representing the shared table.
     """
     profile_json, share, schema, table = _parse_url(url)
@@ -248,7 +249,8 @@ def load_table_changes_as_pandas(
       format.
     :param convert_in_batches: Whether to convert the parquet files to pandas one batch at a time
       rather than one file at a time. This may reduce memory consumption at the cost of taking
-      longer and downloading more data.
+      longer or downloading more data, with parquet format queries being more likely to see
+      improvements.
     :return: A pandas DataFrame representing the shared table.
     """
     profile_json, share, schema, table = _parse_url(url)

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -113,6 +113,7 @@ def load_as_pandas(
     timestamp: Optional[str] = None,
     jsonPredicateHints: Optional[str] = None,
     use_delta_format: Optional[bool] = None,
+    convert_in_batches: bool = False,
 ) -> pd.DataFrame:
     """
     Load the shared table using the given url as a pandas DataFrame.
@@ -124,6 +125,11 @@ def load_as_pandas(
     :param version: an optional non-negative int. Load the snapshot of table at version
     :param jsonPredicateHints: Predicate hints to be applied to the table. For more details see:
       https://github.com/delta-io/delta-sharing/blob/main/PROTOCOL.md#json-predicates-for-filtering
+    :param use_delta_format: Whether to use delta format or parquet format. If not set, table
+      metadata will be used to determine whether to use delta or parquet format.
+    :param convert_in_batches: Whether to convert the parquet files to pandas one batch at a time
+      rather than one file at a time. This may reduce memory consumption at the cost of taking
+      longer and downloading more data.
     :return: A pandas DataFrame representing the shared table.
     """
     profile_json, share, schema, table = _parse_url(url)
@@ -136,6 +142,7 @@ def load_as_pandas(
         version=version,
         timestamp=timestamp,
         use_delta_format=use_delta_format,
+        convert_in_batches=convert_in_batches,
     ).to_pandas()
 
 
@@ -224,6 +231,7 @@ def load_table_changes_as_pandas(
     starting_timestamp: Optional[str] = None,
     ending_timestamp: Optional[str] = None,
     use_delta_format: Optional[bool] = None,
+    convert_in_batches: bool = False,
 ) -> pd.DataFrame:
     """
     Load the table changes of shared table as a pandas DataFrame using the given url.
@@ -236,6 +244,11 @@ def load_table_changes_as_pandas(
     :param ending_version: The ending version of table changes.
     :param starting_timestamp: The starting timestamp of table changes.
     :param ending_timestamp: The ending timestamp of table changes.
+    :param use_delta_format: Whether to use delta format or parquet format. Default is parquet
+      format.
+    :param convert_in_batches: Whether to convert the parquet files to pandas one batch at a time
+      rather than one file at a time. This may reduce memory consumption at the cost of taking
+      longer and downloading more data.
     :return: A pandas DataFrame representing the shared table.
     """
     profile_json, share, schema, table = _parse_url(url)
@@ -244,6 +257,7 @@ def load_table_changes_as_pandas(
         table=Table(name=table, share=share, schema=schema),
         rest_client=DataSharingRestClient(profile),
         use_delta_format=use_delta_format,
+        convert_in_batches=convert_in_batches,
     ).table_changes_to_pandas(
         CdfOptions(
             starting_version=starting_version,

--- a/python/delta_sharing/protocol.py
+++ b/python/delta_sharing/protocol.py
@@ -97,7 +97,7 @@ class DeltaSharingProfile:
                     type=type,
                     endpoint=endpoint,
                     bearer_token=json["bearerToken"],
-                    expiration_time=json.get("expirationTime")
+                    expiration_time=json.get("expirationTime"),
                 )
             elif type == "basic":
                 return DeltaSharingProfile(
@@ -109,8 +109,8 @@ class DeltaSharingProfile:
                 )
             else:
                 raise ValueError(
-                    f"The current release does not supports {type} type. "
-                    "Please check type.")
+                    f"The current release does not supports {type} type. " "Please check type."
+                )
         else:
             raise ValueError(
                 "'shareCredentialsVersion' in the profile is "
@@ -153,8 +153,7 @@ class Table:
     def from_json(json) -> "Table":
         if isinstance(json, (str, bytes, bytearray)):
             json = loads(json)
-        return Table(name=json["name"], share=json["share"],
-                     schema=json["schema"])
+        return Table(name=json["name"], share=json["share"], schema=json["schema"])
 
 
 @dataclass(frozen=True)
@@ -234,7 +233,7 @@ class Metadata:
                 version=json.get("version", None),
                 size=json.get("size", None),
                 num_files=json.get("numFiles", None),
-                created_time=delta_metadata.get("createdTime", None)
+                created_time=delta_metadata.get("createdTime", None),
             )
         else:
             configuration = json.get("configuration", {})
@@ -248,7 +247,7 @@ class Metadata:
                 partition_columns=json["partitionColumns"],
                 version=json.get("version", None),
                 size=json.get("size", None),
-                num_files=json.get("numFiles", None)
+                num_files=json.get("numFiles", None),
             )
 
 

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -72,7 +72,7 @@ class DeltaSharingReader:
             jsonPredicateHints=self._jsonPredicateHints,
             limit=self._limit,
             version=self._version,
-            timestamp=self._timestamp
+            timestamp=self._timestamp,
         )
 
     def jsonPredicateHints(self, jsonPredicateHints: Optional[str]) -> "DeltaSharingReader":
@@ -81,7 +81,7 @@ class DeltaSharingReader:
             jsonPredicateHints=jsonPredicateHints,
             limit=self._limit,
             version=self._version,
-            timestamp=self._timestamp
+            timestamp=self._timestamp,
         )
 
     def limit(self, limit: Optional[int]) -> "DeltaSharingReader":
@@ -90,7 +90,7 @@ class DeltaSharingReader:
             jsonPredicateHints=self._jsonPredicateHints,
             limit=limit,
             version=self._version,
-            timestamp=self._timestamp
+            timestamp=self._timestamp,
         )
 
     def __to_pandas_kernel(self):
@@ -110,7 +110,7 @@ class DeltaSharingReader:
             jsonPredicateHints=self._jsonPredicateHints,
             limitHint=self._limit,
             version=self._version,
-            timestamp=self._timestamp
+            timestamp=self._timestamp,
         )
 
         lines = response.lines
@@ -126,7 +126,7 @@ class DeltaSharingReader:
         scan = delta_kernel_rust_sharing_wrapper.ScanBuilder(snapshot).build()
 
         # The table is empty so use the schema to return an empty table with correct col names
-        if (num_files == 0):
+        if num_files == 0:
             schema = scan.execute(interface).schema
             return pd.DataFrame(columns=schema.names)
 
@@ -152,7 +152,7 @@ class DeltaSharingReader:
             response_format = response_format = DataSharingRestClient.DELTA_FORMAT
 
         # If the response format is delta, use delta kernel rust
-        if (response_format == DataSharingRestClient.DELTA_FORMAT):
+        if response_format == DataSharingRestClient.DELTA_FORMAT:
             return self.__to_pandas_kernel()
 
         # Otherwise use the standard approach
@@ -162,7 +162,7 @@ class DeltaSharingReader:
             jsonPredicateHints=self._jsonPredicateHints,
             limitHint=self._limit,
             version=self._version,
-            timestamp=self._timestamp
+            timestamp=self._timestamp,
         )
 
         schema_json = loads(response.metadata.schema_string)
@@ -174,8 +174,8 @@ class DeltaSharingReader:
 
         if self._limit is None:
             pdfs = [
-                DeltaSharingReader._to_pandas(
-                    file, converters, False, None) for file in response.add_files
+                DeltaSharingReader._to_pandas(file, converters, False, None)
+                for file in response.add_files
             ]
         else:
             left = self._limit
@@ -208,13 +208,13 @@ class DeltaSharingReader:
         table_path = "file:///" + delta_log_dir_name
 
         # Create a new directory named '_delta_log' within the temporary directory
-        log_dir = os.path.join(delta_log_dir_name, '_delta_log')
+        log_dir = os.path.join(delta_log_dir_name, "_delta_log")
         os.makedirs(log_dir)
 
         # Create a new .json file within the '_delta_log' directory
         json_file_name = "0".zfill(20) + ".json"
         json_file_path = os.path.join(log_dir, json_file_name)
-        json_file = open(json_file_path, 'w+')
+        json_file = open(json_file_path, "w+")
 
         # Write the protocol action to the log file
         protocol_json = loads(lines.pop(0))
@@ -246,11 +246,11 @@ class DeltaSharingReader:
         max_version: int,
         version_to_metadata: Dict[int, Any],
         version_to_actions: Dict[int, Any],
-        version_to_timestamp: Dict[int, int]
+        version_to_timestamp: Dict[int, int],
     ):
         min_version_file_name = str(min_version).zfill(20) + ".json"
         min_version_path = os.path.join(log_dir, min_version_file_name)
-        with open(min_version_path, 'w+') as min_version_file:
+        with open(min_version_path, "w+") as min_version_file:
             dump(delta_protocol, min_version_file)
             min_version_file.write("\n")
 
@@ -258,7 +258,7 @@ class DeltaSharingReader:
         for version in range(min_version, max_version + 1):
             log_file_name = str(version).zfill(20) + ".json"
             log_file_path = os.path.join(log_dir, log_file_name)
-            with open(log_file_path, 'a+') as log_file:
+            with open(log_file_path, "a+") as log_file:
                 if version in version_to_metadata:
                     dump(version_to_metadata[version], log_file)
                     log_file.write("\n")
@@ -275,15 +275,16 @@ class DeltaSharingReader:
             # Fake checkpoint so kernel reads logs from the start version
             checkpoint_version = min_version - 1
             checkpoint_file_name = str(checkpoint_version).zfill(20) + ".checkpoint.parquet"
-            with open(os.path.join(log_dir, checkpoint_file_name), 'w+b') as checkpoint_file:
+            with open(os.path.join(log_dir, checkpoint_file_name), "w+b") as checkpoint_file:
                 checkpoint_file.write(get_fake_checkpoint_byte_array())
                 checkpoint_file.close()
 
             # Ensure _last_checkpoint points to the fake checkpoint
-            last_checkpoint_content = \
+            last_checkpoint_content = (
                 f'{{"version":{min_version - 1},"size":{len(get_fake_checkpoint_byte_array())}}}'
-            last_checkpoint_path = os.path.join(log_dir, '_last_checkpoint')
-            with open(last_checkpoint_path, 'w+') as last_checkpoint_file:
+            )
+            last_checkpoint_path = os.path.join(log_dir, "_last_checkpoint")
+            with open(last_checkpoint_path, "w+") as last_checkpoint_file:
                 last_checkpoint_file.write(last_checkpoint_content)
                 last_checkpoint_file.close()
 
@@ -324,9 +325,7 @@ class DeltaSharingReader:
                 max_version = max(max_version, version)
                 version_to_metadata[version] = delta_metadata
             else:
-                raise Exception(
-                    f"Invalid JSON object:\n{line}\nIs neither metadata nor file."
-                )
+                raise Exception(f"Invalid JSON object:\n{line}\nIs neither metadata nor file.")
 
         num_versions_with_action = len(version_to_actions)
         print(
@@ -343,7 +342,7 @@ class DeltaSharingReader:
             table_path = "file:///" + delta_log_dir_name
 
             # Create a new directory named '_delta_log' within the temporary directory
-            log_dir = os.path.join(delta_log_dir_name, '_delta_log')
+            log_dir = os.path.join(delta_log_dir_name, "_delta_log")
             os.makedirs(log_dir)
             self.__write_temp_delta_log_cdf(
                 log_dir,
@@ -402,7 +401,7 @@ class DeltaSharingReader:
         jsonPredicateHints: Optional[str],
         limit: Optional[int],
         version: Optional[int],
-        timestamp: Optional[str]
+        timestamp: Optional[str],
     ) -> "DeltaSharingReader":
         return DeltaSharingReader(
             table=self._table,
@@ -410,7 +409,7 @@ class DeltaSharingReader:
             predicateHints=predicateHints,
             limit=limit,
             version=version,
-            timestamp=timestamp
+            timestamp=timestamp,
         )
 
     @staticmethod
@@ -418,7 +417,7 @@ class DeltaSharingReader:
         action: FileAction,
         converters: Dict[str, Callable[[str], Any]],
         for_cdf: bool,
-        limit: Optional[int]
+        limit: Optional[int],
     ) -> pd.DataFrame:
         url = urlparse(action.url)
         if "storage.googleapis.com" in (url.netloc.lower()):
@@ -428,7 +427,7 @@ class DeltaSharingReader:
         protocol = url.scheme
         proxy = getproxies()
         if len(proxy) != 0:
-            filesystem = fsspec.filesystem(protocol, client_kwargs={"trust_env":True})
+            filesystem = fsspec.filesystem(protocol, client_kwargs={"trust_env": True})
         else:
             filesystem = fsspec.filesystem(protocol)
 
@@ -486,7 +485,7 @@ class DeltaSharingReader:
     @staticmethod
     def _add_special_cdf_schema(schema_json: dict) -> dict:
         fields = schema_json["fields"]
-        fields.append({"name" : DeltaSharingReader._change_type_col_name(), "type" : "string"})
-        fields.append({"name" : DeltaSharingReader._commit_version_col_name(), "type" : "long"})
-        fields.append({"name" : DeltaSharingReader._commit_timestamp_col_name(), "type" : "long"})
+        fields.append({"name": DeltaSharingReader._change_type_col_name(), "type": "string"})
+        fields.append({"name": DeltaSharingReader._commit_version_col_name(), "type": "long"})
+        fields.append({"name": DeltaSharingReader._commit_timestamp_col_name(), "type": "long"})
         return schema_json

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -165,7 +165,8 @@ class DataSharingRestClient:
     def __auth_session(self, profile):
         self._session = requests.Session()
         self._auth_credential_provider = (
-            AuthCredentialProviderFactory.create_auth_credential_provider(profile))
+            AuthCredentialProviderFactory.create_auth_credential_provider(profile)
+        )
         if urlparse(profile.endpoint).hostname == "localhost":
             self._session.verify = False
 
@@ -177,8 +178,9 @@ class DataSharingRestClient:
 
     def set_sharing_capabilities_header(self):
         delta_sharing_capabilities = (
-            DataSharingRestClient.DELTA_AND_PARQUET_RESPONSE_FORMAT + ';' +
-            self.__get_reader_features(False)
+            DataSharingRestClient.DELTA_AND_PARQUET_RESPONSE_FORMAT
+            + ";"
+            + self.__get_reader_features(False)
         )
         self._session.headers.update(
             {
@@ -191,8 +193,7 @@ class DataSharingRestClient:
 
     def set_delta_format_header(self, for_cdf=False):
         delta_sharing_capabilities = (
-            DataSharingRestClient.DELTA_RESPONSE_FORMAT + ';' +
-            self.__get_reader_features(for_cdf)
+            DataSharingRestClient.DELTA_RESPONSE_FORMAT + ";" + self.__get_reader_features(for_cdf)
         )
         self._session.headers.update(
             {
@@ -279,7 +280,7 @@ class DataSharingRestClient:
     def query_table_metadata(self, table: Table) -> QueryTableMetadataResponse:
         with self._get_internal(
             f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/metadata",
-            return_headers=True
+            return_headers=True,
         ) as values:
             headers = values[0]
             # it's a bug in the server if it doesn't return delta-table-version in the header
@@ -289,8 +290,9 @@ class DataSharingRestClient:
             protocol_json = json.loads(next(lines))
             metadata_json = json.loads(next(lines))
             return QueryTableMetadataResponse(
-                delta_table_version=int(headers.get(
-                    DataSharingRestClient.DELTA_TABLE_VERSION_HEADER)),
+                delta_table_version=int(
+                    headers.get(DataSharingRestClient.DELTA_TABLE_VERSION_HEADER)
+                ),
                 protocol=Protocol.from_json(protocol_json["protocol"]),
                 metadata=Metadata.from_json(metadata_json["metaData"]),
             )
@@ -306,7 +308,7 @@ class DataSharingRestClient:
 
         with self._get_internal(
             f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/metadata",
-            return_headers=True
+            return_headers=True,
         ) as values:
             # removing the client-reader-features that were set to avoid diverging standard codepath
             self.remove_sharing_capabilities_header()
@@ -322,7 +324,7 @@ class DataSharingRestClient:
             response_format = headers[DataSharingRestClient.CAPABILITIES_HEADER]
 
             # we now parse it to get either "delta" or "parquet"
-            if (DataSharingRestClient.DELTA_FORMAT in response_format):
+            if DataSharingRestClient.DELTA_FORMAT in response_format:
                 return DataSharingRestClient.DELTA_FORMAT
             else:
                 return DataSharingRestClient.PARQUET_FORMAT
@@ -336,10 +338,7 @@ class DataSharingRestClient:
         query_str = f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/version"
         if starting_timestamp is not None:
             query_str += f"?startingTimestamp={quote(starting_timestamp)}"
-        with self._get_internal(
-            query_str,
-            return_headers=True
-        ) as values:
+        with self._get_internal(query_str, return_headers=True) as values:
             headers = values[0]
 
             # it's a bug in the server if it doesn't return delta-table-version in the header
@@ -375,7 +374,7 @@ class DataSharingRestClient:
         with self._post_internal(
             f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/query",
             data=data,
-            return_headers=True
+            return_headers=True,
         ) as values:
             headers = values[0]
             # it's a bug in the server if it doesn't return delta-table-version in the header
@@ -384,11 +383,14 @@ class DataSharingRestClient:
 
             lines = values[1]
 
-            if (DataSharingRestClient.CAPABILITIES_HEADER in headers and
-                    "responseformat=delta" in headers[DataSharingRestClient.CAPABILITIES_HEADER]):
+            if (
+                DataSharingRestClient.CAPABILITIES_HEADER in headers
+                and "responseformat=delta" in headers[DataSharingRestClient.CAPABILITIES_HEADER]
+            ):
                 return ListFilesInTableResponse(
-                    delta_table_version=int(headers.get(
-                        DataSharingRestClient.DELTA_TABLE_VERSION_HEADER)),
+                    delta_table_version=int(
+                        headers.get(DataSharingRestClient.DELTA_TABLE_VERSION_HEADER)
+                    ),
                     protocol=None,
                     metadata=None,
                     add_files=[],
@@ -403,7 +405,7 @@ class DataSharingRestClient:
                     protocol=Protocol.from_json(protocol_json["protocol"]),
                     metadata=Metadata.from_json(metadata_json["metaData"]),
                     add_files=[AddFile.from_json(json.loads(file)["file"]) for file in lines],
-                    lines=[]
+                    lines=[],
                 )
 
     @retry_with_exponential_backoff
@@ -429,8 +431,10 @@ class DataSharingRestClient:
             if DataSharingRestClient.DELTA_TABLE_VERSION_HEADER not in headers:
                 raise LookupError("Missing delta-table-version header")
 
-            if (DataSharingRestClient.CAPABILITIES_HEADER in headers and
-                    "responseformat=delta" in headers[DataSharingRestClient.CAPABILITIES_HEADER]):
+            if (
+                DataSharingRestClient.CAPABILITIES_HEADER in headers
+                and "responseformat=delta" in headers[DataSharingRestClient.CAPABILITIES_HEADER]
+            ):
                 return ListTableChangesResponse(
                     protocol=None,
                     metadata=None,
@@ -448,7 +452,7 @@ class DataSharingRestClient:
                     protocol=Protocol.from_json(protocol_json["protocol"]),
                     metadata=Metadata.from_json(metadata_json["metaData"]),
                     actions=actions,
-                    lines=None
+                    lines=None,
                 )
 
     def close(self):
@@ -461,7 +465,8 @@ class DataSharingRestClient:
         return_headers: bool = False,
     ):
         return self._request_internal(
-            request=self._session.get, return_headers=return_headers, target=target, params=data)
+            request=self._session.get, return_headers=return_headers, target=target, params=data
+        )
 
     def _post_internal(
         self,
@@ -470,7 +475,8 @@ class DataSharingRestClient:
         return_headers: bool = False,
     ):
         return self._request_internal(
-            request=self._session.post, return_headers=return_headers, target=target, json=data)
+            request=self._session.post, return_headers=return_headers, target=target, json=data
+        )
 
     @contextmanager
     def _request_internal(

--- a/python/delta_sharing/tests/test_auth.py
+++ b/python/delta_sharing/tests/test_auth.py
@@ -16,11 +16,13 @@
 
 from unittest.mock import MagicMock
 from datetime import datetime, timedelta
-from delta_sharing._internal_auth import (OAuthClient,
-                                          BasicAuthProvider,
-                                          AuthCredentialProviderFactory,
-                                          OAuthClientCredentialsAuthProvider,
-                                          OAuthClientCredentials)
+from delta_sharing._internal_auth import (
+    OAuthClient,
+    BasicAuthProvider,
+    AuthCredentialProviderFactory,
+    OAuthClientCredentialsAuthProvider,
+    OAuthClientCredentials,
+)
 from requests import Session
 import requests
 from delta_sharing._internal_auth import BearerTokenAuthProvider
@@ -83,7 +85,8 @@ def test_oauth_client_credentials_auth_provider_exchange_token():
     provider.add_auth_header(mock_session)
 
     mock_session.headers.update.assert_called_once_with(
-        {"Authorization": f"Bearer {token.access_token}"})
+        {"Authorization": f"Bearer {token.access_token}"}
+    )
     oauth_client.client_credentials.assert_called_once()
 
 
@@ -99,14 +102,14 @@ def test_oauth_client_credentials_auth_provider_reuse_token():
     mock_session = MagicMock(spec=Session)
     mock_session.headers = MagicMock()
 
-    valid_token = OAuthClientCredentials(
-        "valid-token", 3600, int(datetime.now().timestamp()))
+    valid_token = OAuthClientCredentials("valid-token", 3600, int(datetime.now().timestamp()))
     provider.current_token = valid_token
 
     provider.add_auth_header(mock_session)
 
     mock_session.headers.update.assert_called_once_with(
-        {"Authorization": f"Bearer {valid_token.access_token}"})
+        {"Authorization": f"Bearer {valid_token.access_token}"}
+    )
     oauth_client.client_credentials.assert_not_called()
 
 
@@ -123,16 +126,17 @@ def test_oauth_client_credentials_auth_provider_refresh_token():
     mock_session.headers = MagicMock()
 
     expired_token = OAuthClientCredentials(
-        "expired-token", 1, int(datetime.now().timestamp()) - 3600)
-    new_token = OAuthClientCredentials(
-        "new-token", 3600, int(datetime.now().timestamp()))
+        "expired-token", 1, int(datetime.now().timestamp()) - 3600
+    )
+    new_token = OAuthClientCredentials("new-token", 3600, int(datetime.now().timestamp()))
     provider.current_token = expired_token
     oauth_client.client_credentials.return_value = new_token
 
     provider.add_auth_header(mock_session)
 
     mock_session.headers.update.assert_called_once_with(
-        {"Authorization": f"Bearer {new_token.access_token}"})
+        {"Authorization": f"Bearer {new_token.access_token}"}
+    )
     oauth_client.client_credentials.assert_called_once()
 
 
@@ -147,15 +151,16 @@ def test_oauth_client_credentials_auth_provider_needs_refresh():
     provider = OAuthClientCredentialsAuthProvider(oauth_client)
 
     expired_token = OAuthClientCredentials(
-        "expired-token", 1, int(datetime.now().timestamp()) - 3600)
+        "expired-token", 1, int(datetime.now().timestamp()) - 3600
+    )
     assert provider.needs_refresh(expired_token)
 
     token_expiring_soon = OAuthClientCredentials(
-        "expiring-soon-token", 600 - 5, int(datetime.now().timestamp()))
+        "expiring-soon-token", 600 - 5, int(datetime.now().timestamp())
+    )
     assert provider.needs_refresh(token_expiring_soon)
 
-    valid_token = OAuthClientCredentials(
-        "valid-token", 600 + 10, int(datetime.now().timestamp()))
+    valid_token = OAuthClientCredentials("valid-token", 600 + 10, int(datetime.now().timestamp()))
     assert not provider.needs_refresh(valid_token)
 
 
@@ -215,7 +220,7 @@ def test_factory_creation():
         type="basic",
         endpoint="https://localhost/delta-sharing/",
         username="username",
-        password="password"
+        password="password",
     )
     provider = AuthCredentialProviderFactory.create_auth_credential_provider(profile_basic)
     assert isinstance(provider, BasicAuthProvider)
@@ -225,7 +230,7 @@ def test_factory_creation():
         type="bearer_token",
         endpoint="https://localhost/delta-sharing/",
         bearer_token="token",
-        expiration_time=(datetime.now() + timedelta(hours=1)).isoformat()
+        expiration_time=(datetime.now() + timedelta(hours=1)).isoformat(),
     )
     provider = AuthCredentialProviderFactory.create_auth_credential_provider(profile_bearer)
     assert isinstance(provider, BearerTokenAuthProvider)
@@ -236,7 +241,7 @@ def test_factory_creation():
         endpoint="https://localhost/delta-sharing/",
         token_endpoint="https://localhost/token",
         client_id="clientId",
-        client_secret="clientSecret"
+        client_secret="clientSecret",
     )
     provider = AuthCredentialProviderFactory.create_auth_credential_provider(profile_oauth)
     assert isinstance(provider, OAuthClientCredentialsAuthProvider)
@@ -249,7 +254,7 @@ def test_oauth_auth_provider_reused():
         endpoint="https://localhost/delta-sharing/",
         token_endpoint="https://localhost/token",
         client_id="clientId",
-        client_secret="clientSecret"
+        client_secret="clientSecret",
     )
     provider1 = AuthCredentialProviderFactory.create_auth_credential_provider(profile_oauth1)
     assert isinstance(provider1, OAuthClientCredentialsAuthProvider)
@@ -260,7 +265,7 @@ def test_oauth_auth_provider_reused():
         endpoint="https://localhost/delta-sharing/",
         token_endpoint="https://localhost/token",
         client_id="clientId",
-        client_secret="clientSecret"
+        client_secret="clientSecret",
     )
 
     provider2 = AuthCredentialProviderFactory.create_auth_credential_provider(profile_oauth2)
@@ -275,7 +280,7 @@ def test_oauth_auth_provider_with_different_profiles():
         endpoint="https://localhost/delta-sharing/",
         token_endpoint="https://localhost/1/token",
         client_id="clientId",
-        client_secret="clientSecret"
+        client_secret="clientSecret",
     )
     provider1 = AuthCredentialProviderFactory.create_auth_credential_provider(profile_oauth1)
     assert isinstance(provider1, OAuthClientCredentialsAuthProvider)
@@ -286,7 +291,7 @@ def test_oauth_auth_provider_with_different_profiles():
         endpoint="https://localhost/delta-sharing/",
         token_endpoint="https://localhost/2/token",
         client_id="clientId",
-        client_secret="clientSecret"
+        client_secret="clientSecret",
     )
 
     provider2 = AuthCredentialProviderFactory.create_auth_credential_provider(profile_oauth2)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -56,7 +56,7 @@ def test_list_shares(sharing_client: SharingClient):
         Share(name="share7"),
         Share(name="share_azure"),
         Share(name="share_gcp"),
-        Share(name="share8")
+        Share(name="share8"),
     ]
 
 
@@ -75,7 +75,7 @@ def test_list_tables(sharing_client: SharingClient):
     assert tables == [
         Table(name="table1", share="share1", schema="default"),
         Table(name="table3", share="share1", schema="default"),
-        Table(name="table7", share="share1", schema="default")
+        Table(name="table7", share="share1", schema="default"),
     ]
 
     tables = sharing_client.list_tables(Schema(name="default", share="share2"))
@@ -194,7 +194,7 @@ def test_get_table_version(
     fragments: str,
     starting_timestamp: Optional[str],
     error: Optional[str],
-    expected_version: int
+    expected_version: int,
 ):
     if error is None:
         actual_version = get_table_version(f"{profile_path}#{fragments}", starting_timestamp)
@@ -259,11 +259,7 @@ def test_get_table_version(
         ),
     ],
 )
-def test_get_table_metadata(
-    profile_path: str,
-    fragments: str,
-    expected: Metadata
-):
+def test_get_table_metadata(profile_path: str, fragments: str, expected: Metadata):
     actual = get_table_metadata(f"{profile_path}#{fragments}")
     assert expected == actual
     actual_using_parquet = get_table_metadata(f"{profile_path}#{fragments}", use_delta_format=False)
@@ -275,8 +271,7 @@ def test_get_table_protocol(profile_path: str):
     actual = get_table_protocol(f"{profile_path}#share1.default.table1")
     assert Protocol(min_reader_version=1) == actual
     actual_using_parquet = get_table_protocol(
-        f"{profile_path}#share1.default.table1",
-        use_delta_format=False
+        f"{profile_path}#share1.default.table1", use_delta_format=False
     )
     assert Protocol(min_reader_version=1) == actual_using_parquet
 
@@ -326,8 +321,16 @@ def test_get_table_protocol(profile_path: str):
                         pd.Timestamp("2021-04-28 23:35:53.156"),
                         pd.Timestamp("2021-04-28 23:36:47.599"),
                     ],
-                    "date": [date(2021, 4, 28), date(2021, 4, 28), date(2021, 4, 28),],
-                    "type": ["bar", None, "foo",],
+                    "date": [
+                        date(2021, 4, 28),
+                        date(2021, 4, 28),
+                        date(2021, 4, 28),
+                    ],
+                    "type": [
+                        "bar",
+                        None,
+                        "foo",
+                    ],
                 }
             ),
             id="partitioned and different schemas",
@@ -383,7 +386,7 @@ def test_get_table_protocol(profile_path: str):
                     "eventTime": [
                         pd.Timestamp("2021-04-28 23:36:51.945"),
                         pd.Timestamp("2021-04-28 23:35:53.156"),
-                        pd.Timestamp("2021-04-28 23:36:47.599")
+                        pd.Timestamp("2021-04-28 23:36:47.599"),
                     ],
                     "date": [date(2021, 4, 28), date(2021, 4, 28), date(2021, 4, 28)],
                     "type": ["bar", None, "foo"],
@@ -400,7 +403,7 @@ def test_get_table_protocol(profile_path: str):
                     "eventTime": [
                         pd.Timestamp("2021-04-28 23:36:51.945"),
                         pd.Timestamp("2021-04-28 23:35:53.156"),
-                        pd.Timestamp("2021-04-28 23:36:47.599")
+                        pd.Timestamp("2021-04-28 23:36:47.599"),
                     ],
                     "date": [date(2021, 4, 28), date(2021, 4, 28), date(2021, 4, 28)],
                     "type": ["bar", None, "foo"],
@@ -500,7 +503,7 @@ def test_load_as_pandas_success(
     fragments: str,
     limit: Optional[int],
     version: Optional[int],
-    expected: pd.DataFrame
+    expected: pd.DataFrame,
 ):
     pdf = load_as_pandas(f"{profile_path}#{fragments}", limit, version, None)
     pd.testing.assert_frame_equal(pdf, expected)
@@ -554,7 +557,7 @@ def test_load_as_pandas_success(
                         pd.Timestamp("2023-05-31T18:58:33.633+00:00"),
                         pd.Timestamp("2023-05-31T18:58:33.633+00:00"),
                         pd.Timestamp("2023-05-31T18:58:33.633+00:00"),
-                        pd.Timestamp("2023-05-31T18:58:33.633+00:00")
+                        pd.Timestamp("2023-05-31T18:58:33.633+00:00"),
                     ],
                     "rand": [
                         0.7918174793484931,
@@ -562,7 +565,7 @@ def test_load_as_pandas_success(
                         0.27796520310701633,
                         0.15263801464228832,
                         0.1981143710215575,
-                        0.3069439236599195
+                        0.3069439236599195,
                     ],
                 }
             ),
@@ -579,13 +582,9 @@ def test_load_as_pandas_success(
                     "timestamp": [
                         pd.Timestamp("2023-05-31T18:58:33.633+00:00"),
                         pd.Timestamp("2023-05-31T18:58:33.633+00:00"),
-                        pd.Timestamp("2023-05-31T18:58:33.633+00:00")
+                        pd.Timestamp("2023-05-31T18:58:33.633+00:00"),
                     ],
-                    "rand": [
-                        0.7918174793484931,
-                        0.9281049271981882,
-                        0.27796520310701633
-                    ],
+                    "rand": [0.7918174793484931, 0.9281049271981882, 0.27796520310701633],
                 }
             ),
             id="dv",
@@ -600,12 +599,9 @@ def test_load_as_pandas_success(
                     "value": ["3", "4"],
                     "timestamp": [
                         pd.Timestamp("2023-05-31T18:58:33.633+00:00"),
-                        pd.Timestamp("2023-05-31T18:58:33.633+00:00")
+                        pd.Timestamp("2023-05-31T18:58:33.633+00:00"),
                     ],
-                    "rand": [
-                        0.7918174793484931,
-                        0.9281049271981882
-                    ],
+                    "rand": [0.7918174793484931, 0.9281049271981882],
                 }
             ),
             id="dv",
@@ -617,10 +613,10 @@ def test_load_as_pandas_success_dv(
     fragments: str,
     limit: Optional[int],
     version: Optional[int],
-    expected: pd.DataFrame
+    expected: pd.DataFrame,
 ):
     pdf = load_as_pandas(f"{profile_path}#{fragments}", limit, version, None)
-    expected['timestamp'] = expected['timestamp'].astype('datetime64[us, UTC]')
+    expected["timestamp"] = expected["timestamp"].astype("datetime64[us, UTC]")
     pd.testing.assert_frame_equal(pdf, expected)
 
 
@@ -638,7 +634,7 @@ def test_load_as_pandas_success_dv(
                     "eventTime": [
                         pd.Timestamp("2024-06-25T00:00:00.000+00:00"),
                         pd.Timestamp("2024-06-25T01:00:00.000+00:00"),
-                        pd.Timestamp("2024-06-25T00:00:00.000+00:00")
+                        pd.Timestamp("2024-06-25T00:00:00.000+00:00"),
                     ],
                 }
             ),
@@ -653,7 +649,7 @@ def test_load_as_pandas_success_dv(
                     "date": [date(2024, 6, 25), date(2024, 6, 25)],
                     "eventTime": [
                         pd.Timestamp("2024-06-25T00:00:00.000+00:00"),
-                        pd.Timestamp("2024-06-25T01:00:00.000+00:00")
+                        pd.Timestamp("2024-06-25T01:00:00.000+00:00"),
                     ],
                 }
             ),
@@ -666,9 +662,7 @@ def test_load_as_pandas_success_dv(
             pd.DataFrame(
                 {
                     "date": [date(2024, 6, 25)],
-                    "eventTime": [
-                        pd.Timestamp("2024-06-25T00:00:00.000+00:00")
-                    ],
+                    "eventTime": [pd.Timestamp("2024-06-25T00:00:00.000+00:00")],
                 }
             ),
             id="column map name",
@@ -680,10 +674,10 @@ def test_load_as_pandas_success_cm(
     fragments: str,
     limit: Optional[int],
     version: Optional[int],
-    expected: pd.DataFrame
+    expected: pd.DataFrame,
 ):
     pdf = load_as_pandas(f"{profile_path}#{fragments}", limit, version, None)
-    expected['eventTime'] = expected['eventTime'].astype('datetime64[us, UTC]')
+    expected["eventTime"] = expected["eventTime"].astype("datetime64[us, UTC]")
     pd.testing.assert_frame_equal(pdf, expected)
 
 
@@ -699,7 +693,7 @@ def test_load_as_pandas_success_cm(
                 {
                     "id": [0, 2, 3, 4, 5],
                     "rand": [74, 45, 37, 69, 58],
-                    "partition_col": [3, 3, 3, 3, 3]
+                    "partition_col": [3, 3, 3, 3, 3],
                 }
             ),
             id="deletion vector and column map name",
@@ -711,11 +705,11 @@ def test_load_as_pandas_success_dv_and_cm(
     fragments: str,
     limit: Optional[int],
     version: Optional[int],
-    expected: pd.DataFrame
+    expected: pd.DataFrame,
 ):
     pdf = load_as_pandas(f"{profile_path}#{fragments}", limit, version, None)
-    expected['rand'] = expected['rand'].astype('int32')
-    expected['partition_col'] = expected['partition_col'].astype('int32')
+    expected["rand"] = expected["rand"].astype("int32")
+    expected["partition_col"] = expected["partition_col"].astype("int32")
     pd.testing.assert_frame_equal(pdf, expected)
 
     # Test client specifying explicit delta format
@@ -741,7 +735,7 @@ def test_load_as_pandas_success_empty_dv_and_cm(
     fragments: str,
     limit: Optional[int],
     version: Optional[int],
-    expected: pd.DataFrame
+    expected: pd.DataFrame,
 ):
     pdf = load_as_pandas(f"{profile_path}#{fragments}", limit, version, None)
     pd.testing.assert_frame_equal(pdf, expected)
@@ -767,13 +761,11 @@ def test_load_as_pandas_success_empty_dv_and_cm(
     ],
 )
 def test_load_as_pandas_success_timestampntz(
-    profile_path: str,
-    fragments: str,
-    expected: pd.DataFrame
+    profile_path: str, fragments: str, expected: pd.DataFrame
 ):
     pdf = load_as_pandas(f"{profile_path}#{fragments}")
-    expected['time'] = expected['time'].values.astype('datetime64[us]')
-    expected['id'] = expected['id'].astype('int32')
+    expected["time"] = expected["time"].values.astype("datetime64[us]")
+    expected["id"] = expected["id"].astype("int32")
     pd.testing.assert_frame_equal(pdf, expected)
 
 
@@ -803,10 +795,10 @@ def test_load_as_pandas_success_client_delta_kernel_enabled_with_normal_table(
     fragments: str,
     limit: Optional[int],
     version: Optional[int],
-    expected: pd.DataFrame
+    expected: pd.DataFrame,
 ):
     pdf = load_as_pandas(f"{profile_path}#{fragments}", limit, version, None, None, True)
-    expected['eventTime'] = expected['eventTime'].astype('datetime64[us, UTC]')
+    expected["eventTime"] = expected["eventTime"].astype("datetime64[us, UTC]")
     pd.testing.assert_frame_equal(pdf, expected)
 
 
@@ -902,10 +894,7 @@ def test_load_as_pandas_success_client_delta_kernel_enabled_with_normal_table(
     ],
 )
 def test_load_as_pandas_with_json_predicates(
-    profile_path: str,
-    fragments: str,
-    jsonPredicateHints: Optional[str],
-    expected: pd.DataFrame
+    profile_path: str, fragments: str, jsonPredicateHints: Optional[str], expected: pd.DataFrame
 ):
     pdf = load_as_pandas(f"{profile_path}#{fragments}", None, None, None, jsonPredicateHints)
     pd.testing.assert_frame_equal(pdf, expected)
@@ -950,7 +939,7 @@ def test_load_as_pandas_exception(
     fragments: str,
     version: Optional[int],
     timestamp: Optional[str],
-    error: Optional[str]
+    error: Optional[str],
 ):
     try:
         load_as_pandas(f"{profile_path}#{fragments}", None, version, timestamp)
@@ -978,7 +967,7 @@ def test_load_as_pandas_exception_kernel(
     fragments: str,
     version: Optional[int],
     timestamp: Optional[str],
-    error: Optional[str]
+    error: Optional[str],
 ):
     try:
         load_as_pandas(f"{profile_path}#{fragments}", None, version, timestamp)
@@ -1005,7 +994,7 @@ def test_load_as_pandas_exception_client_delta_kernel_disabled_with_delta_table(
     fragments: str,
     version: Optional[int],
     timestamp: Optional[str],
-    error: Optional[str]
+    error: Optional[str],
 ):
     try:
         load_as_pandas(f"{profile_path}#{fragments}", None, version, timestamp, None, False)
@@ -1117,7 +1106,7 @@ def test_load_table_changes(
     starting_timestamp: Optional[str],
     ending_timestamp: Optional[str],
     error: Optional[str],
-    expected: pd.DataFrame
+    expected: pd.DataFrame,
 ):
     if error is None:
         pdf = load_table_changes_as_pandas(
@@ -1125,7 +1114,7 @@ def test_load_table_changes(
             starting_version,
             ending_version,
             starting_timestamp,
-            ending_timestamp
+            ending_timestamp,
         )
         pd.testing.assert_frame_equal(pdf, expected)
     else:
@@ -1135,7 +1124,7 @@ def test_load_table_changes(
                 starting_version,
                 ending_version,
                 starting_timestamp,
-                ending_timestamp
+                ending_timestamp,
             )
             assert False
         except Exception as e:
@@ -1258,7 +1247,7 @@ def test_load_table_changes_kernel(
             use_delta_format=True,
         )
         if len(pdf) > 0:
-            pdf['_commit_timestamp'] = pdf['_commit_timestamp'].astype('int') // 1000
+            pdf["_commit_timestamp"] = pdf["_commit_timestamp"].astype("int") // 1000
         pd.testing.assert_frame_equal(pdf, expected)
     else:
         try:
@@ -1391,7 +1380,7 @@ def test_load_table_changes_partition_kernel(
             use_delta_format=True,
         )
         if len(pdf) > 0:
-            pdf['_commit_timestamp'] = pdf['_commit_timestamp'].astype('int') // 1000
+            pdf["_commit_timestamp"] = pdf["_commit_timestamp"].astype("int") // 1000
         pd.testing.assert_frame_equal(pdf, expected)
     else:
         try:
@@ -1410,8 +1399,7 @@ def test_load_table_changes_partition_kernel(
 
 # TODO: Enable once timestampntz + CDF support is enabled for both
 @pytest.mark.skipif(
-    True,
-    reason="timestampNtz + CDF not supported in OSS server or delta-kernel-rs yet"
+    True, reason="timestampNtz + CDF not supported in OSS server or delta-kernel-rs yet"
 )
 @pytest.mark.parametrize(
     "fragments,expected",
@@ -1445,7 +1433,7 @@ def test_load_table_changes_partition_kernel(
                         1741140657000,
                         1741140657000,
                         1741140565000,
-                    ]
+                    ],
                 }
             ),
             id="test read timestampntz",
@@ -1453,18 +1441,14 @@ def test_load_table_changes_partition_kernel(
     ],
 )
 def test_load_table_changes_as_pandas_timestampntz(
-    profile_path: str,
-    fragments: str,
-    expected: pd.DataFrame
+    profile_path: str, fragments: str, expected: pd.DataFrame
 ):
     pdf = load_table_changes_as_pandas(
-        f"{profile_path}#{fragments}",
-        starting_version=0,
-        use_delta_format=True
+        f"{profile_path}#{fragments}", starting_version=0, use_delta_format=True
     )
-    expected['time'] = expected['time'].values.astype('datetime64[us]')
-    expected['id'] = expected['id'].astype('int32')
-    pdf['_commit_timestamp'] = pdf['_commit_timestamp'].astype('int') // 1000
+    expected["time"] = expected["time"].values.astype("datetime64[us]")
+    expected["id"] = expected["id"].astype("int32")
+    pdf["_commit_timestamp"] = pdf["_commit_timestamp"].astype("int") // 1000
     pd.testing.assert_frame_equal(pdf, expected)
 
 
@@ -1563,12 +1547,14 @@ def test_load_as_spark(
 ):
     try:
         from pyspark.sql import SparkSession
-        spark = SparkSession.builder \
-            .appName("delta-sharing-test") \
-            .master("local[*]") \
-            .config("spark.jars.packages", "io.delta:delta-sharing-spark_2.12:1.0.0-SNAPSHOT") \
-            .config("spark.delta.sharing.network.sslTrustAll", "true") \
+
+        spark = (
+            SparkSession.builder.appName("delta-sharing-test")
+            .master("local[*]")
+            .config("spark.jars.packages", "io.delta:delta-sharing-spark_2.12:1.0.0-SNAPSHOT")
+            .config("spark.delta.sharing.network.sslTrustAll", "true")
             .getOrCreate()
+        )
 
         if error is None:
             expected_df = spark.createDataFrame(expected_data, expected_schema_str)
@@ -1590,8 +1576,8 @@ def test_load_as_spark(
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 @pytest.mark.parametrize(
-    "fragments,starting_version,ending_version,starting_timestamp,ending_timestamp,error," +
-    "expected_data,expected_schema_str",
+    "fragments,starting_version,ending_version,starting_timestamp,ending_timestamp,error,"
+    + "expected_data,expected_schema_str",
     [
         pytest.param(
             "share8.default.cdf_table_cdf_enabled",
@@ -1608,8 +1594,8 @@ def test_load_as_spark(
                 ("2", 2, date(2020, 2, 2), 3, 1651272660000, "update_postimage"),
                 ("3", 3, date(2020, 1, 1), 2, 1651272655000, "delete"),
             ],
-            "name: string, age: int, birthday:date, _commit_version: long, _commit_timestamp" +
-            ": long, _change_type: string",
+            "name: string, age: int, birthday:date, _commit_version: long, _commit_timestamp"
+            + ": long, _change_type: string",
             id="cdf_table_cdf_enabled table changes",
         ),
         pytest.param(
@@ -1642,8 +1628,8 @@ def test_load_as_spark(
             None,
             "cdf is not enabled on table share1.default.table1",
             [],
-            "name: string, age: int, birthday:date, _commit_version: long, _commit_timestamp" +
-            ": long, _change_type: string",
+            "name: string, age: int, birthday:date, _commit_version: long, _commit_timestamp"
+            + ": long, _change_type: string",
             id="table1 table changes not enabled",
         ),
     ],
@@ -1657,16 +1643,18 @@ def test_load_table_changes_as_spark(
     ending_timestamp: Optional[str],
     error: Optional[str],
     expected_data: list,
-    expected_schema_str: str
+    expected_schema_str: str,
 ):
     try:
         from pyspark.sql import SparkSession
-        spark = SparkSession.builder \
-            .appName("delta-sharing-test") \
-            .master("local[*]") \
-            .config("spark.jars.packages", "io.delta:delta-sharing-spark_2.12:1.0.0-SNAPSHOT") \
-            .config("spark.delta.sharing.network.sslTrustAll", "true") \
+
+        spark = (
+            SparkSession.builder.appName("delta-sharing-test")
+            .master("local[*]")
+            .config("spark.jars.packages", "io.delta:delta-sharing-spark_2.12:1.0.0-SNAPSHOT")
+            .config("spark.delta.sharing.network.sslTrustAll", "true")
             .getOrCreate()
+        )
 
         if error is None:
             expected_df = spark.createDataFrame(expected_data, expected_schema_str)
@@ -1676,7 +1664,7 @@ def test_load_table_changes_as_spark(
                 starting_version=starting_version,
                 ending_version=ending_version,
                 starting_timestamp=starting_timestamp,
-                ending_timestamp=ending_timestamp
+                ending_timestamp=ending_timestamp,
             )
             assert expected_df.schema == actual_df.schema
             assert expected_df.collect() == actual_df.collect()
@@ -1687,7 +1675,7 @@ def test_load_table_changes_as_spark(
                     starting_version=starting_version,
                     ending_version=ending_version,
                     starting_timestamp=starting_timestamp,
-                    ending_timestamp=ending_timestamp
+                    ending_timestamp=ending_timestamp,
                 )
             except Exception as e:
                 assert isinstance(e, HTTPError)
@@ -1695,7 +1683,7 @@ def test_load_table_changes_as_spark(
 
     except ImportError:
         with pytest.raises(
-            ImportError, match="Unable to import pyspark. `load_table_changes_as_spark` requires" +
-            " PySpark."
+            ImportError,
+            match="Unable to import pyspark. `load_table_changes_as_spark` requires" + " PySpark.",
         ):
             load_table_changes_as_spark("not-used")

--- a/python/delta_sharing/tests/test_oauth_client.py
+++ b/python/delta_sharing/tests/test_oauth_client.py
@@ -29,7 +29,7 @@ class MockServer:
     def add_response(self, status_code, json_data):
         response = Response()
         response.status_code = status_code
-        response._content = json_data.encode('utf-8')
+        response._content = json_data.encode("utf-8")
         self.responses.append(response)
 
     def get_response(self):
@@ -42,37 +42,36 @@ def mock_server():
     yield server
 
 
-@pytest.mark.parametrize("response_data, expected_expires_in, expected_access_token", [
-    # OAuth spec requires 'expires_in' to be an integer, e.g., 3600.
-    # See https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
-    # But some token endpoints return `expires_in` as a string e.g., "3600".
-    # This test ensures the client can handle such cases.
-    # The test case ensures that we support both integer and string values for 'expires_in' field.
-    (
-        '{"access_token": "test-access-token", "expires_in": 3600, "token_type": "bearer"}',
-        3600,
-        "test-access-token"
-    ),
-    (
-        '{"access_token": "test-access-token", "expires_in": "3600", "token_type": "bearer"}',
-        3600,
-        "test-access-token"
-    )
-])
-def test_oauth_client_should_parse_token_response_correctly(mock_server,
-                                                            response_data,
-                                                            expected_expires_in,
-                                                            expected_access_token):
-    mock_server.add_response(
-        200,
-        response_data)
+@pytest.mark.parametrize(
+    "response_data, expected_expires_in, expected_access_token",
+    [
+        # OAuth spec requires 'expires_in' to be an integer, e.g., 3600.
+        # See https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+        # But some token endpoints return `expires_in` as a string e.g., "3600".
+        # This test ensures the client can handle such cases.
+        # The test case ensures that we support both integer and string values
+        # for the 'expires_in' field.
+        (
+            '{"access_token": "test-access-token", "expires_in": 3600, "token_type": "bearer"}',
+            3600,
+            "test-access-token",
+        ),
+        (
+            '{"access_token": "test-access-token", "expires_in": "3600", "token_type": "bearer"}',
+            3600,
+            "test-access-token",
+        ),
+    ],
+)
+def test_oauth_client_should_parse_token_response_correctly(
+    mock_server, response_data, expected_expires_in, expected_access_token
+):
+    mock_server.add_response(200, response_data)
 
-    with patch('requests.post') as mock_post:
+    with patch("requests.post") as mock_post:
         mock_post.side_effect = lambda *args, **kwargs: mock_server.get_response()
         oauth_client = OAuthClient(
-            token_endpoint=mock_server.url,
-            client_id="client-id",
-            client_secret="client-secret"
+            token_endpoint=mock_server.url, client_id="client-id", client_secret="client-secret"
         )
 
         start = datetime.now().timestamp()
@@ -86,14 +85,12 @@ def test_oauth_client_should_parse_token_response_correctly(mock_server,
 
 
 def test_oauth_client_should_handle_401_unauthorized_response(mock_server):
-    mock_server.add_response(401, 'Unauthorized')
+    mock_server.add_response(401, "Unauthorized")
 
-    with patch('requests.post') as mock_post:
+    with patch("requests.post") as mock_post:
         mock_post.side_effect = lambda *args, **kwargs: mock_server.get_response()
         oauth_client = OAuthClient(
-            token_endpoint=mock_server.url,
-            client_id="client-id",
-            client_secret="client-secret"
+            token_endpoint=mock_server.url, client_id="client-id", client_secret="client-secret"
         )
         try:
             oauth_client.client_credentials()

--- a/python/delta_sharing/tests/test_protocol.py
+++ b/python/delta_sharing/tests/test_protocol.py
@@ -108,11 +108,9 @@ def test_share_profile_bearer(tmp_path):
         }
         """
     profile = DeltaSharingProfile.from_json(json)
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          "token",
-                                          None,
-                                          "bearer_token")
+    assert profile == DeltaSharingProfile(
+        2, "https://localhost/delta-sharing", "token", None, "bearer_token"
+    )
 
     json = """
         {
@@ -125,50 +123,38 @@ def test_share_profile_bearer(tmp_path):
         }
         """
     profile = DeltaSharingProfile.from_json(json)
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          "token",
-                                          "2021-11-12T00:12:29.0Z",
-                                          "bearer_token")
+    assert profile == DeltaSharingProfile(
+        2, "https://localhost/delta-sharing", "token", "2021-11-12T00:12:29.0Z", "bearer_token"
+    )
 
     profile = DeltaSharingProfile.read_from_file(io.StringIO(json))
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          "token",
-                                          "2021-11-12T00:12:29.0Z",
-                                          "bearer_token")
+    assert profile == DeltaSharingProfile(
+        2, "https://localhost/delta-sharing", "token", "2021-11-12T00:12:29.0Z", "bearer_token"
+    )
 
     profile_path = tmp_path / "test_profile_bearer.json"
     with open(profile_path, "w") as f:
         f.write(json)
 
     profile = DeltaSharingProfile.read_from_file(str(profile_path))
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          "token",
-                                          "2021-11-12T00:12:29.0Z",
-                                          "bearer_token")
+    assert profile == DeltaSharingProfile(
+        2, "https://localhost/delta-sharing", "token", "2021-11-12T00:12:29.0Z", "bearer_token"
+    )
 
     profile = DeltaSharingProfile.read_from_file(profile_path.as_uri())
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          "token",
-                                          "2021-11-12T00:12:29.0Z",
-                                          "bearer_token")
+    assert profile == DeltaSharingProfile(
+        2, "https://localhost/delta-sharing", "token", "2021-11-12T00:12:29.0Z", "bearer_token"
+    )
 
     profile = DeltaSharingProfile.read_from_file(profile_path)
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          "token",
-                                          "2021-11-12T00:12:29.0Z",
-                                          "bearer_token")
+    assert profile == DeltaSharingProfile(
+        2, "https://localhost/delta-sharing", "token", "2021-11-12T00:12:29.0Z", "bearer_token"
+    )
 
     profile = DeltaSharingProfile.read_from_file(io.FileIO(profile_path))
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          "token",
-                                          "2021-11-12T00:12:29.0Z",
-                                          "bearer_token")
+    assert profile == DeltaSharingProfile(
+        2, "https://localhost/delta-sharing", "token", "2021-11-12T00:12:29.0Z", "bearer_token"
+    )
 
     json = """
         {
@@ -198,68 +184,80 @@ def oauth_client_credentials(tmp_path):
         }
         """
     profile = DeltaSharingProfile.from_json(json)
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          None,
-                                          None,
-                                          "oauth_client_credentials",
-                                          "tokenEndpoint",
-                                          "clientId",
-                                          "clientSecret")
+    assert profile == DeltaSharingProfile(
+        2,
+        "https://localhost/delta-sharing",
+        None,
+        None,
+        "oauth_client_credentials",
+        "tokenEndpoint",
+        "clientId",
+        "clientSecret",
+    )
 
     profile = DeltaSharingProfile.read_from_file(io.StringIO(json))
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          None,
-                                          None,
-                                          "oauth_client_credentials",
-                                          "tokenEndpoint",
-                                          "clientId",
-                                          "clientSecret")
+    assert profile == DeltaSharingProfile(
+        2,
+        "https://localhost/delta-sharing",
+        None,
+        None,
+        "oauth_client_credentials",
+        "tokenEndpoint",
+        "clientId",
+        "clientSecret",
+    )
 
     profile_path = tmp_path / "test_profile_oauth2.json"
     with open(profile_path, "w") as f:
         f.write(json)
 
     profile = DeltaSharingProfile.read_from_file(str(profile_path))
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          None,
-                                          None,
-                                          "oauth_client_credentials",
-                                          "tokenEndpoint",
-                                          "clientId",
-                                          "clientSecret")
+    assert profile == DeltaSharingProfile(
+        2,
+        "https://localhost/delta-sharing",
+        None,
+        None,
+        "oauth_client_credentials",
+        "tokenEndpoint",
+        "clientId",
+        "clientSecret",
+    )
 
     profile = DeltaSharingProfile.read_from_file(profile_path.as_uri())
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          None,
-                                          None,
-                                          "oauth_client_credentials",
-                                          "tokenEndpoint",
-                                          "clientId",
-                                          "clientSecret")
+    assert profile == DeltaSharingProfile(
+        2,
+        "https://localhost/delta-sharing",
+        None,
+        None,
+        "oauth_client_credentials",
+        "tokenEndpoint",
+        "clientId",
+        "clientSecret",
+    )
 
     profile = DeltaSharingProfile.read_from_file(profile_path)
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          None,
-                                          None,
-                                          "oauth_client_credentials",
-                                          "tokenEndpoint",
-                                          "clientId",
-                                          "clientSecret")
+    assert profile == DeltaSharingProfile(
+        2,
+        "https://localhost/delta-sharing",
+        None,
+        None,
+        "oauth_client_credentials",
+        "tokenEndpoint",
+        "clientId",
+        "clientSecret",
+    )
 
     profile = DeltaSharingProfile.read_from_file(io.FileIO(profile_path))
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          None,
-                                          None,
-                                          "oauth_client_credentials",
-                                          "tokenEndpoint",
-                                          "clientId",
-                                          "clientSecret")
+    assert profile == DeltaSharingProfile(
+        2,
+        "https://localhost/delta-sharing",
+        None,
+        None,
+        "oauth_client_credentials",
+        "tokenEndpoint",
+        "clientId",
+        "clientSecret",
+    )
 
     json = """
         {
@@ -288,80 +286,92 @@ def test_share_profile_basic(tmp_path):
         }
         """
     profile = DeltaSharingProfile.from_json(json)
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          None,
-                                          None,
-                                          "basic",
-                                          None,
-                                          None,
-                                          None,
-                                          "username",
-                                          "password")
+    assert profile == DeltaSharingProfile(
+        2,
+        "https://localhost/delta-sharing",
+        None,
+        None,
+        "basic",
+        None,
+        None,
+        None,
+        "username",
+        "password",
+    )
 
     profile = DeltaSharingProfile.read_from_file(io.StringIO(json))
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          None,
-                                          None,
-                                          "basic",
-                                          None,
-                                          None,
-                                          None,
-                                          "username",
-                                          "password")
+    assert profile == DeltaSharingProfile(
+        2,
+        "https://localhost/delta-sharing",
+        None,
+        None,
+        "basic",
+        None,
+        None,
+        None,
+        "username",
+        "password",
+    )
 
     profile_path = tmp_path / "test_profile_basic.json"
     with open(profile_path, "w") as f:
         f.write(json)
 
     profile = DeltaSharingProfile.read_from_file(str(profile_path))
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          None,
-                                          None,
-                                          "basic",
-                                          None,
-                                          None,
-                                          None,
-                                          "username",
-                                          "password")
+    assert profile == DeltaSharingProfile(
+        2,
+        "https://localhost/delta-sharing",
+        None,
+        None,
+        "basic",
+        None,
+        None,
+        None,
+        "username",
+        "password",
+    )
 
     profile = DeltaSharingProfile.read_from_file(profile_path.as_uri())
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          None,
-                                          None,
-                                          "basic",
-                                          None,
-                                          None,
-                                          None,
-                                          "username",
-                                          "password")
+    assert profile == DeltaSharingProfile(
+        2,
+        "https://localhost/delta-sharing",
+        None,
+        None,
+        "basic",
+        None,
+        None,
+        None,
+        "username",
+        "password",
+    )
 
     profile = DeltaSharingProfile.read_from_file(profile_path)
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          None,
-                                          None,
-                                          "basic",
-                                          None,
-                                          None,
-                                          None,
-                                          "username",
-                                          "password")
+    assert profile == DeltaSharingProfile(
+        2,
+        "https://localhost/delta-sharing",
+        None,
+        None,
+        "basic",
+        None,
+        None,
+        None,
+        "username",
+        "password",
+    )
 
     profile = DeltaSharingProfile.read_from_file(io.FileIO(profile_path))
-    assert profile == DeltaSharingProfile(2,
-                                          "https://localhost/delta-sharing",
-                                          None,
-                                          None,
-                                          "basic",
-                                          None,
-                                          None,
-                                          None,
-                                          "username",
-                                          "password")
+    assert profile == DeltaSharingProfile(
+        2,
+        "https://localhost/delta-sharing",
+        None,
+        None,
+        "basic",
+        None,
+        None,
+        None,
+        "username",
+        "password",
+    )
 
     json = """
         {
@@ -441,7 +451,7 @@ def test_protocol_delta():
         }
         """
     protocol = Protocol.from_json(json)
-    assert protocol == Protocol(3, 7, ['columnMapping'], ['columnMapping', 'deletionVectors'])
+    assert protocol == Protocol(3, 7, ["columnMapping"], ["columnMapping", "deletionVectors"])
     json = """
         {
             "deltaProtocol": {
@@ -547,7 +557,7 @@ def test_metadata():
                 schema_string=str.replace(schema_string, r"\"", '"'),
                 configuration={},
                 partition_columns=[],
-            )
+            ),
         ),
         pytest.param(
             f"""
@@ -575,8 +585,8 @@ def test_metadata():
                 format=Format(),
                 schema_string=schema_string.replace(r"\"", '"'),
                 configuration={"enableChangeDataFeed": "true"},
-                partition_columns=['col'],
-            )
+                partition_columns=["col"],
+            ),
         ),
         pytest.param(
             f"""
@@ -604,9 +614,9 @@ def test_metadata():
                 schema_string=(schema_string).replace(r"\"", '"'),
                 partition_columns=[],
                 created_time=1000,
-            )
+            ),
         ),
-    ]
+    ],
 )
 def test_metadata_delta(json: str, expected: Metadata):
     assert Metadata.from_json(json) == expected

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -327,16 +327,48 @@ def test_to_pandas_large_table_batch_convert(tmp_path):
             return "parquet"
 
     expected = pd.concat([pdf1, pdf2]).reset_index(drop=True)
+    expected_100k = pdf1.head(100000)
+    expected_300k = pd.concat([pdf1, pdf2.head(100000)]).reset_index(drop=True)
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.to_pandas()
     pd.testing.assert_frame_equal(pdf, expected)
 
     reader = DeltaSharingReader(
+        Table("table_name", "share_name", "schema_name"), RestClientMock(), limit=100000
+    )
+    pdf = reader.to_pandas()
+    pd.testing.assert_frame_equal(pdf, expected_100k)
+
+    reader = DeltaSharingReader(
+        Table("table_name", "share_name", "schema_name"), RestClientMock(), limit=300000
+    )
+    pdf = reader.to_pandas()
+    pd.testing.assert_frame_equal(pdf, expected_300k)
+
+    reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True
     )
     pdf = reader.to_pandas()
     pd.testing.assert_frame_equal(pdf, expected)
+
+    reader = DeltaSharingReader(
+        Table("table_name", "share_name", "schema_name"),
+        RestClientMock(),
+        limit=100000,
+        convert_in_batches=True,
+    )
+    pdf = reader.to_pandas()
+    pd.testing.assert_frame_equal(pdf, expected_100k)
+
+    reader = DeltaSharingReader(
+        Table("table_name", "share_name", "schema_name"),
+        RestClientMock(),
+        limit=300000,
+        convert_in_batches=True,
+    )
+    pdf = reader.to_pandas()
+    pd.testing.assert_frame_equal(pdf, expected_300k)
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -85,7 +85,7 @@ def test_to_pandas_non_partitioned(tmp_path):
                 protocol=None,
                 metadata=metadata,
                 add_files=add_files,
-                lines=[]
+                lines=[],
             )
 
         def autoresolve_query_format(self, table: Table):
@@ -99,7 +99,7 @@ def test_to_pandas_non_partitioned(tmp_path):
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"),
         RestClientMock(),
-        jsonPredicateHints="dummy_hints"
+        jsonPredicateHints="dummy_hints",
     )
     pdf = reader.to_pandas()
     expected = pd.concat([pdf1]).reset_index(drop=True)
@@ -108,7 +108,7 @@ def test_to_pandas_non_partitioned(tmp_path):
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"),
         RestClientMock(),
-        predicateHints="dummy_hints"
+        predicateHints="dummy_hints",
     )
     pdf = reader.to_pandas()
     expected = pd.concat([pdf2]).reset_index(drop=True)
@@ -164,7 +164,7 @@ def test_to_pandas_partitioned(tmp_path):
                 protocol=None,
                 metadata=metadata,
                 add_files=add_files,
-                lines=[]
+                lines=[],
             )
 
         def autoresolve_query_format(self, table: Table):
@@ -232,7 +232,7 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
                 protocol=None,
                 metadata=metadata,
                 add_files=add_files,
-                lines=[]
+                lines=[],
             )
 
         def autoresolve_query_format(self, table: Table):
@@ -296,7 +296,7 @@ def test_to_pandas_empty(rest_client: DataSharingRestClient):
                 protocol=None,
                 metadata=metadata,
                 add_files=add_files,
-                lines=[]
+                lines=[],
             )
 
         def autoresolve_query_format(self, table: Table):
@@ -405,10 +405,7 @@ def test_table_changes_to_pandas_non_partitioned(tmp_path):
                 ),
             ]
             return ListTableChangesResponse(
-                protocol=None,
-                metadata=metadata,
-                actions=actions,
-                lines=None
+                protocol=None, metadata=metadata, actions=actions, lines=None
             )
 
         def autoresolve_query_format(self, table: Table):
@@ -476,10 +473,7 @@ def test_table_changes_to_pandas_partitioned(tmp_path):
                 ),
             ]
             return ListTableChangesResponse(
-                protocol=None,
-                metadata=metadata,
-                actions=actions,
-                lines=None
+                protocol=None, metadata=metadata, actions=actions, lines=None
             )
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
@@ -505,10 +499,7 @@ def test_table_changes_empty(tmp_path):
                 )
             )
             return ListTableChangesResponse(
-                protocol=None,
-                metadata=metadata,
-                actions=[],
-                lines=None
+                protocol=None, metadata=metadata, actions=[], lines=None
             )
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
@@ -575,9 +566,9 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
                 '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
                 '{"metadata":{},"name":"b","nullable":true,"type":"string"}'
                 '],"type":"struct"}'
-            ).replace('"',r'\"')
+            ).replace('"', r"\"")
             lines = [
-                f'''{{
+                f"""{{
                     "protocol": {{
                         "deltaProtocol": {{
                             "minReaderVersion": 3,
@@ -587,8 +578,8 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
                                 ["deletionVectors", "changeDataFeed"]
                         }}
                     }}
-                }}''',
-                f'''{{
+                }}""",
+                f"""{{
                     "metaData":{{
                         "version":0,
                         "deltaMetadata":{{
@@ -604,8 +595,8 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
                             }}
                         }}
                     }}
-                }}''',
-                f'''{{
+                }}""",
+                f"""{{
                     "file":{{
                         "id":"pdf1",
                         "version":{version1},
@@ -620,8 +611,8 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
                             }}
                         }}
                     }}
-                }}''',
-                f'''{{
+                }}""",
+                f"""{{
                     "file":{{
                         "id":"pdf2",
                         "version":{version2},
@@ -635,8 +626,8 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
                             }}
                         }}
                     }}
-                }}''',
-                f'''{{
+                }}""",
+                f"""{{
                     "file":{{
                         "id":"pdf3",
                         "version":{version3},
@@ -650,8 +641,8 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
                             }}
                         }}
                     }}
-                }}''',
-                f'''{{
+                }}""",
+                f"""{{
                     "file":{{
                         "id":"pdf4",
                         "version":{version4},
@@ -665,7 +656,7 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
                             }}
                         }}
                     }}
-                }}'''
+                }}""",
             ]
             return ListTableChangesResponse(protocol=None, metadata=None, actions=None, lines=lines)
 
@@ -676,12 +667,10 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
             return
 
     reader = DeltaSharingReader(
-        Table("table_name", "share_name", "schema_name"),
-        RestClientMock(),
-        use_delta_format=True
+        Table("table_name", "share_name", "schema_name"), RestClientMock(), use_delta_format=True
     )
     pdf = reader.table_changes_to_pandas(CdfOptions())
-    pdf['_commit_timestamp'] = pdf['_commit_timestamp'].astype('int') // 1000
+    pdf["_commit_timestamp"] = pdf["_commit_timestamp"].astype("int") // 1000
 
     expected = pd.concat([pdf1, pdf2, pdf3, pdf4]).reset_index(drop=True)
 

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -113,7 +113,7 @@ def test_list_shares(rest_client: DataSharingRestClient):
         Share(name="share7"),
         Share(name="share_azure"),
         Share(name="share_gcp"),
-        Share(name="share8")
+        Share(name="share8"),
     ]
 
 
@@ -132,7 +132,7 @@ def test_list_tables(rest_client: DataSharingRestClient):
     assert response.tables == [
         Table(name="table1", share="share1", schema="default"),
         Table(name="table3", share="share1", schema="default"),
-        Table(name="table7", share="share1", schema="default")
+        Table(name="table7", share="share1", schema="default"),
     ]
 
     response = rest_client.list_tables(Schema(name="default", share="share2"))
@@ -299,8 +299,8 @@ def test_query_table_metadata_with_dv_cm_partitioned_delta(
     assert response.protocol == Protocol(
         min_reader_version=3,
         min_writer_version=7,
-        reader_features=['deletionVectors', 'columnMapping'],
-        writer_features=['deletionVectors', 'invariants', 'columnMapping', 'changeDataFeed'],
+        reader_features=["deletionVectors", "columnMapping"],
+        writer_features=["deletionVectors", "invariants", "columnMapping", "changeDataFeed"],
     )
     assert response.metadata == Metadata(
         id="88033a32-ec3c-4592-a606-9b58e2dc245d",
@@ -310,23 +310,23 @@ def test_query_table_metadata_with_dv_cm_partitioned_delta(
             '{"name":"id","type":"long","nullable":false,"metadata":{'
             '"delta.columnMapping.id":1,'
             '"delta.columnMapping.physicalName":"col-62f51670-2c22-4bad-a172-c453ddf09673"'
-            '}},'
+            "}},"
             '{"name":"rand","type":"integer","nullable":false,"metadata":{'
             '"delta.columnMapping.id":2,'
             '"delta.columnMapping.physicalName":"col-c985ad35-5524-4e86-89b0-47d6b9012fce"'
-            '}},'
+            "}},"
             '{"name":"partition_col","type":"integer","nullable":false,"metadata":{'
             '"delta.columnMapping.id":3,'
             '"delta.columnMapping.physicalName":"col-0bd4d7ce-c925-4748-9259-c03586b29b63"'
-            '}}'
+            "}}"
             "]}"
         ),
         partition_columns=["partition_col"],
         configuration={
-            'delta.columnMapping.maxColumnId': '3',
-            'delta.columnMapping.mode': 'name',
-            'delta.enableChangeDataFeed': 'true',
-            'delta.enableDeletionVectors': 'true',
+            "delta.columnMapping.maxColumnId": "3",
+            "delta.columnMapping.mode": "name",
+            "delta.enableChangeDataFeed": "true",
+            "delta.enableDeletionVectors": "true",
         },
         created_time=1721350003845,
     )
@@ -338,8 +338,9 @@ def test_autoresolve_query_format(
 ):
     tables = [
         ("table3", "share1", "parquet"),
-        ('deletion_vectors_with_dvs_dv_property_on', "share8", "delta"),
-        ('table_with_cm_name', "share8", "delta")]
+        ("deletion_vectors_with_dvs_dv_property_on", "share8", "delta"),
+        ("table_with_cm_name", "share8", "delta"),
+    ]
 
     for table in tables:
         table_name = table[0]
@@ -365,7 +366,7 @@ def test_query_existed_table_version(rest_client: DataSharingRestClient):
 def test_query_table_version_with_timestamp(rest_client: DataSharingRestClient):
     response = rest_client.query_table_version(
         Table(name="cdf_table_cdf_enabled", share="share8", schema="default"),
-        starting_timestamp="2020-01-01T00:00:00-08:00"
+        starting_timestamp="2020-01-01T00:00:00-08:00",
     )
     assert isinstance(response.delta_table_version, int)
     assert response.delta_table_version == 0
@@ -376,7 +377,7 @@ def test_query_table_version_with_timestamp_exception(rest_client: DataSharingRe
     try:
         rest_client.query_table_version(
             Table(name="table1", share="share1", schema="default"),
-            starting_timestamp="2020-01-1T00:00:00-08:00"
+            starting_timestamp="2020-01-1T00:00:00-08:00",
         )
     except Exception as e:
         assert isinstance(e, HTTPError)
@@ -543,7 +544,7 @@ def test_list_files_in_table_partitioned_different_schemas(
                 r'"maxValues":{"eventTime":"2021-04-28T23:36:47.599Z","type":"foo"},'
                 r'"nullCount":{"eventTime":0,"type":0}}'
             ),
-        )
+        ),
     ]
 
 
@@ -552,8 +553,7 @@ def test_list_files_in_table_version(
     rest_client: DataSharingRestClient,
 ):
     response = rest_client.list_files_in_table(
-        Table(name="cdf_table_cdf_enabled", share="share8", schema="default"),
-        version=1
+        Table(name="cdf_table_cdf_enabled", share="share8", schema="default"), version=1
     )
     assert response.delta_table_version == 1
     assert response.protocol == Protocol(min_reader_version=1)
@@ -583,7 +583,7 @@ def test_list_files_in_table_version(
                 r'"nullCount":{"name":0,"age":0,"birthday":0}}'
             ),
             version=1,
-            timestamp=None
+            timestamp=None,
         ),
         AddFile(
             url=response.add_files[1].url,
@@ -597,7 +597,7 @@ def test_list_files_in_table_version(
                 r'"nullCount":{"name":0,"age":0,"birthday":0}}'
             ),
             version=1,
-            timestamp=None
+            timestamp=None,
         ),
         AddFile(
             url=response.add_files[2].url,
@@ -611,8 +611,8 @@ def test_list_files_in_table_version(
                 r'"nullCount":{"name":0,"age":0,"birthday":0}}'
             ),
             version=1,
-            timestamp=None
-        )
+            timestamp=None,
+        ),
     ]
 
 
@@ -626,7 +626,7 @@ def test_list_files_with_json_predicates(
     def test_hints(hints, expected_dates):
         response = rest_client.list_files_in_table(
             Table(name="cdf_table_with_partition", share="share8", schema="default"),
-            jsonPredicateHints=hints
+            jsonPredicateHints=hints,
         )
         assert response.protocol == Protocol(min_reader_version=1)
         assert response.metadata == Metadata(
@@ -640,7 +640,7 @@ def test_list_files_with_json_predicates(
                 "]}"
             ),
             configuration={"enableChangeDataFeed": "true"},
-            partition_columns=["birthday"]
+            partition_columns=["birthday"],
         )
 
         # validate that we get back all expected files.
@@ -664,7 +664,7 @@ def test_list_files_with_json_predicates(
         '{"op":"equal","children":['
         '{"op":"column","name":"birthday","valueType":"date"},'
         '{"op":"literal","value":"2020-01-01","valueType":"date"}]}'
-        ']}'
+        "]}"
     )
     test_hints(hints1, ["2020-01-01"])
 
@@ -677,7 +677,7 @@ def test_list_files_with_json_predicates(
         '{"op":"greaterThan","children":['
         '{"op":"column","name":"birthday","valueType":"date"},'
         '{"op":"literal","value":"2020-01-01","valueType":"date"}]}'
-        ']}'
+        "]}"
     )
     test_hints(hints2, ["2020-02-02"])
 
@@ -691,8 +691,7 @@ def test_list_files_in_table_version_exception(
 ):
     try:
         rest_client.list_files_in_table(
-            Table(name="table1", share="share1", schema="default"),
-            version=1
+            Table(name="table1", share="share1", schema="default"), version=1
         )
     except Exception as e:
         assert isinstance(e, HTTPError)
@@ -700,13 +699,10 @@ def test_list_files_in_table_version_exception(
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
-def test_list_files_in_table_timestamp(
-    rest_client: DataSharingRestClient
-):
+def test_list_files_in_table_timestamp(rest_client: DataSharingRestClient):
     try:
         rest_client.list_files_in_table(
-            Table(name="table1", share="share1", schema="default"),
-            timestamp="random_str"
+            Table(name="table1", share="share1", schema="default"), timestamp="random_str"
         )
     except Exception as e:
         assert isinstance(e, HTTPError)
@@ -756,8 +752,7 @@ def test_list_table_changes(
     # The following table query will return all types of actions.
     cdf_table = Table(name="cdf_table_with_partition", share="share8", schema="default")
     response = rest_client.list_table_changes(
-        cdf_table,
-        CdfOptions(starting_version=1, ending_version=3)
+        cdf_table, CdfOptions(starting_version=1, ending_version=3)
     )
 
     assert response.protocol == Protocol(min_reader_version=1)
@@ -773,13 +768,13 @@ def test_list_table_changes(
         ),
         configuration={"enableChangeDataFeed": "true"},
         partition_columns=["birthday"],
-        version=3
+        version=3,
     )
     assert response.actions == [
         AddFile(
             url=response.actions[0].url,
-            id='a04d61f17541fac1f9b5df5b8d26fff8',
-            partition_values={'birthday': '2020-01-01'},
+            id="a04d61f17541fac1f9b5df5b8d26fff8",
+            partition_values={"birthday": "2020-01-01"},
             size=791,
             timestamp=1651614980000,
             version=1,
@@ -792,8 +787,8 @@ def test_list_table_changes(
         ),
         AddFile(
             url=response.actions[1].url,
-            id='f206a7168597c4db5956b2b11ed5cbb2',
-            partition_values={'birthday': '2020-01-01'},
+            id="f206a7168597c4db5956b2b11ed5cbb2",
+            partition_values={"birthday": "2020-01-01"},
             size=791,
             timestamp=1651614980000,
             version=1,
@@ -806,8 +801,8 @@ def test_list_table_changes(
         ),
         AddFile(
             url=response.actions[2].url,
-            id='9410d65d7571842eb7fb6b1ac01af372',
-            partition_values={'birthday': '2020-03-03'},
+            id="9410d65d7571842eb7fb6b1ac01af372",
+            partition_values={"birthday": "2020-03-03"},
             size=791,
             timestamp=1651614980000,
             version=1,
@@ -836,11 +831,11 @@ def test_list_table_changes(
         ),
         RemoveFile(
             url=response.actions[5].url,
-            id='9410d65d7571842eb7fb6b1ac01af372',
-            partition_values={'birthday': '2020-03-03'},
+            id="9410d65d7571842eb7fb6b1ac01af372",
+            partition_values={"birthday": "2020-03-03"},
             size=791,
             timestamp=1651614994000,
-            version=3
+            version=3,
         ),
     ]
 
@@ -854,10 +849,7 @@ def test_list_table_changes_with_more_metadata(
     # include spark structured streaming. So the query will still work: old connector is compatible
     # with new server.
     cdf_table = Table(name="streaming_notnull_to_null", share="share8", schema="default")
-    response = rest_client.list_table_changes(
-        cdf_table,
-        CdfOptions(starting_version=0)
-    )
+    response = rest_client.list_table_changes(cdf_table, CdfOptions(starting_version=0))
 
     assert response.protocol == Protocol(min_reader_version=1)
     assert len(response.actions) == 2
@@ -889,22 +881,19 @@ def test_list_table_changes_with_more_metadata(
                 r'"maxValues":{"name":"2"},'
                 r'"nullCount":{"name":1}}'
             ),
-        )
+        ),
     ]
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
-def test_list_table_changes_with_timestamp(
-    rest_client: DataSharingRestClient
-):
+def test_list_table_changes_with_timestamp(rest_client: DataSharingRestClient):
     cdf_table = Table(name="cdf_table_with_partition", share="share8", schema="default")
 
     # Use a really old start time, and look for an appropriate error.
     # This will ensure that the timestamps are parsed correctly.
     try:
         rest_client.list_table_changes(
-            cdf_table,
-            CdfOptions(starting_timestamp="2000-05-03T00:00:00-08:00")
+            cdf_table, CdfOptions(starting_timestamp="2000-05-03T00:00:00-08:00")
         )
         assert False
     except Exception as e:
@@ -914,8 +903,7 @@ def test_list_table_changes_with_timestamp(
     # Use an end time far away, and look for an appropriate error.
     try:
         rest_client.list_table_changes(
-            cdf_table,
-            CdfOptions(starting_version=0, ending_timestamp="2100-05-03T00:00:00Z")
+            cdf_table, CdfOptions(starting_version=0, ending_timestamp="2100-05-03T00:00:00Z")
         )
         assert False
     except Exception as e:

--- a/python/delta_sharing/version.py
+++ b/python/delta_sharing/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "1.3.1"
+__version__ = "1.3.3"

--- a/python/dev/.gitignore
+++ b/python/dev/.gitignore
@@ -1,0 +1,1 @@
+pycodestyle*.py

--- a/python/dev/lint-python
+++ b/python/dev/lint-python
@@ -238,7 +238,7 @@ function black_test {
     local BLACK_STATUS=
 
     # Skip check if black is not installed.
-    $BLACK_BUILD 2> /dev/null
+    $BLACK_BUILD --version >> /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo "The $BLACK_BUILD command was not found. Skipping black checks for now."
         echo

--- a/python/dev/reformat
+++ b/python/dev/reformat
@@ -24,7 +24,7 @@ PYTHON_EXECUTABLE="${PYTHON_EXECUTABLE:-python}"
 
 BLACK_BUILD="$PYTHON_EXECUTABLE -m black"
 BLACK_VERSION="21.12b0"
-$BLACK_BUILD 2> /dev/null
+$BLACK_BUILD --version >> /dev/null 2>&1
 if [ $? -ne 0 ]; then
     echo "The '$BLACK_BUILD' command was not found. Please install Black, for example, via 'pip install black==$BLACK_VERSION'."
     exit 1

--- a/server/src/test/scala/io/delta/sharing/server/TestResource.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestResource.scala
@@ -207,6 +207,12 @@ object TestResource {
             "default",
             java.util.Arrays.asList(
               TableConfig(
+                "12k_rows",
+                s"s3a://${AWS.bucket}/delta-exchange-test/12k_rows",
+                "00000000-0000-0000-0000-000000000096",
+                historyShared = true
+              ),
+              TableConfig(
                 "timestampntz_cdf_table",
                 s"s3a://${AWS.bucket}/delta-exchange-test/timestampntz_cdf_table",
                 "00000000-0000-0000-0000-000000000096",


### PR DESCRIPTION
Main changes are #737 and #723. #668 was backported too to avoid merge conflicts from formatting differences, and #660 was backported too so that I could use the release script without issues. 