### PR TITLE
Support HTTPS downgrade when not using the proxy. Add support for wildcard DNS support for no proxy hosts.

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystemHttpClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystemHttpClient.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.client
+
+import java.net.URI
+
+import org.apache.http.{HttpHost, HttpRequest}
+import org.apache.http.client.methods.{CloseableHttpResponse, HttpRequestWrapper}
+import org.apache.http.client.utils.URIBuilder
+import org.apache.http.conn.ClientConnectionManager
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.params.HttpParams
+import org.apache.http.protocol.HttpContext
+
+private[sharing] case class DeltaSharingFileSystemHttpClient(
+  noProxyHttpClient: CloseableHttpClient,
+  proxyHttpClient: CloseableHttpClient,
+  useProxy: Boolean,
+  noProxyHosts: Seq[String],
+  disableHttps: Boolean) extends CloseableHttpClient {
+
+  private def hasNoProxyHostsMatch(host: String): Boolean = {
+    noProxyHosts.exists(record => {
+      // Wildcard DNS records support
+      if (record.startsWith("*.")) {
+        host.endsWith(record.drop(2))
+      } else {
+        host == record
+      }
+    })
+  }
+
+  override protected def doExecute(
+    target: HttpHost,
+    request: HttpRequest,
+    context: HttpContext
+  ): CloseableHttpResponse = {
+    val (updatedTarget, updatedRequest) = if (disableHttps && target.getSchemeName == "https") {
+      val modifiedUri: URI = new URIBuilder(request.getRequestLine.getUri).setScheme("http").build()
+      val wrappedRequest = HttpRequestWrapper.wrap(request)
+      wrappedRequest.setURI(modifiedUri)
+      (new HttpHost(target.getHostName, target.getPort, "http"), wrappedRequest)
+    } else {
+      (target, request)
+    }
+    if (useProxy && !hasNoProxyHostsMatch(target.getHostName)) {
+      proxyHttpClient.execute(updatedTarget, updatedRequest, context)
+    } else {
+      noProxyHttpClient.execute(updatedTarget, updatedRequest, context)
+    }
+  }
+
+  override def close(): Unit = {
+    noProxyHttpClient.close()
+    proxyHttpClient.close()
+  }
+
+  // This is deprecated since 4.3, so overriding with a dummy implementation
+  override def getParams(): HttpParams = {
+    throw new UnsupportedOperationException("getParams")
+  }
+
+  // This is deprecated since 4.3, so overriding with a dummy implementation
+  override def getConnectionManager(): ClientConnectionManager = {
+    throw new UnsupportedOperationException("getConnectionManager")
+  }
+}

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystemHttpClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystemHttpClient.scala
@@ -33,11 +33,11 @@ private[sharing] case class DeltaSharingFileSystemHttpClient(
   noProxyHosts: Seq[String],
   disableHttps: Boolean) extends CloseableHttpClient {
 
-  private def hasNoProxyHostsMatch(host: String): Boolean = {
+  private[sharing] def hasNoProxyHostsMatch(host: String): Boolean = {
     noProxyHosts.exists(record => {
       // Wildcard DNS records support
       if (record.startsWith("*.")) {
-        host.endsWith(record.drop(2))
+        host.endsWith(record.drop(1))
       } else {
         host == record
       }

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystemHttpClientBuilder.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystemHttpClientBuilder.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.client
+
+import org.apache.http.HttpHost
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.impl.client.HttpClientBuilder
+
+private[sharing] class DeltaSharingFileSystemHttpClientBuilder {
+  private var noProxyHttpClientClientBuilder: HttpClientBuilder = HttpClientBuilder.create()
+  private var proxyHttpClientClientBuilder: HttpClientBuilder = HttpClientBuilder.create()
+  private var useProxy: Boolean = false
+  private var noProxyHosts: Seq[String] = Seq.empty
+  private var disableHttps: Boolean = false
+
+  def setMaxConnTotal(maxConnTotal: Int): DeltaSharingFileSystemHttpClientBuilder = {
+    noProxyHttpClientClientBuilder.setMaxConnTotal(maxConnTotal)
+    proxyHttpClientClientBuilder.setMaxConnTotal(maxConnTotal)
+    this
+  }
+
+  def setMaxConnPerRoute(maxConnPerRoute: Int): DeltaSharingFileSystemHttpClientBuilder = {
+    noProxyHttpClientClientBuilder.setMaxConnPerRoute(maxConnPerRoute)
+    proxyHttpClientClientBuilder.setMaxConnPerRoute(maxConnPerRoute)
+    this
+  }
+
+  def setDefaultRequestConfig(config: RequestConfig): DeltaSharingFileSystemHttpClientBuilder = {
+    noProxyHttpClientClientBuilder.setDefaultRequestConfig(config)
+    proxyHttpClientClientBuilder.setDefaultRequestConfig(config)
+    this
+  }
+
+  def disableAutomaticRetries(): DeltaSharingFileSystemHttpClientBuilder = {
+    noProxyHttpClientClientBuilder.disableAutomaticRetries()
+    proxyHttpClientClientBuilder.disableAutomaticRetries()
+    this
+  }
+
+  def setProxy(proxy: HttpHost): DeltaSharingFileSystemHttpClientBuilder = {
+    proxyHttpClientClientBuilder.setProxy(proxy)
+    useProxy = true
+    this
+  }
+
+  def setNoProxyHosts(noProxyHosts: Seq[String]): DeltaSharingFileSystemHttpClientBuilder = {
+    this.noProxyHosts = noProxyHosts
+    this
+  }
+
+  def setDisableHttps(): DeltaSharingFileSystemHttpClientBuilder = {
+    disableHttps = true
+    this
+  }
+
+  def build(): DeltaSharingFileSystemHttpClient = {
+    DeltaSharingFileSystemHttpClient(
+      noProxyHttpClient = noProxyHttpClientClientBuilder.build(),
+      proxyHttpClient = proxyHttpClientClientBuilder.build(),
+      useProxy = useProxy,
+      noProxyHosts = noProxyHosts,
+      disableHttps = disableHttps
+    )
+  }
+}
+
+private[sharing] object DeltaSharingFileSystemHttpClientBuilder {
+  def create(): DeltaSharingFileSystemHttpClientBuilder = {
+    new DeltaSharingFileSystemHttpClientBuilder
+  }
+}

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -48,6 +48,9 @@ object ConfUtils {
   val TIMEOUT_CONF = "spark.delta.sharing.network.timeout"
   val TIMEOUT_DEFAULT = "320s"
 
+  // Note: There is a separate pool for proxy and non-proxy connections.
+  //       Thus, if you use both spark.delta.sharing.network.proxyHost and spark.delta.sharing.network.noProxyHosts,
+  //       the max number of connections will be 2 * spark.delta.sharing.network.maxConnections.
   val MAX_CONNECTION_CONF = "spark.delta.sharing.network.maxConnections"
   val MAX_CONNECTION_DEFAULT = 64
 

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -49,7 +49,8 @@ object ConfUtils {
   val TIMEOUT_DEFAULT = "320s"
 
   // Note: There is a separate pool for proxy and non-proxy connections.
-  //       Thus, if you use both spark.delta.sharing.network.proxyHost and spark.delta.sharing.network.noProxyHosts,
+  //       Thus, if you use both spark.delta.sharing.network.proxyHost and
+  //       spark.delta.sharing.network.noProxyHosts,
   //       the max number of connections will be 2 * spark.delta.sharing.network.maxConnections.
   val MAX_CONNECTION_CONF = "spark.delta.sharing.network.maxConnections"
   val MAX_CONNECTION_DEFAULT = 64

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemHttpClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemHttpClientSuite.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.client
+
+import org.apache.http.impl.client.HttpClients
+import org.apache.spark.SparkFunSuite
+
+class DeltaSharingFileSystemHttpClientSuite extends SparkFunSuite {
+  /**
+   * Helper method to create a test DeltaSharingFileSystemHttpClient with mock dependencies
+   */
+  private def createTestHttpClient(noProxyHosts: Seq[String] = Seq.empty): DeltaSharingFileSystemHttpClient = {
+    val mockHttpClient = HttpClients.createDefault()
+    DeltaSharingFileSystemHttpClient(
+      noProxyHttpClient = mockHttpClient,
+      proxyHttpClient = mockHttpClient,
+      useProxy = true,
+      noProxyHosts = noProxyHosts,
+      disableHttps = false
+    )
+  }
+
+  test("hasNoProxyHostsMatch - exact host matches") {
+    val client = createTestHttpClient(noProxyHosts = Seq("example.com", "localhost", "127.0.0.1"))
+    
+    assert(client.hasNoProxyHostsMatch("example.com"))
+    assert(client.hasNoProxyHostsMatch("localhost"))
+    assert(client.hasNoProxyHostsMatch("127.0.0.1"))
+    assert(!client.hasNoProxyHostsMatch("different.com"))
+    assert(!client.hasNoProxyHostsMatch("sub.example.com"))
+  }
+
+  test("hasNoProxyHostsMatch - wildcard DNS matches") {
+    val client = createTestHttpClient(noProxyHosts = Seq("*.example.com", "*.internal"))
+    
+    // Should match wildcard patterns
+    assert(client.hasNoProxyHostsMatch("api.example.com"))
+    assert(client.hasNoProxyHostsMatch("sub.example.com"))
+    assert(client.hasNoProxyHostsMatch("deep.nested.example.com"))
+    assert(client.hasNoProxyHostsMatch("service.internal"))
+    
+    // Should NOT match the wildcard domain itself
+    assert(!client.hasNoProxyHostsMatch("example.com"))
+    assert(!client.hasNoProxyHostsMatch("internal"))
+    
+    // Should NOT match different domains
+    assert(!client.hasNoProxyHostsMatch("example.org"))
+    assert(!client.hasNoProxyHostsMatch("notexample.com"))
+    assert(!client.hasNoProxyHostsMatch("external"))
+  }
+
+  test("hasNoProxyHostsMatch - empty noProxyHosts list") {
+    val client = createTestHttpClient(noProxyHosts = Seq.empty)
+    
+    assert(!client.hasNoProxyHostsMatch("example.com"))
+    assert(!client.hasNoProxyHostsMatch("localhost"))
+    assert(!client.hasNoProxyHostsMatch("127.0.0.1"))
+  }
+
+  test("hasNoProxyHostsMatch - edge cases") {
+    // These edge cases may not be correct, but for simplicity, we will allow some of these behaviors.
+    val client = createTestHttpClient(noProxyHosts = Seq("*.", "*.168.1.1"))
+    
+    assert(!client.hasNoProxyHostsMatch("example.com"))
+    assert(client.hasNoProxyHostsMatch("."))
+    assert(client.hasNoProxyHostsMatch("192.168.1.1")) 
+  }
+}

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemHttpClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemHttpClientSuite.scala
@@ -23,7 +23,8 @@ class DeltaSharingFileSystemHttpClientSuite extends SparkFunSuite {
   /**
    * Helper method to create a test DeltaSharingFileSystemHttpClient with mock dependencies
    */
-  private def createTestHttpClient(noProxyHosts: Seq[String] = Seq.empty): DeltaSharingFileSystemHttpClient = {
+  private def createTestHttpClient(
+    noProxyHosts: Seq[String] = Seq.empty): DeltaSharingFileSystemHttpClient = {
     val mockHttpClient = HttpClients.createDefault()
     DeltaSharingFileSystemHttpClient(
       noProxyHttpClient = mockHttpClient,
@@ -36,7 +37,7 @@ class DeltaSharingFileSystemHttpClientSuite extends SparkFunSuite {
 
   test("hasNoProxyHostsMatch - exact host matches") {
     val client = createTestHttpClient(noProxyHosts = Seq("example.com", "localhost", "127.0.0.1"))
-    
+
     assert(client.hasNoProxyHostsMatch("example.com"))
     assert(client.hasNoProxyHostsMatch("localhost"))
     assert(client.hasNoProxyHostsMatch("127.0.0.1"))
@@ -46,17 +47,17 @@ class DeltaSharingFileSystemHttpClientSuite extends SparkFunSuite {
 
   test("hasNoProxyHostsMatch - wildcard DNS matches") {
     val client = createTestHttpClient(noProxyHosts = Seq("*.example.com", "*.internal"))
-    
+
     // Should match wildcard patterns
     assert(client.hasNoProxyHostsMatch("api.example.com"))
     assert(client.hasNoProxyHostsMatch("sub.example.com"))
     assert(client.hasNoProxyHostsMatch("deep.nested.example.com"))
     assert(client.hasNoProxyHostsMatch("service.internal"))
-    
+
     // Should NOT match the wildcard domain itself
     assert(!client.hasNoProxyHostsMatch("example.com"))
     assert(!client.hasNoProxyHostsMatch("internal"))
-    
+
     // Should NOT match different domains
     assert(!client.hasNoProxyHostsMatch("example.org"))
     assert(!client.hasNoProxyHostsMatch("notexample.com"))
@@ -65,18 +66,19 @@ class DeltaSharingFileSystemHttpClientSuite extends SparkFunSuite {
 
   test("hasNoProxyHostsMatch - empty noProxyHosts list") {
     val client = createTestHttpClient(noProxyHosts = Seq.empty)
-    
+
     assert(!client.hasNoProxyHostsMatch("example.com"))
     assert(!client.hasNoProxyHostsMatch("localhost"))
     assert(!client.hasNoProxyHostsMatch("127.0.0.1"))
   }
 
   test("hasNoProxyHostsMatch - edge cases") {
-    // These edge cases may not be correct, but for simplicity, we will allow some of these behaviors.
+    // These edge cases may not be correct, but for simplicity,
+    // we will allow some of these behaviors.
     val client = createTestHttpClient(noProxyHosts = Seq("*.", "*.168.1.1"))
-    
+
     assert(!client.hasNoProxyHostsMatch("example.com"))
     assert(client.hasNoProxyHostsMatch("."))
-    assert(client.hasNoProxyHostsMatch("192.168.1.1")) 
+    assert(client.hasNoProxyHostsMatch("192.168.1.1"))
   }
 }

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemSuite.scala
@@ -360,7 +360,7 @@ class DeltaSharingFileSystemSuite extends SparkFunSuite {
     }
   }
 
-  test("https traffic is downgraded to http when noProxyHosts is configured by skipping the proxy") {
+  test("https traffic is downgraded to http when noProxyHosts skips the proxy") {
     val server = new Server(0)
     val handler = new ServletHandler()
     server.setHandler(handler)


### PR DESCRIPTION
The previous code touched too much Apache HttpClient internals resulting in certain edge cases not being considered when HTTPS downgrade and proxy settings are being used. This creates a delegating HttpClient that wraps a proxy and a non-proxy HttpClient so that we can minimize overriding internal methods of how HttpClient works. Adding anything more within these internals to fix this issue would make it more difficult to maintain and may introduce other bugs.

This also adds wildcard DNS support for no proxy hosts.

Fixes #747 