### PR TITLE
Add registerQueryStatesInQuerySpecificCachedTable to CachedTableManager for Query-Specific State Registration

### DIFF
--- a/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -372,6 +372,48 @@ class CachedTableManager(
   }
 
   /**
+   * Adds new query states to an existing QuerySpecificCachedTable entry in the cache.
+   *
+   * This method is used when a new query (with its own queryId and refresher wrapper)
+   * wants to share the same cached table entry as other queries, but only needs to add
+   * its own state (references and refresher wrapper) without modifying the rest of the
+   * table's cache entry. If the table is not a QuerySpecificCachedTable, or does not exist,
+   * this method is a no-op.
+   *
+   * The method is atomic and thread-safe, using computeIfPresent to avoid race conditions
+   * with concurrent register or refresh operations.
+   *
+   * @param tablePath The path of the table whose query states should be updated.
+   * @param refs A sequence of weak references for the new query, used to track its usage.
+   * @param profileProvider The profile provider, which supplies the queryId and refresher wrapper
+   *                       for the new query state.
+   */
+  def registerQueryStatesInQuerySpecificCachedTable(
+    tablePath: String,
+    refs: Seq[WeakReference[AnyRef]],
+    profileProvider: DeltaSharingProfileProvider
+  ): Unit = {
+    val queryId = profileProvider.getCustomQueryId()
+      .getOrElse(throw new IllegalStateException("Query ID is not defined."))
+    val refresherWrapper = profileProvider.getCustomRefresherWrapper().getOrElse(
+      throw new IllegalStateException("refresherWrapper is not defined.")
+    )
+    cache.computeIfPresent(tablePath, (_, existingTable) => existingTable match {
+      case q: QuerySpecificCachedTable =>
+        val newQueryStates = q.queryStates + (queryId -> (refs, refresherWrapper))
+        new QuerySpecificCachedTable(
+          q.expiration,
+          q.idToUrl,
+          q.lastAccess,
+          q.refreshToken,
+          q.refresher,
+          newQueryStates
+        )
+      case _ => existingTable
+    })
+  }
+
+  /**
    * Registers a query-specific cached table in the cache. This method ensures that each query
    * maintains its own refresher state, even if multiple queries share the same table.
    * If the table is not already in the cache, a new entry is created. If the table is

--- a/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
+++ b/client/src/test/scala/org/apache/spark/delta/sharing/CachedTableManagerSuite.scala
@@ -855,4 +855,61 @@ class CachedTableManagerSuite extends SparkFunSuite with SharedSparkSession{
     manager.refresh()
     assert(manager.size == 0)
   }
+
+  test("registerQueryStatesInQuerySpecificCachedTable only adds new query states") {
+    // Basic set up
+    SparkSession.active.sessionState.conf.setConfString(
+      "spark.delta.sharing.client.sparkParquetIOCache.enabled", "true")
+    val manager = createManager()
+    val tablePath = "test_table"
+    val fileId = "file1"
+    val url1 = "https://test.com/file1"
+    val url2 = "https://test.com/file2"
+    val queryId1 = "query1"
+    val queryId2 = "query2"
+
+    val refresherWrapper: QuerySpecificCachedTable.RefresherWrapper =
+      (token, refresher) => refresher(token)
+    val refresher: Option[String] => TableRefreshResult = _ =>
+      TableRefreshResult(Map(fileId -> url2), Some(System.currentTimeMillis() + 60000), None)
+
+    val profileProvider1 = createProfileProvider(queryId1, refresherWrapper)
+    val profileProvider2 = createProfileProvider(queryId2, refresherWrapper)
+
+    // Register initial QuerySpecificCachedTable with queryId1
+    val ref1 = new WeakReference[AnyRef](new Object())
+    manager.register(
+      tablePath,
+      Map(fileId -> url1),
+      Seq(ref1),
+      profileProvider1,
+      refresher,
+      System.currentTimeMillis() + refreshThresholdMs + 100,
+      None
+    )
+
+    // Add queryId2 using the new method
+    manager.registerQueryStatesInQuerySpecificCachedTable(
+      tablePath,
+      Seq(new WeakReference[AnyRef](new Object())),
+      profileProvider2
+    )
+
+    // Check that both query states are present
+    assert(manager.size == 1)
+    assert(manager.getQueryStateSize(tablePath) == 2)
+
+    val (retrievedUrl1, _) = manager.getPreSignedUrl(tablePath, fileId)
+    assert(retrievedUrl1 === url1)
+
+    // Sleep to let the URLs expire
+    ref1.clear()
+    Thread.sleep(200)
+    manager.refresh()
+
+    // Refresh still works
+    assert(manager.getQueryStateSize(tablePath) == 1)
+    val (retrievedUrl2, _) = manager.getPreSignedUrl(tablePath, fileId)
+    assert(retrievedUrl2 === url2)
+  }
 }


### PR DESCRIPTION
This PR introduces a new method, `registerQueryStatesInQuerySpecificCachedTable`, to the `CachedTableManager` class in `PreSignedUrlCache.scala`. The new function allows for the atomic and thread-safe registration of query-specific states (including weak references and refresher wrappers) to an existing `QuerySpecificCachedTable` entry in the cache.