### PR TITLE
Add keepUrlsAfterRefsGone parameter to QuerySpecificCachedTable for flexible URL retention

### DIFF
--- a/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -572,7 +572,7 @@ class CachedTableManager(
    *                     the same set of files with refreshed urls.
    * @param keepUrlsAfterRefsGone If true, for QuerySpecificCachedTable, URLs will be kept in cache
    *                              even when all references are gone, and will only be cleaned up
-   *                              based on access expiry time.
+   *                              based on cache expiry time.
    */
   def register(
       tablePath: String,

--- a/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -99,7 +99,7 @@ class CachedTable(
  * @param queryStates A mapping of query identifiers to their associated weak references
  *                        and refresher wrappers.
  * @param keepUrlsAfterRefsGone If true, URLs will be kept in cache even when all references
- *                              are gone, and will only be cleaned up based on access expiry time.
+ *                              are gone, and will only be cleaned up based on cache expiry time.
  */
 class QuerySpecificCachedTable(
     expiration: Long,


### PR DESCRIPTION
This PR introduces a new `keepUrlsAfterRefsGone` boolean parameter to the `QuerySpecificCachedTable` class and related methods in `PreSignedUrlCache.scala`. This enhancement provides more flexible control over URL retention behavior when all FileIndex references are garbage collected. New queries don't need to be concurrent to reuse the existing urls.