### PR TITLE
Handle empty String nextPageToken correctly in DeltaSharingClient

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -261,7 +261,7 @@ class DeltaSharingRestClient(
     if (response != null && response.items != null) {
       shares ++= response.items
     }
-    while (response.nextPageToken.nonEmpty) {
+    while (response.nextPageToken.exists(_.nonEmpty)) {
       val encodedPageToken = URLEncoder.encode(response.nextPageToken.get, "UTF-8")
       val target = getTargetUrl(s"/shares?pageToken=$encodedPageToken")
       response = getJson[ListSharesResponse](target)
@@ -280,7 +280,7 @@ class DeltaSharingRestClient(
     if (response != null && response.items != null) {
       tables ++= response.items
     }
-    while (response.nextPageToken.nonEmpty) {
+    while (response.nextPageToken.exists(_.nonEmpty)) {
       val encodedPageToken = URLEncoder.encode(response.nextPageToken.get, "UTF-8")
       val target =
         getTargetUrl(s"/shares/$encodedShareName/all-tables?pageToken=$encodedPageToken")


### PR DESCRIPTION
According to PROTOCOL.md, an empty String also means end of the list, so it should be handled identically to None.