### PR TITLE
Make RemoteDeltaSnapshotFileIndex class public

### DIFF
--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -188,7 +188,7 @@ private[sharing] abstract class RemoteDeltaFileIndexBase(
 }
 
 // The index for processing files in a delta snapshot.
-private[sharing] case class RemoteDeltaSnapshotFileIndex(
+case class RemoteDeltaSnapshotFileIndex(
     override val params: RemoteDeltaFileIndexParams,
     limitHint: Option[Long]) extends RemoteDeltaFileIndexBase(params) {
 


### PR DESCRIPTION
Make the RemoteDeltaSnapshotFileIndex class public so that other libraries in Spark can perform a case check on HadoopFsRelation in the logical plan:

```
case h: HadoopFsRelation =>
  h.location match {
    case index: RemoteDeltaSnapshotFileIndex =>
```