### PR TITLE
Log URI and position details on HTTP stream read errors

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/RandomAccessHttpInputStream.scala
+++ b/client/src/main/scala/io/delta/sharing/client/RandomAccessHttpInputStream.scala
@@ -108,7 +108,7 @@ private[sharing] class RandomAccessHttpInputStream(
       currentStream.read()
     } catch {
       case e: Exception =>
-        if(logPreSignedUrlAccess) {
+        if (logPreSignedUrlAccess) {
           logInfo(s"Error reading from stream - uri: $uri, position: $pos, " +
             s"error: ${e.getMessage}")
         }
@@ -139,7 +139,7 @@ private[sharing] class RandomAccessHttpInputStream(
       currentStream.read(buf, off, len)
     } catch {
       case e: Exception =>
-        if(logPreSignedUrlAccess) {
+        if (logPreSignedUrlAccess) {
           logInfo(s"Error reading from stream - uri: $uri, position: $pos, offset: $off, " +
             s"length: $len, error: ${e.getMessage}")
         }


### PR DESCRIPTION
Added try-catch blocks with error logging to the `read()` methods in `RandomAccessHttpInputStream` to improve debugging of HTTP stream read failures.
