### PR TITLE
Use integrationTest for version mismatch check tests

### DIFF
--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -1403,7 +1403,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     checkErrorMessage(e, "BAD REQUEST: Error Occurred During Streaming")
   }
 
-  test("version mismatch check - getMetadata with mocked response") {
+  integrationTest("version mismatch check - getMetadata with mocked response") {
     Seq(true, false).foreach { isMSTQueryFlag =>
       val requestedVersion = 5L
       val returnedVersion = 10L
@@ -1460,7 +1460,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  test("version mismatch check - getFiles with mocked response") {
+  integrationTest("version mismatch check - getFiles with mocked response") {
     // Test delta format where version validation is controlled by isMSTQuery
     Seq(true, false).foreach { isMSTQueryFlag =>
       val requestedVersion = 15L


### PR DESCRIPTION
For all tests using testProfileFile, we would need use integrationTest.

integrationTest makes sure the test case only run when the PR user is able to fetch github credentials