### PR TITLE
Require delta-kernel-rust-sharing-wrapper >= 0.3.0

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     python_requires='>=3.8',
     install_requires=[
-        'delta-kernel-rust-sharing-wrapper>=0.2.0',
+        'delta-kernel-rust-sharing-wrapper>=0.3.0',
         'pandas',
         'pyarrow>=16.1.0',
         'fsspec>=0.7.4',


### PR DESCRIPTION
This way, future releases of the python connector will automatically pick up the updated rust wrapper.