### PR TITLE
Improve type safety for shareCredentialsOptions by using Map[String, String]

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -1251,7 +1251,7 @@ object DeltaSharingRestClient extends Logging {
    */
   def parsePath(
      path: String,
-     shareCredentialsOptions: Map[String, Any]): ParsedDeltaSharingTablePath = {
+     shareCredentialsOptions: Map[String, String]): ParsedDeltaSharingTablePath = {
     val shapeIndex = path.lastIndexOf('#')
 
     val (profileFile, tablePath) = {
@@ -1340,7 +1340,7 @@ object DeltaSharingRestClient extends Logging {
 
   def apply(
       profileFile: String,
-      shareCredentialsOptions: Map[String, Any],
+      shareCredentialsOptions: Map[String, String],
       forStreaming: Boolean = false,
       responseFormat: String = RESPONSE_FORMAT_PARQUET,
       readerFeatures: String = ""

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingProfileProvider.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingProfileProvider.scala
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.delta.sharing.TableRefreshResult
 
 import io.delta.sharing.client.util.JsonUtils
+import io.delta.sharing.spark.DeltaSharingOptions
 
 case class DeltaSharingProfile(
     shareCredentialsVersion: Option[Int],
@@ -111,11 +112,18 @@ private[sharing] class DeltaSharingFileProfileProvider(
  * Load [[DeltaSharingProfile]] from options.
  */
 private[sharing] class DeltaSharingOptionsProfileProvider(
-    shareCredentialsOptions: Map[String, Any]) extends DeltaSharingProfileProvider {
+    shareCredentialsOptions: Map[String, String]) extends DeltaSharingProfileProvider {
 
   val profile = {
+    // Convert string representations of shareCredentialsVersion to Int
+    val normalizedOptions: Map[String, Any] = shareCredentialsOptions.map {
+      case (DeltaSharingOptions.PROFILE_SHARE_CREDENTIALS_VERSION, v) =>
+        DeltaSharingOptions.PROFILE_SHARE_CREDENTIALS_VERSION -> v.toInt
+      case (k, v) => k -> v
+    }
+
     val profile = {
-      JsonUtils.fromJson[DeltaSharingProfile](JsonUtils.toJson(shareCredentialsOptions))
+      JsonUtils.fromJson[DeltaSharingProfile](JsonUtils.toJson(normalizedOptions))
     }
 
     validate(profile)

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -127,7 +127,7 @@ private[sharing] object RemoteDeltaLog {
 
   def apply(
       path: String,
-      shareCredentialsOptions: Map[String, Any],
+      shareCredentialsOptions: Map[String, String],
       forStreaming: Boolean = false,
       responseFormat: String = DeltaSharingOptions.RESPONSE_FORMAT_PARQUET,
       initDeltaTableMetadata: Option[DeltaTableMetadata] = None): RemoteDeltaLog = {

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingOptionsProfileProviderSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingOptionsProfileProviderSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.SparkFunSuite
 class DeltaSharingOptionsProfileProviderSuite extends SparkFunSuite {
 
   private def testProfile(
-    shareCredentialsOptions: Map[String, Any], expected: DeltaSharingProfile): Unit = {
+    shareCredentialsOptions: Map[String, String], expected: DeltaSharingProfile): Unit = {
     assert(new DeltaSharingOptionsProfileProvider(shareCredentialsOptions)
       .getProfile == expected)
   }
@@ -31,7 +31,7 @@ class DeltaSharingOptionsProfileProviderSuite extends SparkFunSuite {
   test("parse") {
     testProfile(
       Map(
-        "shareCredentialsVersion" -> 1,
+        "shareCredentialsVersion" -> "1",
         "endpoint" -> "foo",
         "bearerToken" -> "bar",
         "expirationTime" -> "2021-11-12T00:12:29Z"
@@ -48,7 +48,7 @@ class DeltaSharingOptionsProfileProviderSuite extends SparkFunSuite {
   test("expirationTime is optional") {
     testProfile(
       Map(
-        "shareCredentialsVersion" -> 1,
+        "shareCredentialsVersion" -> "1",
         "endpoint" -> "foo",
         "bearerToken" -> "bar"
       ),
@@ -78,7 +78,7 @@ class DeltaSharingOptionsProfileProviderSuite extends SparkFunSuite {
     val e = intercept[IllegalArgumentException] {
       testProfile(
         Map(
-          "shareCredentialsVersion" -> 2,
+          "shareCredentialsVersion" -> "2",
           "endpoint" -> "foo",
           "bearerToken" -> "bar"
         ),
@@ -94,7 +94,7 @@ class DeltaSharingOptionsProfileProviderSuite extends SparkFunSuite {
     val e = intercept[IllegalArgumentException] {
       testProfile(
         Map(
-          "shareCredentialsVersion" -> 100
+          "shareCredentialsVersion" -> "100"
         ),
         null
       )
@@ -107,7 +107,7 @@ class DeltaSharingOptionsProfileProviderSuite extends SparkFunSuite {
     val e = intercept[IllegalArgumentException] {
       testProfile(
         Map(
-          "shareCredentialsVersion" -> 1,
+          "shareCredentialsVersion" -> "1",
           "bearerToken" -> "bar"
         ),
         null
@@ -120,7 +120,7 @@ class DeltaSharingOptionsProfileProviderSuite extends SparkFunSuite {
     val e = intercept[IllegalArgumentException] {
       testProfile(
         Map(
-          "shareCredentialsVersion" -> 1,
+          "shareCredentialsVersion" -> "1",
           "endpoint" -> "foo"
         ),
         null
@@ -132,7 +132,7 @@ class DeltaSharingOptionsProfileProviderSuite extends SparkFunSuite {
   test("unknown field should be ignored") {
     testProfile(
       Map(
-        "shareCredentialsVersion" -> 1,
+        "shareCredentialsVersion" -> "1",
         "endpoint" -> "foo",
         "bearerToken" -> "bar",
         "expirationTime" -> "2021-11-12T00:12:29Z",

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -636,7 +636,7 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
          |  "bearerToken": "xxxxx"
          |}""".stripMargin, UTF_8)
     val tablePath = s"${testProfileFile.getCanonicalPath}#share.schema.table"
-    lazy val shareCredentialsOptions: Map[String, Any] = Map.empty
+    lazy val shareCredentialsOptions: Map[String, String] = Map.empty
 
     spark.sessionState.conf.setConfString(
       "spark.delta.sharing.client.sparkParquetIOCache.enabled", "false")
@@ -650,8 +650,8 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
 
   test("RemoteDeltaLog path with options") {
     lazy val tablePath = "share.schema.table"
-    lazy val shareCredentialsOptions: Map[String, Any] = Map(
-      "shareCredentialsVersion" -> 1,
+    lazy val shareCredentialsOptions: Map[String, String] = Map(
+      "shareCredentialsVersion" -> "1",
       "endpoint" -> "foo",
       "bearerToken" -> "bar",
       "expirationTime" -> "2021-11-12T00:12:29Z"


### PR DESCRIPTION
## Summary
This PR improves type safety by changing `shareCredentialsOptions` from `Map[String, Any]` to `Map[String, String]` throughout the codebase, and adds explicit type conversion in DeltaSharingOptionsProfileProvider

## Problem
The integration test **"table1 passing profile with read options"** in `DeltaSharingSuite` was failing with:
```
java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Integer
at io.delta.sharing.client.DeltaSharingProfileProvider.validate(DeltaSharingProfileProvider.scala:70)
```
