### PR TITLE
Upgrade delta-kernel-rs to 0.18.2

### DIFF
--- a/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
+++ b/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
@@ -2,7 +2,7 @@
 name = "delta-kernel-rust-sharing-wrapper"
 edition = "2021"
 license = "Apache-2.0"
-version = "0.3.0"
+version = "0.3.1"
 
 [lib]
 name = "delta_kernel_rust_sharing_wrapper"
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 arrow = { version = "57", features = ["pyarrow"] }
 object_store = "0.12.4"
-delta_kernel = { version = "0.18.1", features = ["default-engine-rustls", "arrow-57"]}
+delta_kernel = { version = "0.18.2", features = ["default-engine-rustls", "arrow-57"]}
 openssl = { version = "0.10", features = ["vendored"] }
 url = "2"
 


### PR DESCRIPTION
This fixes a bug where the combination of `minReaderVersion = 2` and the presence of column mappings in `writerFeatures` leads to a kernel error.

This was tested manually because our reference server doesn't return any writer features in the protocol, so the above failure cannot be reproduced in our current integration tests.