### PR TITLE
Avoid integrationTest when real table not required

### DIFF
--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -1482,7 +1482,16 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     checkErrorMessage(e, "BAD REQUEST: Error Occurred During Streaming")
   }
 
-  integrationTest("generateTemporaryTableCredential - parse responses") {
+  class TestProfileProvider(isMSTQuery: Boolean = false) extends DeltaSharingProfileProvider {
+    override def getProfile: DeltaSharingProfile = DeltaSharingProfile(
+      shareCredentialsVersion = Some(1),
+      endpoint = "http://localhost:12345",
+      bearerToken = "test-bearer-token"
+    )
+    override def isMSTQuery(): Boolean = isMSTQuery
+  }
+
+  test("generateTemporaryTableCredential - parse responses") {
     val testCases = Seq(
       (
         """{"credentials":{"location":"s3://some/path/to/table","awsTempCredentials":{"accessKeyId":"some-access-key-id","secretAccessKey":"some-secret-access-key","sessionToken":"some-session-token"},"expirationTime":1}}""",
@@ -1527,7 +1536,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     testCases.foreach { case (jsonResponse, expectedCredentials) =>
       // Create a client that overrides getResponse to return a mocked response
       val client = new DeltaSharingRestClient(
-        profileProvider = testProfileProvider,
+        profileProvider = new TestProfileProvider,
         sslTrustAll = true
       ) {
         override private[client] def getResponse(
@@ -1584,11 +1593,11 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  integrationTest("generateTemporaryTableCredential - with location parameter") {
+  test("generateTemporaryTableCredential - with location parameter") {
     var capturedRequest: Option[HttpRequestBase] = None
 
     val client = new DeltaSharingRestClient(
-      profileProvider = testProfileProvider,
+      profileProvider = new TestProfileProvider,
       sslTrustAll = true
     ) {
       override private[client] def getResponse(
@@ -1641,7 +1650,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     // Test without location parameter (location = None)
     capturedRequest = None
     val client2 = new DeltaSharingRestClient(
-      profileProvider = testProfileProvider,
+      profileProvider = new TestProfileProvider,
       sslTrustAll = true
     ) {
       override private[client] def getResponse(
@@ -1684,10 +1693,10 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  integrationTest("generateTemporaryTableCredential - error on not one-line response") {
+  test("generateTemporaryTableCredential - error on not one-line response") {
     // Test with more than 1 line in response
     val client = new DeltaSharingRestClient(
-      profileProvider = testProfileProvider,
+      profileProvider = new TestProfileProvider,
       sslTrustAll = true
     ) {
       override private[client] def getResponse(
@@ -1721,7 +1730,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
 
     // Test with 0 lines in response
     val client2 = new DeltaSharingRestClient(
-      profileProvider = testProfileProvider,
+      profileProvider = new TestProfileProvider,
       sslTrustAll = true
     ) {
       override private[client] def getResponse(
@@ -1750,10 +1759,10 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  integrationTest("generateTemporaryTableCredential - malformed response handling") {
+  test("generateTemporaryTableCredential - malformed response handling") {
     // Test with malformed JSON
     val malformedJsonClient = new DeltaSharingRestClient(
-      profileProvider = testProfileProvider,
+      profileProvider = new TestProfileProvider,
       sslTrustAll = true
     ) {
       override private[client] def getResponse(
@@ -1783,7 +1792,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
 
     // Test with missing required fields (no credentials types set)
     val missingFieldsClient = new DeltaSharingRestClient(
-      profileProvider = testProfileProvider,
+      profileProvider = new TestProfileProvider,
       sslTrustAll = true
     ) {
       override private[client] def getResponse(
@@ -1814,7 +1823,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
 
     // Test with null credentials
     val nullCredentialsClient = new DeltaSharingRestClient(
-      profileProvider = testProfileProvider,
+      profileProvider = new TestProfileProvider,
       sslTrustAll = true
     ) {
       override private[client] def getResponse(
@@ -1844,7 +1853,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
 
     // Test with completely invalid JSON structure
     val invalidStructureClient = new DeltaSharingRestClient(
-      profileProvider = testProfileProvider,
+      profileProvider = new TestProfileProvider,
       sslTrustAll = true
     ) {
       override private[client] def getResponse(
@@ -1873,7 +1882,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
 
     // Test with empty JSON object
     val emptyJsonClient = new DeltaSharingRestClient(
-      profileProvider = testProfileProvider,
+      profileProvider = new TestProfileProvider,
       sslTrustAll = true
     ) {
       override private[client] def getResponse(
@@ -1902,21 +1911,14 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  integrationTest("version mismatch check - getMetadata with mocked response") {
+  test("version mismatch check - getMetadata with mocked response") {
     Seq(true, false).foreach { isMSTQueryFlag =>
       val requestedVersion = 5L
       val returnedVersion = 10L
 
-      val mockProfileProvider = new DeltaSharingFileProfileProvider(
-        new Configuration(),
-        testProfileFile.getCanonicalPath
-      ) {
-        override def isMSTQuery(): Boolean = isMSTQueryFlag
-      }
-
       // Create a client that overrides getNDJson to return a mocked response
       val client = new DeltaSharingRestClient(
-        profileProvider = mockProfileProvider
+        profileProvider = new TestProfileProvider(isMSTQueryFlag)
       ) {
         override def getNDJson(
             target: String,
@@ -1959,22 +1961,15 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  integrationTest("version mismatch check - getFiles with mocked response") {
+  test("version mismatch check - getFiles with mocked response") {
     // Test delta format where version validation is controlled by isMSTQuery
     Seq(true, false).foreach { isMSTQueryFlag =>
       val requestedVersion = 15L
       val returnedVersion = 20L
 
-      val mockProfileProvider = new DeltaSharingFileProfileProvider(
-        new Configuration(),
-        testProfileFile.getCanonicalPath
-      ) {
-        override def isMSTQuery(): Boolean = isMSTQueryFlag
-      }
-
       // Create a client that overrides getNDJsonPost to return a mocked delta format response
       val client = new DeltaSharingRestClient(
-        profileProvider = mockProfileProvider,
+        profileProvider = new TestProfileProvider(isMSTQueryFlag),
         responseFormat = RESPONSE_FORMAT_DELTA
       ) {
         override def getNDJsonPost[T: Manifest](


### PR DESCRIPTION
Avoid integrationTest when real table not required so that the tests are run for non-trusted contributors