### PR TITLE
Improve the error message of idle URL access 

### DIFF
--- a/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
+++ b/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala
@@ -390,7 +390,11 @@ class CachedTableManager(
       fileId: String): PreSignedUrlCache.Rpc.GetPreSignedUrlResponse = {
     val cachedTable = cache.get(tablePath)
     if (cachedTable == null) {
-      throw new IllegalStateException(s"table $tablePath was removed")
+      throw new IllegalStateException(
+        s"Table $tablePath was removed from the cache (URL entry idle too long and cleaned up). " +
+        s"Set spark.delta.sharing.driver.accessThresholdToExpireMs (milliseconds) " +
+        s"to be the same as the query's expected execution time."
+      )
     }
     cachedTable.lastAccess = System.currentTimeMillis()
     val url = cachedTable.idToUrl.getOrElse(fileId, {


### PR DESCRIPTION
When a table is missing from the cache (removed after idle), throw a clearer error that explains cleanup and tells users to set spark.delta.sharing.driver.accessThresholdToExpireMs to the query’s expected execution time (milliseconds).