### PR TITLE
Add skipFileIdHashVerification conf to skip verifyFileIdHashResponse

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -211,11 +211,12 @@ class DeltaSharingRestClient(
     tokenExchangeMaxRetries: Int = 5,
     tokenExchangeMaxRetryDurationInSeconds: Int = 60,
     tokenRenewalThresholdInSeconds: Int = 600,
-    callerOrg: String = ""
+    callerOrg: String = "",
+    skipFileIdHashVerification: Boolean = false
   ) extends DeltaSharingClient with Logging {
 
   logInfo(s"DeltaSharingRestClient with endStreamActionEnabled: $endStreamActionEnabled, " +
-    s"enableAsyncQuery:$enableAsyncQuery")
+    s"enableAsyncQuery:$enableAsyncQuery, skipFileIdHashVerification:$skipFileIdHashVerification")
 
   import DeltaSharingRestClient._
 
@@ -1282,6 +1283,7 @@ class DeltaSharingRestClient(
       requestFileIdHash: Option[String],
       responseFileIdHash: Option[String],
       rpc: String): Unit = {
+    if (skipFileIdHashVerification) return
     if (requestFileIdHash.isDefined) {
       val expected = requestFileIdHash.get.toLowerCase(Locale.ROOT)
       if (responseFileIdHash.isEmpty) {
@@ -1671,6 +1673,7 @@ object DeltaSharingRestClient extends Logging {
     val tokenExchangeMaxRetryDurationInSeconds =
       ConfUtils.tokenExchangeMaxRetryDurationInSeconds(sqlConf)
     val tokenRenewalThresholdInSeconds = ConfUtils.tokenRenewalThresholdInSeconds(sqlConf)
+    val skipFileIdHashVerification = ConfUtils.skipFileIdHashVerification(sqlConf)
 
     val clientClass = ConfUtils.clientClass(sqlConf)
     Class.forName(clientClass)
@@ -1693,7 +1696,8 @@ object DeltaSharingRestClient extends Logging {
         classOf[Int],
         classOf[Int],
         classOf[Int],
-        classOf[String]
+        classOf[String],
+        classOf[Boolean]
     ).newInstance(profileProvider,
         java.lang.Integer.valueOf(timeoutInSeconds),
         java.lang.Integer.valueOf(numRetries),
@@ -1712,7 +1716,8 @@ object DeltaSharingRestClient extends Logging {
         java.lang.Integer.valueOf(tokenExchangeMaxRetries),
         java.lang.Integer.valueOf(tokenExchangeMaxRetryDurationInSeconds),
         java.lang.Integer.valueOf(tokenRenewalThresholdInSeconds),
-        callerOrg.getOrElse("")
+        callerOrg.getOrElse(""),
+        java.lang.Boolean.valueOf(skipFileIdHashVerification)
       ).asInstanceOf[DeltaSharingClient]
   }
 }

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -114,6 +114,9 @@ object ConfUtils {
   val OPTIONS_PROFILE_PROVIDER_ENABLED_CONF = "spark.delta.sharing.profile.optionsProvider.enabled"
   val OPTIONS_PROFILE_PROVIDER_ENABLED_DEFAULT = true
 
+  val SKIP_FILE_ID_HASH_VERIFICATION_CONF = "spark.delta.sharing.client.skipFileIdHashVerification"
+  val SKIP_FILE_ID_HASH_VERIFICATION_DEFAULT = "false"
+
   def getProxyConfig(conf: Configuration): Option[ProxyConfig] = {
     val proxyHost = conf.get(PROXY_HOST, null)
     val proxyPortAsString = conf.get(PROXY_PORT, null)
@@ -351,6 +354,12 @@ object ConfUtils {
     conf.getConfString(
       OPTIONS_PROFILE_PROVIDER_ENABLED_CONF,
       OPTIONS_PROFILE_PROVIDER_ENABLED_DEFAULT.toString).toBoolean
+  }
+
+  def skipFileIdHashVerification(conf: SQLConf): Boolean = {
+    conf.getConfString(
+      SKIP_FILE_ID_HASH_VERIFICATION_CONF,
+      SKIP_FILE_ID_HASH_VERIFICATION_DEFAULT).toBoolean
   }
 
   private def toTimeInSeconds(timeStr: String, conf: String): Int = {

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -2241,4 +2241,36 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
+  test("fileIdHash - skipFileIdHashVerification=true skips verification when server does not echo") {
+    val client = new DeltaSharingRestClient(
+      profileProvider = new TestProfileProvider(false),
+      responseFormat = RESPONSE_FORMAT_DELTA,
+      skipFileIdHashVerification = true
+    ) {
+      override def getNDJsonPost[T: Manifest](
+          target: String,
+          data: T,
+          setIncludeEndStreamAction: Boolean,
+          requestFileIdHash: Option[String]
+      ): ParsedDeltaSharingResponse = {
+        ParsedDeltaSharingResponse(
+          version = 1L,
+          respondedFormat = RESPONSE_FORMAT_DELTA,
+          lines = Seq(
+            """{"protocol":{"minReaderVersion":1}}""",
+            """{"metaData":{"id":"test-id","format":{"provider":"parquet"},"schemaString":"{}","partitionColumns":[]}}"""
+          ),
+          capabilitiesMap = Map.empty,
+          fileIdHash = None
+        )
+      }
+    }
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      val files = client.getFiles(table, Nil, None, None, None, None, None, Some("md5"))
+      assert(files.version == 1L)
+    } finally {
+      client.close()
+    }
+  }
 }

--- a/client/src/test/scala/io/delta/sharing/client/util/ConfUtilsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/ConfUtilsSuite.scala
@@ -276,4 +276,14 @@ class ConfUtilsSuite extends SparkFunSuite {
       tokenRenewalThresholdInSeconds(newSqlConf(Map(OAUTH_EXPIRATION_THRESHOLD_CONF -> "-1")))
     }.getMessage.contains(OAUTH_EXPIRATION_THRESHOLD_CONF)
   }
+
+  test("skipFileIdHashVerification with SQLConf") {
+    assert(skipFileIdHashVerification(newSqlConf()) == false)
+    assert(
+      skipFileIdHashVerification(newSqlConf(Map(SKIP_FILE_ID_HASH_VERIFICATION_CONF -> "true")))
+        == true)
+    assert(
+      skipFileIdHashVerification(newSqlConf(Map(SKIP_FILE_ID_HASH_VERIFICATION_CONF -> "false")))
+        == false)
+  }
 }

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -29,8 +29,9 @@ import org.apache.spark.sql.execution.datasources.HadoopFsRelation
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-import io.delta.sharing.client.DeltaSharingFileSystem
+import io.delta.sharing.client.{DeltaSharingFileSystem, DeltaSharingRestClient}
 import io.delta.sharing.client.model.Table
+import io.delta.sharing.client.util.ConfUtils
 import io.delta.sharing.spark.util.QueryUtils
 
 
@@ -1045,5 +1046,33 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     assert(deltaLog2.path.toString.split("\\.")(2).split("_").length == 4)
     val snapshot2 = deltaLog2.snapshot()
     assert(snapshot2.getTablePath.toString.split("\\.")(2).split("_").length == 4)
+  }
+
+  test("skipFileIdHashVerification conf is passed through DeltaSharingRestClient.apply()") {
+    val testShareCredentialsOptions: Map[String, String] = Map(
+      "shareCredentialsVersion" -> "1",
+      "endpoint" -> "https://example.com",
+      "bearerToken" -> "test-token"
+    )
+    val spark = SparkSession.active
+    val sqlConf = spark.sessionState.conf
+    val originalClientClass =
+      sqlConf.getConfString(ConfUtils.CLIENT_CLASS_CONF, ConfUtils.CLIENT_CLASS_DEFAULT)
+    try {
+      sqlConf.setConfString(ConfUtils.CLIENT_CLASS_CONF,
+        "io.delta.sharing.spark.TestDeltaSharingClient")
+      TestDeltaSharingClient.lastSkipFileIdHashVerification = false
+
+      sqlConf.setConfString(ConfUtils.SKIP_FILE_ID_HASH_VERIFICATION_CONF, "true")
+      DeltaSharingRestClient("", testShareCredentialsOptions)
+      assert(TestDeltaSharingClient.lastSkipFileIdHashVerification === true)
+
+      sqlConf.setConfString(ConfUtils.SKIP_FILE_ID_HASH_VERIFICATION_CONF, "false")
+      DeltaSharingRestClient("", testShareCredentialsOptions)
+      assert(TestDeltaSharingClient.lastSkipFileIdHashVerification === false)
+    } finally {
+      sqlConf.setConfString(ConfUtils.CLIENT_CLASS_CONF, originalClientClass)
+      sqlConf.setConfString(ConfUtils.SKIP_FILE_ID_HASH_VERIFICATION_CONF, "false")
+    }
   }
 }

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -58,8 +58,11 @@ class TestDeltaSharingClient(
     tokenExchangeMaxRetries: Int = 5,
     tokenExchangeMaxRetryDurationInSeconds: Int = 60,
     tokenRenewalThresholdInSeconds: Int = 600,
-    callerOrg: String = ""
+    callerOrg: String = "",
+    skipFileIdHashVerification: Boolean = false
   ) extends DeltaSharingClient {
+
+  TestDeltaSharingClient.lastSkipFileIdHashVerification = skipFileIdHashVerification
 
   import DeltaSharingOptions.RESPONSE_FORMAT_PARQUET
 
@@ -234,6 +237,9 @@ object TestDeltaSharingClient {
   var jsonPredicateHints = Seq.empty[String]
 
   var numMetadataCalled = 0
+
+  /** Captured skipFileIdHashVerification from last constructor call (for conf wiring tests). */
+  var lastSkipFileIdHashVerification: Boolean = false
 
   val TESTING_TIMESTAMP = "2022-01-01 00:00:00.0"
 


### PR DESCRIPTION
In case that open server doesn't support fileIdHash, provide a way to bypass the validation check to unblock query.

## Change
- ConfUtils: SKIP_FILE_ID_HASH_VERIFICATION_CONF and skipFileIdHashVerification(conf)
- DeltaSharingRestClient: skipFileIdHashVerification param, skip verify when true

## Test
- TestDeltaSharingClient: capture lastSkipFileIdHashVerification for tests
- ConfUtilsSuite: test skipFileIdHashVerification SQLConf parsing
- DeltaSharingRestClientSuite: test skip verification when server does not echo
- RemoteDeltaLogSuite: test conf passed through apply() using TestDeltaSharingClient