### PR TITLE
Build wheels for linux arm64

### DIFF
--- a/.github/workflows/build-kernel-wheels.yml
+++ b/.github/workflows/build-kernel-wheels.yml
@@ -22,12 +22,6 @@ jobs:
         python-version: ["3.10"]
         arch: [x86_64, arm64]
         exclude:
-          - os: ubuntu-latest
-            arch: arm64
-          - os: ubuntu-24.04
-            arch: arm64
-          - os: ubuntu-22.04
-            arch: arm64
           - os: windows-latest
             arch: arm64
 


### PR DESCRIPTION
We are using delta-sharing on Linux ARM64 and our docker builds need to build this package from scratch every time due to that there are no binaries so would really like to have them prebuilt in the PyPi package.