### PR TITLE
Server: use parquet/delta for fileidhash header

### DIFF
--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharedTableProtocol.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharedTableProtocol.scala
@@ -69,17 +69,17 @@ object DeltaSharingUtils {
   val RESPONSE_FORMAT_DELTA = "delta"
 
   /**
-   * Hash a file path to produce a file ID. When the client explicitly requests an algorithm
-   * via `fileIdHash`, that algorithm is used. Otherwise the default is sha256 for the delta
-   * response format and md5 for parquet (backward compatibility).
+   * Hash a file path to produce a file ID. When the client explicitly requests a scheme
+   * via `fileIdHash` (`parquet` or `delta`), that scheme is used. Otherwise the default
+   * matches the response format: `delta` uses SHA-256 of the path; `parquet` uses MD5.
    */
   def hashFileId(
       path: String,
       fileIdHash: Option[String],
       respondedFormat: String): String = {
     fileIdHash match {
-      case Some("sha256") => Hashing.sha256().hashString(path, UTF_8).toString
-      case Some("md5") => Hashing.md5().hashString(path, UTF_8).toString
+      case Some("delta") => Hashing.sha256().hashString(path, UTF_8).toString
+      case Some("parquet") => Hashing.md5().hashString(path, UTF_8).toString
       case _ =>
         if (respondedFormat == RESPONSE_FORMAT_DELTA) {
           Hashing.sha256().hashString(path, UTF_8).toString

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -635,7 +635,7 @@ class DeltaSharingService(serverConfig: ServerConfig) {
     )
   }
 
-  /** Returns validated fileidhash request header (md5 or sha256, lowercase) or None. */
+  /** Returns validated fileidhash request header (parquet or delta, lowercase) or None. */
   private def getRequestFileIdHash(req: HttpRequest): Option[String] = {
     // scalastyle:off caselocale
     Option(req.headers().get(FILEIDHASH_HEADER)).map { raw =>
@@ -748,7 +748,7 @@ object DeltaSharingService {
   val DELTA_TABLE_METADATA_CONTENT_TYPE = "application/x-ndjson; charset=utf-8"
   val DELTA_SHARING_CAPABILITIES_HEADER = "delta-sharing-capabilities"
   val FILEIDHASH_HEADER = "fileidhash"
-  val FILEIDHASH_VALID_VALUES = Set("md5", "sha256")
+  val FILEIDHASH_VALID_VALUES = Set("parquet", "delta")
   val DELTA_SHARING_RESPONSE_FORMAT = "responseformat"
   val DELTA_SHARING_CAPABILITIES_ASYNC_QUERY = "asyncquery"
   val DELTA_SHARING_INCLUDE_END_STREAM_ACTION = "includeendstreamaction"

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -728,7 +728,7 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     }
   }
 
-  integrationTest("queryTable file id signed with requested fileidhash (md5 and sha256)") {
+  integrationTest("queryTable file id signed with requested fileidhash (parquet and delta)") {
     val p =
       s"""
          |{
@@ -738,28 +738,28 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
          |}
          |""".stripMargin
     val url = requestPath("/shares/share1/schemas/default/tables/table1/query")
-    val (responseMd5, fileIdHashHeaderMd5) = readNDJsonWithFileIdHashHeader(
-      url, Some("POST"), Some(p), Some(2), RESPONSE_FORMAT_PARQUET, requestFileIdHash = Some("md5"))
-    val (responseSha256, fileIdHashHeaderSha256) = readNDJsonWithFileIdHashHeader(
-      url, Some("POST"), Some(p), Some(2), RESPONSE_FORMAT_PARQUET, requestFileIdHash = Some("sha256"))
-    assert(fileIdHashHeaderMd5.contains("md5"), s"Expected fileidhash response header 'md5', got $fileIdHashHeaderMd5")
-    assert(fileIdHashHeaderSha256.contains("sha256"), s"Expected fileidhash response header 'sha256', got $fileIdHashHeaderSha256")
-    val fileIdsMd5 = extractFileIdsFromQueryResponse(responseMd5)
-    val fileIdsSha256 = extractFileIdsFromQueryResponse(responseSha256)
-    assert(fileIdsMd5.nonEmpty && fileIdsSha256.nonEmpty)
-    assert(fileIdsMd5.size == fileIdsSha256.size)
-    fileIdsMd5.foreach { id =>
-      assert(id.length == 32, s"MD5 file id should be 32 hex chars: $id")
-      assert(id.matches("[0-9a-f]+"), s"MD5 file id should be hex: $id")
+    val (responseParquet, fileIdHashHeaderParquet) = readNDJsonWithFileIdHashHeader(
+      url, Some("POST"), Some(p), Some(2), RESPONSE_FORMAT_PARQUET, requestFileIdHash = Some("parquet"))
+    val (responseDelta, fileIdHashHeaderDelta) = readNDJsonWithFileIdHashHeader(
+      url, Some("POST"), Some(p), Some(2), RESPONSE_FORMAT_PARQUET, requestFileIdHash = Some("delta"))
+    assert(fileIdHashHeaderParquet.contains("parquet"), s"Expected fileidhash response header 'parquet', got $fileIdHashHeaderParquet")
+    assert(fileIdHashHeaderDelta.contains("delta"), s"Expected fileidhash response header 'delta', got $fileIdHashHeaderDelta")
+    val fileIdsParquet = extractFileIdsFromQueryResponse(responseParquet)
+    val fileIdsDelta = extractFileIdsFromQueryResponse(responseDelta)
+    assert(fileIdsParquet.nonEmpty && fileIdsDelta.nonEmpty)
+    assert(fileIdsParquet.size == fileIdsDelta.size)
+    fileIdsParquet.foreach { id =>
+      assert(id.length == 32, s"parquet fileidhash should produce 32 hex char (MD5) ids: $id")
+      assert(id.matches("[0-9a-f]+"), s"parquet file id should be hex: $id")
     }
-    fileIdsSha256.foreach { id =>
-      assert(id.length == 64, s"SHA256 file id should be 64 hex chars: $id")
-      assert(id.matches("[0-9a-f]+"), s"SHA256 file id should be hex: $id")
+    fileIdsDelta.foreach { id =>
+      assert(id.length == 64, s"delta fileidhash should produce 64 hex char (SHA-256) ids: $id")
+      assert(id.matches("[0-9a-f]+"), s"delta file id should be hex: $id")
     }
-    assert(fileIdsMd5 != fileIdsSha256, "file ids should differ between md5 and sha256")
+    assert(fileIdsParquet != fileIdsDelta, "file ids should differ between parquet and delta fileidhash")
   }
 
-  integrationTest("queryTable fileidhash defaults: parquet=md5, delta=sha256") {
+  integrationTest("queryTable fileidhash defaults: parquet format uses parquet ids, delta format uses delta ids") {
     val p =
       s"""
          |{
@@ -772,33 +772,33 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
 
     val defaultParquetIds = extractFileIdsFromQueryResponse(
       readNDJson(url, Some("POST"), Some(p), Some(2), RESPONSE_FORMAT_PARQUET))
-    val explicitMd5Ids = extractFileIdsFromQueryResponse(
+    val explicitParquetIds = extractFileIdsFromQueryResponse(
       readNDJson(url, Some("POST"), Some(p), Some(2), RESPONSE_FORMAT_PARQUET,
-        requestFileIdHash = Some("md5")))
+        requestFileIdHash = Some("parquet")))
     assert(defaultParquetIds.nonEmpty)
     defaultParquetIds.foreach { id =>
-      assert(id.length == 32, s"Parquet default should produce 32-char md5 IDs: $id")
+      assert(id.length == 32, s"Parquet response default should produce 32-char (MD5) IDs: $id")
     }
-    assert(defaultParquetIds == explicitMd5Ids,
-      "Parquet default file IDs should match explicit md5 file IDs")
+    assert(defaultParquetIds == explicitParquetIds,
+      "Parquet default file IDs should match explicit parquet fileidhash file IDs")
 
     val defaultDeltaIds = extractFileIdsFromQueryResponse(
       readNDJson(url, Some("POST"), Some(p), Some(2), RESPONSE_FORMAT_DELTA))
-    val explicitSha256Ids = extractFileIdsFromQueryResponse(
+    val explicitDeltaIds = extractFileIdsFromQueryResponse(
       readNDJson(url, Some("POST"), Some(p), Some(2), RESPONSE_FORMAT_DELTA,
-        requestFileIdHash = Some("sha256")))
+        requestFileIdHash = Some("delta")))
     assert(defaultDeltaIds.nonEmpty)
     defaultDeltaIds.foreach { id =>
-      assert(id.length == 64, s"Delta default should produce 64-char sha256 IDs: $id")
+      assert(id.length == 64, s"Delta response default should produce 64-char (SHA-256) IDs: $id")
     }
-    assert(defaultDeltaIds == explicitSha256Ids,
-      "Delta default file IDs should match explicit sha256 file IDs")
+    assert(defaultDeltaIds == explicitDeltaIds,
+      "Delta default file IDs should match explicit delta fileidhash file IDs")
   }
 
   integrationTest("queryTable rejects unsupported fileidhash value with 400") {
     val queryBody = """{"predicateHints": []}"""
     val url = requestPath("/shares/share1/schemas/default/tables/table1/query")
-    Seq("sha512", "SHA3-256", "none", "blake2b").foreach { invalid =>
+    Seq("sha512", "SHA3-256", "none", "blake2b", "md5", "sha256").foreach { invalid =>
       assertHttpError(
         url = url,
         method = "POST",
@@ -3180,26 +3180,26 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     }
   }
 
-  integrationTest("queryCDF file id signed with requested fileidhash (md5 and sha256)") {
+  integrationTest("queryCDF file id signed with requested fileidhash (parquet and delta)") {
     val baseUrl = requestPath(
       s"/shares/share8/schemas/default/tables/cdf_table_cdf_enabled/changes?startingVersion=0&endingVersion=3")
-    val responseMd5 = readNDJson(baseUrl, Some("GET"), None, Some(0), RESPONSE_FORMAT_PARQUET,
-      requestFileIdHash = Some("md5"))
-    val responseSha256 = readNDJson(baseUrl, Some("GET"), None, Some(0), RESPONSE_FORMAT_PARQUET,
-      requestFileIdHash = Some("sha256"))
-    val fileIdsMd5 = extractFileIdsFromQueryResponse(responseMd5)
-    val fileIdsSha256 = extractFileIdsFromQueryResponse(responseSha256)
-    assert(fileIdsMd5.nonEmpty && fileIdsSha256.nonEmpty)
-    assert(fileIdsMd5.size == fileIdsSha256.size)
-    fileIdsMd5.foreach { id =>
-      assert(id.length == 32, s"MD5 file id should be 32 hex chars: $id")
-      assert(id.matches("[0-9a-f]+"), s"MD5 file id should be hex: $id")
+    val responseParquet = readNDJson(baseUrl, Some("GET"), None, Some(0), RESPONSE_FORMAT_PARQUET,
+      requestFileIdHash = Some("parquet"))
+    val responseDelta = readNDJson(baseUrl, Some("GET"), None, Some(0), RESPONSE_FORMAT_PARQUET,
+      requestFileIdHash = Some("delta"))
+    val fileIdsParquet = extractFileIdsFromQueryResponse(responseParquet)
+    val fileIdsDelta = extractFileIdsFromQueryResponse(responseDelta)
+    assert(fileIdsParquet.nonEmpty && fileIdsDelta.nonEmpty)
+    assert(fileIdsParquet.size == fileIdsDelta.size)
+    fileIdsParquet.foreach { id =>
+      assert(id.length == 32, s"parquet fileidhash should produce 32 hex chars: $id")
+      assert(id.matches("[0-9a-f]+"), s"parquet file id should be hex: $id")
     }
-    fileIdsSha256.foreach { id =>
-      assert(id.length == 64, s"SHA256 file id should be 64 hex chars: $id")
-      assert(id.matches("[0-9a-f]+"), s"SHA256 file id should be hex: $id")
+    fileIdsDelta.foreach { id =>
+      assert(id.length == 64, s"delta fileidhash should produce 64 hex chars: $id")
+      assert(id.matches("[0-9a-f]+"), s"delta file id should be hex: $id")
     }
-    assert(fileIdsMd5 != fileIdsSha256, "file ids should differ between md5 and sha256")
+    assert(fileIdsParquet != fileIdsDelta, "file ids should differ between parquet and delta fileidhash")
   }
 
   integrationTest("cdf_table_cdf_enabled_changes - paginated query table changes") {


### PR DESCRIPTION
Renames supported `fileidhash` values from `md5`/`sha256` to `parquet`/`delta`. Hashing is unchanged (parquet → MD5 of path, delta → SHA-256). Defaults when the header is omitted are unchanged.