### PR TITLE
Fix python build-and-test jobs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -123,18 +123,15 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-      - name: Install uv
+      - name: Install Python and uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           cd python
           uv sync
-          cd delta-kernel-rust-sharing-wrapper
-          uv run maturin develop
+          uv run maturin develop --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml
       - name: Build Server
         run: ./build/sbt package
       - name: Run tests

--- a/.github/workflows/build-kernel-wheels.yml
+++ b/.github/workflows/build-kernel-wheels.yml
@@ -34,56 +34,58 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - name: Set up Python and uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install maturin
-        run: pipx install maturin==1.12.6
+      - name: Install dependencies
+        run: |
+          cd python
+          uv sync
 
       - name: Build wheel (x86_64 macOS)
         if: matrix.os == 'macos-latest' && matrix.arch == 'x86_64'
         run: |
           rustup target add x86_64-apple-darwin
-          cd python/delta-kernel-rust-sharing-wrapper
-          maturin build --release --target x86_64-apple-darwin
+          cd python
+          uv run maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release --target x86_64-apple-darwin
         shell: bash
 
       - name: Build wheel (ARM macOS)
         if: matrix.os == 'macos-latest' && matrix.arch == 'arm64'
         run: |
           rustup target add aarch64-apple-darwin
-          cd python/delta-kernel-rust-sharing-wrapper
-          maturin build --release --target aarch64-apple-darwin
+          cd python
+          uv run maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release --target aarch64-apple-darwin
         shell: bash
 
       - name: Build wheel (x86_64 Windows)
         if: runner.os == 'Windows'
         run: |
-          cd python/delta-kernel-rust-sharing-wrapper
-          maturin build --release
+          cd python
+          uv run maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release
         shell: powershell
 
       - name: Build wheel (x86_64 Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          cd python/delta-kernel-rust-sharing-wrapper
-          maturin build --release
+          cd python
+          uv run maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release
         shell: bash
 
       - name: Build wheel (x86_64 Linux Ubuntu 24.04)
         if: matrix.os == 'ubuntu-24.04'
         run: |
-          cd python/delta-kernel-rust-sharing-wrapper
-          maturin build --release
+          cd python
+          uv run maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release
         shell: bash
 
       - name: Build wheel (x86_64 Linux Ubuntu 22.04)
         if: matrix.os == 'ubuntu-22.04'
         run: |
-          cd python/delta-kernel-rust-sharing-wrapper
-          maturin build --release
+          cd python
+          uv run maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release
         shell: bash
 
       - name: Upload wheels
@@ -93,7 +95,6 @@ jobs:
           path: python/delta-kernel-rust-sharing-wrapper/target/wheels/*.whl
 
   merge:
-    # Re-enabled: build job now uses pipx
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
Changelog:
* Get rid of the setup-python action because setup-uv already also allows setting python version
* Have the build-kernel-wheels job use uv too
* Use --manifest-path in `maturin` commands rather than cd-ing into `delta-kernel-rust-sharing-wrapper`. This ensures that uv uses the global `pyproject.toml` instead of `delta-kernel-rust-sharing-wrapper/pyproject.toml`.