### PR TITLE
Branch-1.2: CI/CD security hardening — pinned Actions, secret scoping, Dependabot, CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS — require maintainer review for security-sensitive paths
+#
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Dependabot and GitHub config
+/.github/            @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88
+
+# Build scripts (SBT launcher, linting)
+/build/              @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,6 @@ build.sbt            @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wc
 # Python dependency specifications
 python/requirements-dev.txt                                  @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88
 python/setup.py                                              @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88
-python/delta-sharing-sharing-rust-wrapper/Cargo.toml         @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88
-python/delta-sharing-sharing-rust-wrapper/pyproject.toml     @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88
+python/delta-kernel-rust-sharing-wrapper/Cargo.toml          @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88
+python/delta-kernel-rust-sharing-wrapper/pyproject.toml      @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,11 @@
 
 # Build scripts (SBT launcher, linting)
 /build/              @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88
+build.sbt            @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88 
+
+# Python dependency specifications
+python/requirements-dev.txt                                  @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88
+python/setup.py                                              @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88
+python/delta-sharing-sharing-rust-wrapper/Cargo.toml         @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88
+python/delta-sharing-sharing-rust-wrapper/pyproject.toml     @linzhou-db @littlegrasscao @PatrickJin-db @chakankardb @wchau @mengxi-chen88
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_service_account_key.json
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Cache Scala, SBT
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
@@ -27,7 +27,7 @@ jobs:
             ~/.cache/coursier
           key: build-and-test-server
       - name: Install Java 8
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62  # v3.14.1
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '8'
@@ -46,7 +46,7 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_service_account_key.json
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Cache Scala, SBT
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
@@ -56,7 +56,7 @@ jobs:
             ~/.cache/coursier
           key: build-and-test-client-scala-2_13
       - name: Install Java 17
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62  # v3.14.1
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -75,7 +75,7 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_service_account_key.json
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Cache Scala, SBT
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
@@ -85,7 +85,7 @@ jobs:
             ~/.cache/coursier
           key: build-and-test-client-scala-2_12
       - name: Install Java 17
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62  # v3.14.1
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,13 @@
 name: Build and Test
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'branch-*'
+  workflow_dispatch:
 jobs:
-  build-and-test:
+  build-and-test-server:
     runs-on: ubuntu-24.04
     env:
       SPARK_LOCAL_IP: localhost
@@ -12,17 +18,72 @@ jobs:
       GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2.7.0
       - name: Cache Scala, SBT
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: |
             ~/.sbt
             ~/.ivy2
             ~/.cache/coursier
-          key: build-and-test-scala
+          key: build-and-test-server
       - name: Install Java 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62  # v3.14.1
         with:
+          distribution: 'zulu'
           java-version: '8'
-      - run: ./build/sbt test
+      - run: ./build/sbt server/test
+
+  build-and-test-client-scala-2_13:
+    runs-on: ubuntu-24.04
+    env:
+      SPARK_LOCAL_IP: localhost
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_service_account_key.json
+      GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2.7.0
+      - name: Cache Scala, SBT
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2
+            ~/.cache/coursier
+          key: build-and-test-client-scala-2_13
+      - name: Install Java 17
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62  # v3.14.1
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - run: ./build/sbt client/test spark/test
+
+  build-and-test-client-scala-2_12:
+    runs-on: ubuntu-24.04
+    env:
+      SPARK_LOCAL_IP: localhost
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_service_account_key.json
+      GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2.7.0
+      - name: Cache Scala, SBT
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2
+            ~/.cache/coursier
+          key: build-and-test-client-scala-2_12
+      - name: Install Java 17
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62  # v3.14.1
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - run: ./build/sbt ++2.12.18 client/test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ on:
 permissions: read-all
 
 jobs:
-  build-and-test-server:
+  build-and-test:
     runs-on: ubuntu-24.04
     env:
       SPARK_LOCAL_IP: localhost
@@ -25,7 +25,7 @@ jobs:
             ~/.sbt
             ~/.ivy2
             ~/.cache/coursier
-          key: build-and-test-server
+          key: build-and-test
       - name: Install Java 8
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
@@ -37,62 +37,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
           GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
-        run: ./build/sbt server/test
-
-  build-and-test-client-scala-2_13:
-    runs-on: ubuntu-24.04
-    env:
-      SPARK_LOCAL_IP: localhost
-      GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_service_account_key.json
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-      - name: Cache Scala, SBT
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2
-            ~/.cache/coursier
-          key: build-and-test-client-scala-2_13
-      - name: Install Java 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-      - name: Run tests
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
-          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
-        run: ./build/sbt client/test spark/test
-
-  build-and-test-client-scala-2_12:
-    runs-on: ubuntu-24.04
-    env:
-      SPARK_LOCAL_IP: localhost
-      GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_service_account_key.json
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-      - name: Cache Scala, SBT
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2
-            ~/.cache/coursier
-          key: build-and-test-client-scala-2_12
-      - name: Install Java 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-      - name: Run tests
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
-          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
-        run: ./build/sbt ++2.12.18 client/test
+        run: ./build/sbt test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,9 @@ on:
       - main
       - 'branch-*'
   workflow_dispatch:
+
+permissions: read-all
+
 jobs:
   build-and-test-server:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,11 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       SPARK_LOCAL_IP: localhost
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_service_account_key.json
-      GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2.7.0
@@ -32,17 +28,19 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-      - run: ./build/sbt server/test
+      - name: Run tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
+          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+        run: ./build/sbt server/test
 
   build-and-test-client-scala-2_13:
     runs-on: ubuntu-24.04
     env:
       SPARK_LOCAL_IP: localhost
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_service_account_key.json
-      GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2.7.0
@@ -59,17 +57,19 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - run: ./build/sbt client/test spark/test
+      - name: Run tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
+          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+        run: ./build/sbt client/test spark/test
 
   build-and-test-client-scala-2_12:
     runs-on: ubuntu-24.04
     env:
       SPARK_LOCAL_IP: localhost
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_service_account_key.json
-      GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2.7.0
@@ -86,4 +86,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - run: ./build/sbt ++2.12.18 client/test
+      - name: Run tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
+          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+        run: ./build/sbt ++2.12.18 client/test

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ spark-warehouse/
 
 # For venv
 *.venv
+
+# For direnv
+.envrc

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -44,6 +44,7 @@ acquire_sbt_jar () {
   # Ex:
   #   DEFAULT_ARTIFACT_REPOSITORY=https://artifacts.internal.com/libs-release/
   URL1=${DEFAULT_ARTIFACT_REPOSITORY:-https://repo1.maven.org/maven2/}org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar
+  SHA_URL=${DEFAULT_ARTIFACT_REPOSITORY:-https://repo1.maven.org/maven2/}org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar.sha1
   JAR=build/sbt-launch-${SBT_VERSION}.jar
 
   sbt_jar=$JAR
@@ -54,15 +55,33 @@ acquire_sbt_jar () {
     # Download
     printf "Attempting to fetch sbt\n"
     JAR_DL="${JAR}.part"
+    SHA_DL="${JAR}.sha1"
     if [ $(command -v curl) ]; then
       curl --fail --location --silent ${URL1} > "${JAR_DL}" &&\
-        mv "${JAR_DL}" "${JAR}"
+        curl --fail --location --silent ${SHA_URL} > "${SHA_DL}"
     elif [ $(command -v wget) ]; then
       wget --quiet ${URL1} -O "${JAR_DL}" &&\
-        mv "${JAR_DL}" "${JAR}"
+        wget --quiet ${SHA_URL} -O "${SHA_DL}"
     else
       printf "You do not have curl or wget installed, please install sbt manually from https://www.scala-sbt.org/\n"
       exit -1
+    fi
+    # Verify checksum before accepting the downloaded JAR
+    if [ -f "${JAR_DL}" ] && [ -f "${SHA_DL}" ]; then
+      EXPECTED_SHA=$(cat "${SHA_DL}" | awk '{print $1}')
+      ACTUAL_SHA=$(sha1sum "${JAR_DL}" | awk '{print $1}')
+      if [ "${EXPECTED_SHA}" = "${ACTUAL_SHA}" ]; then
+        mv "${JAR_DL}" "${JAR}"
+        rm -f "${SHA_DL}"
+      else
+        printf "SHA1 checksum verification failed for sbt-launch JAR!\n"
+        printf "  Expected: ${EXPECTED_SHA}\n"
+        printf "  Actual:   ${ACTUAL_SHA}\n"
+        rm -f "${JAR_DL}" "${SHA_DL}"
+        exit 1
+      fi
+    else
+      rm -f "${JAR_DL}" "${SHA_DL}"
     fi
     fi
     if [ ! -f "${JAR}" ]; then

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,9 +19,8 @@ resolvers += Resolver.url("artifactory", url("https://scalasbt.artifactoryonline
 
 resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-resolvers += Resolver.url(
-  "typesafe sbt-plugins",
-  url("https://dl.bintray.com/typesafe/sbt-plugins"))(Resolver.ivyStylePatterns)
+// Removed: dl.bintray.com shut down 2021 — potential domain takeover risk
+// Typesafe plugins are available via the Typesafe Repository resolver above
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 


### PR DESCRIPTION
## Summary
Brings `branch-1.3` in line with recent CI/CD security and supply-chain practices: pin and upgrade GitHub Actions, reduce secret exposure, add automation for Action updates, and enforce review on sensitive paths.
## What’s included
- **Supply chain**: Remove defunct Bintray resolver; verify SBT launcher JAR with SHA1 from Maven Central; pin GitHub Actions to commit SHAs; upgrade `build-and-test` Actions (e.g. checkout / setup-java) to current supported Node runtimes where applicable.
- **Least privilege**: Add top-level `permissions: read-all` on workflows; move AWS / Azure / GCP credentials from job-level `env` to the steps that actually run tests.
- **Maintenance**: Add Dependabot for the `github-actions` ecosystem (weekly).
- **Governance**: Add `CODEOWNERS` for `.github/`, `build/`, `build.sbt`, and selected Python dependency files.
- **Dev hygiene**: Ignore `.envrc` (direnv) in `.gitignore`.