### PR TITLE
[Build] Support MAVEN_PROXY_URL for SBT resolution and sbt-launch download

### DIFF
--- a/build/sbt
+++ b/build/sbt
@@ -47,6 +47,20 @@ realpath () {
 )
 }
 
+# If MAVEN_PROXY_URL is set, use it as the sole repository for all dependencies (aggregating mirror).
+# If unset, use the committed build/sbt-config/repositories (see delta-io/delta#6501).
+if [[ -n "$MAVEN_PROXY_URL" ]]; then
+  SBT_REPOSITORIES_CONFIG=$(mktemp)
+  cat > "$SBT_REPOSITORIES_CONFIG" <<EOF
+[repositories]
+  maven-proxy: $MAVEN_PROXY_URL
+  maven-proxy-ivy: $MAVEN_PROXY_URL, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+EOF
+else
+  SBT_REPOSITORIES_CONFIG="$(dirname "$(realpath "$0")")/sbt-config/repositories"
+fi
+export SBT_OPTS="-Dsbt.override.build.repos=true -Dsbt.repository.config=$SBT_REPOSITORIES_CONFIG"
+
 . "$(dirname "$(realpath "$0")")"/sbt-launch-lib.bash
 
 

--- a/build/sbt-config/repositories
+++ b/build/sbt-config/repositories
@@ -7,5 +7,5 @@
   typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   sbt-ivy-snapshots: https://repo.scala-sbt.org/scalasbt/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   sbt-plugin-releases: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
-  bintray-spark-packages: https://dl.bintray.com/spark-packages/maven/
-  typesafe-releases: http://repo.typesafe.com/typesafe/releases/
+  repos-spark-packages: https://repos.spark-packages.org
+  typesafe-releases: https://repo.typesafe.com/typesafe/releases/

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -41,10 +41,12 @@ acquire_sbt_jar () {
   SBT_VERSION=`awk -F "=" '/sbt\.version/ {print $2}' ./project/build.properties`
   # DEFAULT_ARTIFACT_REPOSITORY env variable can be used to only fetch
   # artifacts from internal repos only.
+  # MAVEN_PROXY_URL is a fallback for the sbt-launch JAR when using ./build/sbt (see delta-io/delta#6501).
   # Ex:
   #   DEFAULT_ARTIFACT_REPOSITORY=https://artifacts.internal.com/libs-release/
-  URL1=${DEFAULT_ARTIFACT_REPOSITORY:-https://repo1.maven.org/maven2/}org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar
-  SHA_URL=${DEFAULT_ARTIFACT_REPOSITORY:-https://repo1.maven.org/maven2/}org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar.sha1
+  BASE_REPO=${DEFAULT_ARTIFACT_REPOSITORY:-${MAVEN_PROXY_URL:-https://repo1.maven.org/maven2/}}
+  URL1=${BASE_REPO}org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar
+  SHA_URL=${BASE_REPO}org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar.sha1
   JAR=build/sbt-launch-${SBT_VERSION}.jar
 
   sbt_jar=$JAR


### PR DESCRIPTION
## Summary

Adds optional `MAVEN_PROXY_URL` to the `./build/sbt` wrapper and launcher scripts, following the same pattern as [delta-io/delta#6501](https://github.com/delta-io/delta/pull/6501).

## What changes

- **`build/sbt`**: If `MAVEN_PROXY_URL` is set, writes a temporary `repositories` file so Maven and Ivy resolution go through that URL (use an aggregating mirror). If unset, uses the committed `build/sbt-config/repositories`. Sets `SBT_OPTS` with `-Dsbt.override.build.repos=true` and `-Dsbt.repository.config=...`.
- **`build/sbt-launch-lib.bash`**: Download base for the sbt-launch JAR and `.sha1` is `DEFAULT_ARTIFACT_REPOSITORY` → `MAVEN_PROXY_URL` → Maven Central.
- **`build/sbt-config/repositories`**: Replace defunct Bintray spark-packages with `https://repos.spark-packages.org` and use HTTPS for Typesafe releases, since this file is now used whenever `MAVEN_PROXY_URL` is not set.

## Usage

```bash
export MAVEN_PROXY_URL='https://your-mirror.example.com/your-virtual-repo/'
./build/sbt compile
```

The URL should be a Maven repository root (typically ending with `/`).

## Behavior

No change for developers who do not set `MAVEN_PROXY_URL`; CI and default builds keep using the checked-in `sbt-config/repositories` file.
