### PR TITLE
Upgrade sbt-release to com.github.sbt fork 1.1.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,7 +22,7 @@ resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releas
 // Removed: dl.bintray.com shut down 2021 — potential domain takeover risk
 // Typesafe plugins are available via the Typesafe Repository resolver above
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.3")
 


### PR DESCRIPTION
## Summary

Swap the unmaintained `com.github.gseitz` fork of `sbt-release` for the actively-maintained `com.github.sbt` fork.

- `com.github.gseitz:sbt-release:1.0.13` is only published to `sbt-plugin-releases` (Ivy layout) and is not available from Maven Central, which makes it unresolvable in CI environments that proxy only through Maven Central (e.g. hardened / network-restricted runners).
- `com.github.sbt:sbt-release:1.1.0` is the official successor fork, published to Maven Central, and is an API-compatible drop-in (same task names — `release`, `release-with-defaults`, etc. — and same settings).

No other changes required.

## Test plan

- [ ] Existing GitHub Actions CI (`test.yaml`) passes: compile + unit tests across Scala 2.12 / 2.13 and Python.
- [ ] `build/sbt release --help` still prints the release task.
- [ ] `build/sbt "show releaseVersion"` still returns a value.