### PR TITLE
[branch-1.2] Upgrade sbt-release to com.github.sbt fork 1.1.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,7 +22,7 @@ resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releas
 // Removed: dl.bintray.com shut down 2021 — potential domain takeover risk
 // Typesafe plugins are available via the Typesafe Repository resolver above
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.3")
 


### PR DESCRIPTION
## Summary

Backport of #937 to `branch-1.2`.

Swap the unmaintained `com.github.gseitz:sbt-release:1.0.13` for the actively-maintained `com.github.sbt:sbt-release:1.1.0` fork.

- The `gseitz` fork is only published to `sbt-plugin-releases` (Ivy layout) and is not available from Maven Central, which makes it unresolvable in CI environments that proxy only through Maven Central (e.g. hardened / network-restricted release runners).
- The `com.github.sbt` fork is the official successor, published to Maven Central, and is an API-compatible drop-in (same task names, same settings).

Needed on this maintenance branch so that release CI can build `delta-sharing-client` `1.2.x` artifacts from a hardened runner.

## Test plan

- [ ] Branch CI (`test.yaml`) passes: compile + unit tests across Scala 2.12 / 2.13.
- [ ] `build/sbt release --help` still prints the release task.