### PR TITLE
Fix flakiness in integration tests

### DIFF
--- a/server/src/test/scala/io/delta/sharing/server/TestDeltaSharingServer.scala
+++ b/server/src/test/scala/io/delta/sharing/server/TestDeltaSharingServer.scala
@@ -41,9 +41,9 @@ object TestDeltaSharingServer {
       println("serverConfigPath=" + serverConfigPath)
       println("serverConfig=" + serverConfig)
       val server = DeltaSharingService.start(serverConfig)
-      // Run at most 420 seconds and exit. This is to ensure we can exit even if the parent process
+      // Run at most 900 seconds and exit. This is to ensure we can exit even if the parent process
       // hits any error.
-      Thread.sleep(420000)
+      Thread.sleep(900000)
       server.stop()
     } else {
       throw new IllegalArgumentException("Cannot find AWS_ACCESS_KEY_ID in sys.env")


### PR DESCRIPTION
The integration tests would sometimes fail due to a shutdown failsafe shutting down the server too early. This PR increases the shutdown window from 7 min to 15 min to ensure all the tests run before the server shuts down.