### PR TITLE
Improve glibc compatibility by using maturin-action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -144,3 +144,120 @@ jobs:
           cd python
           uv run dev/lint-python
           uv run dev/pytest
+
+  python-release-build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Install Python and uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          python-version: "3.10"
+      - name: Install twine
+        run: uv tool install twine
+      - name: Build delta-sharing package
+        run: |
+          cd python
+          uv build
+      - name: Build delta-kernel-rust-sharing-wrapper distribution
+        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380  # v1.49.4
+        with:
+          command: build
+          maturin-version: v1.12.6
+          manylinux: 2014
+          # maturin-action's default for manylinux2014 is the floating
+          # quay.io/pypa/manylinux2014_x86_64:latest image.
+          container: quay.io/pypa/manylinux2014_x86_64:2026.04.25-0@sha256:79abced054d8add673e4885d9598e1adc56260989b83aec0922e4cd6eb3ef066
+          working-directory: python
+          # The manylinux2014 container has perl but omits some core modules
+          # that vendored OpenSSL's Configure script requires.
+          before-script-linux: yum install -y perl-core
+          args: >-
+            --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml
+            --release
+            --sdist
+            -i python3.10
+      - name: Check built distributions
+        run: |
+          cd python
+          uv run twine check --strict dist/*
+          uv run twine check --strict delta-kernel-rust-sharing-wrapper/target/wheels/*
+      - name: Upload distributions
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: python-release-distributions
+          path: |
+            python/dist/*
+            python/delta-kernel-rust-sharing-wrapper/target/wheels/*
+          if-no-files-found: error
+
+  # Install the wheels built by python-release-build on an older Ubuntu image
+  # so we catch glibc / shared-library regressions that ubuntu-24.04 would
+  # otherwise hide.
+  python-release-test:
+    needs: python-release-build
+    runs-on: ubuntu-22.04
+    env:
+      SPARK_LOCAL_IP: localhost
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_service_account_key.json
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Cache Scala, SBT
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2
+            ~/.cache/coursier
+          key: build-and-test-python-release-test
+      - name: Install Java 8
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Install Python and uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          python-version: "3.10"
+      - name: Download built wheels
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: python-release-distributions
+          path: built-wheels/
+      - name: Install built wheels into a fresh venv
+        run: |
+          set -euo pipefail
+          shopt -s failglob
+          uv venv /tmp/release-venv --python 3.10
+          # actions/upload-artifact@v4 collapses the LCA, so paths inside the
+          # artifact start at `dist/` and `delta-kernel-rust-sharing-wrapper/`,
+          # not `python/dist/` and `python/delta-kernel-rust-sharing-wrapper/`.
+          uv pip install --python /tmp/release-venv/bin/python \
+            built-wheels/delta-kernel-rust-sharing-wrapper/target/wheels/*.whl \
+            built-wheels/dist/*.whl \
+            pytest
+          # The published wheel intentionally excludes delta_sharing.tests, but
+          # the test files import from `delta_sharing.tests.conftest`. Copy the
+          # tests subpackage into the installed location so the import works.
+          site_packages=$(/tmp/release-venv/bin/python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")
+          cp -r python/delta_sharing/tests "$site_packages/delta_sharing/tests"
+          # Rename the source package so it does not shadow the installed wheel
+          # when pytest runs from python/ (cwd is needed for the sbt server fixture).
+          mv python/delta_sharing python/delta_sharing.src
+      - name: Build Server
+        run: ./build/sbt package
+      - name: Run tests against installed wheels
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AZURE_TEST_ACCOUNT_KEY: ${{ secrets.AZURE_TEST_ACCOUNT_KEY }}
+          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+        run: |
+          cd python
+          /tmp/release-venv/bin/python -m pytest \
+            --verbose --showlocals --color=yes \
+            --doctest-modules --pyargs delta_sharing \
+            --ignore-glob='*/_yarl_patch.py' \
+            -o log_cli=true -s

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -59,7 +59,7 @@ dev = [
     "flake8<=7.3.0",                                                                                                                                                           
     "black==26.3.1",
     "pytest<=9.0.3",                                                                                                                                                           
-    "maturin<=1.12.6",                                                                                                                                                         
+    "maturin[zig]<=1.12.6",
     "types-requests<=2.32.0.20260311",
     "setuptools>=64",
     "packaging",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -676,7 +676,7 @@ s3 = [
 dev = [
     { name = "black" },
     { name = "flake8" },
-    { name = "maturin" },
+    { name = "maturin", extra = ["zig"] },
     { name = "mypy" },
     { name = "packaging" },
     { name = "pytest" },
@@ -706,7 +706,7 @@ provides-extras = ["s3", "abfs", "adl", "gcs", "gs"]
 dev = [
     { name = "black", specifier = "==26.3.1" },
     { name = "flake8", specifier = "<=7.3.0" },
-    { name = "maturin", specifier = "<=1.12.6" },
+    { name = "maturin", extras = ["zig"], specifier = "<=1.12.6" },
     { name = "mypy", specifier = "==0.981" },
     { name = "packaging" },
     { name = "pytest", specifier = "<=9.0.3" },
@@ -1208,6 +1208,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/d5/39c594c27b1a8b32a0cb95fff9ad60b888c4352d1d1c389ac1bd20dc1e16/maturin-1.12.6-py3-none-win32.whl", hash = "sha256:3f32e0a3720b81423c9d35c14e728cb1f954678124749776dc72d533ea1115e8", size = 8553012, upload-time = "2026-03-01T14:53:50.706Z" },
     { url = "https://files.pythonhosted.org/packages/94/66/b262832a91747e04051e21f986bd01a8af81fbffafacc7d66a11e79aab5f/maturin-1.12.6-py3-none-win_amd64.whl", hash = "sha256:977290159d252db946054a0555263c59b3d0c7957135c69e690f4b1558ee9983", size = 9890470, upload-time = "2026-03-01T14:53:56.659Z" },
     { url = "https://files.pythonhosted.org/packages/e3/47/76b8ca470ddc8d7d36aa8c15f5a6aed1841806bb93a0f4ead8ee61e9a088/maturin-1.12.6-py3-none-win_arm64.whl", hash = "sha256:bae91976cdc8148038e13c881e1e844e5c63e58e026e8b9945aa2d19b3b4ae89", size = 8606158, upload-time = "2026-03-01T14:54:02.423Z" },
+]
+
+[package.optional-dependencies]
+zig = [
+    { name = "ziglang" },
 ]
 
 [[package]]
@@ -2396,4 +2401,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
     { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "ziglang"
+version = "0.15.2"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/2e/42c49a5b539a595ff5f2293de0bd339636875e44b4c69f51470bdf1d599d/ziglang-0.15.2-py3-none-macosx_12_0_arm64.whl", hash = "sha256:acae2a9ce67ed249ad68d42c21bc73b5f9d51a33ba5ea42f609f78683e8d9bb7", size = 92993702, upload-time = "2025-11-10T06:23:24.805Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c7/151df628321266a38da133d481c5e929bd36d9d0424e8c2b7a9c4964c172/ziglang-0.15.2-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:47af4f85e3e59bd672126cc026d3a01b516cad24b9a9ea075abfe8532f4c6bc1", size = 97049112, upload-time = "2026-01-29T09:44:04.612Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/13/006c26f2dc7510385dc549eb44983402e4539519d48567d9a6b0ae71adc7/ziglang-0.15.2-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:04eb9c4135ef431487b920c73312cd3a5e754019839024eeed3521772d1585a2", size = 97299386, upload-time = "2026-01-29T09:44:21.973Z" },
+    { url = "https://files.pythonhosted.org/packages/db/81/f9f5c7fd68d80b8edff2a641a1c95ac4125356387d298374227040b8e1e8/ziglang-0.15.2-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:806316453d1ede7174ed3fefb8e5348154629089c3bb5fe812dfd0e172fac130", size = 93508126, upload-time = "2026-01-29T09:44:41.936Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7d/8c277208250ffa72f12a10f52dfc1d45850f08244093065b40c5f4628260/ziglang-0.15.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:edc0aa60ec964a4cf462d40f68d7de242ddf37fd9a80f2afaee6397059463230", size = 90542084, upload-time = "2026-01-29T09:45:00.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/ba/b85879ff883f152e2278852d3f8af37924badefaabb38d89e62a5d066b40/ziglang-0.15.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:ad43a4692311512ab55cc918596c814ff44fb811b1299fa9a57cc4e2bf315c6b", size = 91550707, upload-time = "2026-01-29T09:45:22.725Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/09d2baf722521d3878b8e17d3ee6271f02c7ef7ec398bbd059fa6466a5e6/ziglang-0.15.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:85faefbd4cfe420de92aaa8f8300bec2b9afe8d1f1d8c5abf71bf92754682536", size = 99943068, upload-time = "2026-01-29T09:45:42.651Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5d/5690870969ed52501deaa4c722c476279a00d2c034ef7f82cf778507c3fd/ziglang-0.15.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.musllinux_1_1_s390x.whl", hash = "sha256:978ebcc3c6c9624cbc999dd8dcb65427e7474650d9709a889aace8e325705ce2", size = 99561757, upload-time = "2026-01-29T09:46:03.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/da/2e6655300a3174bd6299c06da577b0cb14685058d9b00b61042cf9d9e38b/ziglang-0.15.2-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:d3fe40825e18238e986b305cbf3a4d93a50461b893339e31c81b0d6c73f33937", size = 94112157, upload-time = "2026-01-29T09:46:24.268Z" },
+    { url = "https://files.pythonhosted.org/packages/57/04/e54964be82dce7b9a5708a8a5f345d373bc78c558c0712e6e356593292ec/ziglang-0.15.2-py3-none-win32.whl", hash = "sha256:b174f7ebb9d1f2210d32d1420333120f6117ebee3de8b3e221e6ebb0c3beec4b", size = 96136271, upload-time = "2026-01-29T09:46:47.975Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6b/8ab0853a312108b4089747486366b824b5da89773cb56f661f9994de17db/ziglang-0.15.2-py3-none-win_amd64.whl", hash = "sha256:ca80dc9c70dbdfdd9ee51d000de3501a95d33d9782ab9ab9b56f700484ebcd83", size = 94052409, upload-time = "2026-01-29T09:47:02.419Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/dec7e1b867ce3640f9bba9204f8ea658f6ca5161350e92b76bf17aeffb9b/ziglang-0.15.2-py3-none-win_arm64.whl", hash = "sha256:a81ebfc61e1b7aa43a33add23f93b98954d757434f894eb21bd40b176b6688aa", size = 89688080, upload-time = "2026-01-29T09:47:20.903Z" },
 ]


### PR DESCRIPTION
Adding a test to build the kernel wheels via maturin-action, and then run the tests using that built wheel on an older linux version to ensure the built wheel works on an older linux version. This lets us specify the  glibc compatibility, allowing us to build a single wheel using glibc 2.17, which should be usable by almost all linux distros and eliminates the need to rebuild wheels on various ubuntu versions. 