### PR TITLE
Fix broken async query test

### DIFF
--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -395,7 +395,7 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       queryId
     }
 
-    // Keep returning pending status until we've been polled more than 5 times
+    // Keep returning pending status until we've been polled more than 4 times
     if(pollCount <= 3 && !request.pageToken.isDefined) {
         streamingOutput(
           Some(0),

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -878,16 +878,21 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
 
   integrationTest("table1 async query get status") {
     Seq(RESPONSE_FORMAT_PARQUET, RESPONSE_FORMAT_DELTA).foreach { responseFormat =>
-      val response = readNDJson(
-        requestPath("/shares/share1/schemas/default/tables/table1/queries/1234"),
-        method = Some("POST"),
-        Some("""{"maxFiles": 1}"""),
-        expectedTableVersion = None,
-        responseFormat,
-        asyncQuery = "true"
-      )
+      var lines: Array[String] = Array.empty
 
-      val lines = response.split("\n")
+      do {
+        val response = readNDJson(
+          requestPath("/shares/share1/schemas/default/tables/table1/queries/1234"),
+          method = Some("POST"),
+          Some("""{"maxFiles": 1}"""),
+          expectedTableVersion = None,
+          responseFormat,
+          asyncQuery = "true"
+        )
+
+        lines = response.split("\n")
+      } while (lines.length == 1)
+
       assert(lines.length == 4)
     }
   }


### PR DESCRIPTION
Previously GetQueryStatus with query id 1234 would just load instantly. However in my last PR that added more async query tests, it made it so it required at least four polls before it would return the table.

This PR fixes broken async query test by polling until the lines exceeds 1 line (table has loaded)