### PR TITLE
Add Azure Managed Identity (SAMI/UAMI) support for ADLS Gen2

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,84 @@ The server is using `hadoop-azure` to read Azure Data Lake Storage Gen2. We supp
 ```
 `YOUR-ACCOUNT-NAME` is your Azure storage account and `YOUR-ACCOUNT-KEY` is your account key.
 
+#### Using Managed Identity (Azure VM)
+
+When running the Delta Sharing server on an Azure VM (or other Azure compute with managed identity support such as AKS or App Service), you can authenticate to ADLS Gen2 using [managed identities for Azure resources](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview) instead of storing account keys or client secrets.
+
+**Prerequisites:**
+- The VM must have a System-Assigned Managed Identity (SAMI) enabled, or a User-Assigned Managed Identity (UAMI) attached.
+- The identity must be granted the following RBAC roles on the storage account:
+  - `Storage Blob Data Reader` — for reading delta table data
+  - `Storage Blob Delegator` — for generating User Delegation SAS tokens for clients
+
+**System-Assigned Managed Identity (SAMI):**
+
+Note: This configuration only works when the VM has a single managed identity (SAMI only). If the VM also has User-Assigned Managed Identities attached, you must use the UAMI configuration below and specify the client ID explicitly, even if you intend to use the SAMI — otherwise Azure cannot determine which identity to use.
+
+```xml
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>fs.azure.account.auth.type.YOUR-ACCOUNT-NAME.dfs.core.windows.net</name>
+    <value>OAuth</value>
+  </property>
+  <property>
+    <name>fs.azure.account.oauth.provider.type.YOUR-ACCOUNT-NAME.dfs.core.windows.net</name>
+    <value>org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider</value>
+  </property>
+  <property>
+    <name>fs.azure.account.oauth2.msi.tenant.YOUR-ACCOUNT-NAME.dfs.core.windows.net</name>
+    <value>YOUR-TENANT-ID</value>
+  </property>
+  <property>
+    <name>fs.azure.account.oauth2.client.id.YOUR-ACCOUNT-NAME.dfs.core.windows.net</name>
+    <value>YOUR-SAMI-APP-ID</value>
+  </property>
+  <property>
+    <name>delta.sharing.azure.auth.type</name>
+    <value>managed_identity</value>
+  </property>
+</configuration>
+```
+
+`YOUR-TENANT-ID` is your Azure AD tenant ID and `YOUR-SAMI-APP-ID` is the Application (client) ID of the VM's system-assigned managed identity (found in the Azure Portal under VM > Identity > System assigned > Object ID link > Application ID).
+
+**User-Assigned Managed Identity (UAMI):**
+
+```xml
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>fs.azure.account.auth.type.YOUR-ACCOUNT-NAME.dfs.core.windows.net</name>
+    <value>OAuth</value>
+  </property>
+  <property>
+    <name>fs.azure.account.oauth.provider.type.YOUR-ACCOUNT-NAME.dfs.core.windows.net</name>
+    <value>org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider</value>
+  </property>
+  <property>
+    <name>fs.azure.account.oauth2.msi.tenant.YOUR-ACCOUNT-NAME.dfs.core.windows.net</name>
+    <value>YOUR-TENANT-ID</value>
+  </property>
+  <property>
+    <name>fs.azure.account.oauth2.client.id.YOUR-ACCOUNT-NAME.dfs.core.windows.net</name>
+    <value>YOUR-UAMI-CLIENT-ID</value>
+  </property>
+  <property>
+    <name>delta.sharing.azure.auth.type</name>
+    <value>managed_identity</value>
+  </property>
+  <property>
+    <name>delta.sharing.azure.managed.identity.client.id</name>
+    <value>YOUR-UAMI-CLIENT-ID</value>
+  </property>
+</configuration>
+```
+
+Replace `YOUR-ACCOUNT-NAME` with your storage account name and `YOUR-UAMI-CLIENT-ID` with the client ID of your User-Assigned Managed Identity.
+
 ### Google Cloud Storage
 
 We support using [Service Account](https://cloud.google.com/iam/docs/service-accounts) to read Google Cloud Storage. You can find more details in [GCP Authentication Doc](https://cloud.google.com/docs/authentication/getting-started).

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -395,7 +395,7 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       queryId
     }
 
-    // Keep returning pending status until we've been polled more than 5 times
+    // Keep returning pending status until we've been polled more than 4 times
     if(pollCount <= 3 && !request.pageToken.isDefined) {
         streamingOutput(
           Some(0),

--- a/server/src/main/scala/io/delta/sharing/server/common/AzureUserDelegationSasGenerator.scala
+++ b/server/src/main/scala/io/delta/sharing/server/common/AzureUserDelegationSasGenerator.scala
@@ -20,25 +20,38 @@ import java.io.{InputStream, OutputStreamWriter}
 import java.net.{HttpURLConnection, URL}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.OffsetDateTime
-import java.util.Scanner
+import java.time.format.DateTimeFormatter
+import java.util.{Base64, Scanner}
 import java.util.concurrent.TimeUnit.SECONDS
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import javax.xml.parsers.DocumentBuilderFactory
 
-import com.azure.core.credential.{AccessToken, TokenCredential, TokenRequestContext}
-import com.azure.storage.blob.{BlobServiceClient, BlobServiceClientBuilder}
-import com.azure.storage.blob.sas.{BlobContainerSasPermission, BlobServiceSasSignatureValues}
-import reactor.core.publisher.Mono
+import org.xml.sax.InputSource
 
 import io.delta.sharing.server.common.JsonUtils
 
 /**
- * Generates Azure User Delegation SAS (AAD token -> User Delegation Key -> SAS).
- * Replicates the Unity Catalog flow: get AAD token via client_credentials, then
- * BlobServiceClient.getUserDelegationKey(), then build SAS locally.
+ * Generates Azure User Delegation SAS tokens via direct REST calls.
+ * Avoids the Azure SDK BlobServiceClient HTTP pipeline which requires
+ * Jackson 2.9+ and conflicts with the Jackson 2.6.x pin required
+ * by delta-standalone.
+ *
+ * TODO: migrate to Azure Storage SDK (BlobServiceClient) when the
+ * Jackson version constraint is resolved (see delta-io/delta#5598).
+ * The SDK handles SAS version changes automatically.
  */
 object AzureUserDelegationSasGenerator {
 
   val StorageScope = "https://storage.azure.com/.default"
-  val AadTokenEndpointTemplate = "https://login.microsoftonline.com/%s/oauth2/v2.0/token"
+  val AadTokenEndpointTemplate =
+    "https://login.microsoftonline.com/%s/oauth2/v2.0/token"
+  // SAS signature format is coupled to this version. Update the
+  // string-to-sign in computeUserDelegationSas if changing.
+  val StorageApiVersion = "2022-11-02"
+  private val ISO = DateTimeFormatter.ofPattern(
+    "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    .withZone(java.time.ZoneOffset.UTC)
 
   /** Fetch AAD access token using client_credentials grant. */
   def getAadToken(
@@ -80,26 +93,218 @@ object AzureUserDelegationSasGenerator {
     }
   }
 
-  /** TokenCredential that returns a pre-fetched AAD token. */
-  private class StaticTokenCredential(
-      accessToken: String, expiryMillis: Long) extends TokenCredential {
-    override def getToken(request: TokenRequestContext): Mono[AccessToken] =
-      Mono.just(new AccessToken(
-        accessToken,
-        java.time.Instant.ofEpochMilli(expiryMillis)
-          .atOffset(OffsetDateTime.now().getOffset)))
+  /**
+   * Fetch an AAD token from the Azure IMDS managed identity endpoint.
+   * @param clientId optional UAMI client ID; if None, uses SAMI.
+   * @return (accessToken, expiryMillis)
+   */
+  def getManagedIdentityToken(
+      clientId: Option[String]): (String, Long) = {
+    val resource = "https://storage.azure.com/"
+    val baseUrl =
+      "http://169.254.169.254/metadata/identity/oauth2/token" +
+        s"?api-version=2018-02-01&resource=$resource"
+    val urlStr = clientId match {
+      case Some(id) =>
+        baseUrl + "&client_id=" +
+          java.net.URLEncoder.encode(id, UTF_8.name)
+      case None => baseUrl
+    }
+    val url = new URL(urlStr)
+    val conn =
+      url.openConnection().asInstanceOf[HttpURLConnection]
+    conn.setRequestMethod("GET")
+    conn.setRequestProperty("Metadata", "true")
+    conn.setConnectTimeout(10000)
+    conn.setReadTimeout(10000)
+    try {
+      val code = conn.getResponseCode
+      val stream: InputStream =
+        if (code >= 200 && code < 300) conn.getInputStream
+        else conn.getErrorStream
+      val response = new Scanner(stream, UTF_8.name)
+        .useDelimiter("\\A").next()
+      if (code >= 300) {
+        throw new RuntimeException(
+          s"IMDS token request failed ($code): $response")
+      }
+      val tree = JsonUtils.mapper.readTree(response)
+      val accessToken = tree.get("access_token").asText
+      val expiresIn = if (tree.has("expires_in")) {
+        tree.get("expires_in").asText.toLong
+      } else 3600L
+      val expiryMillis =
+        System.currentTimeMillis() + SECONDS.toMillis(expiresIn)
+      (accessToken, expiryMillis)
+    } finally {
+      conn.disconnect()
+    }
+  }
+
+  /** Parsed fields from Get User Delegation Key REST response. */
+  case class UserDelegationKeyInfo(
+      signedOid: String,
+      signedTid: String,
+      signedStart: String,
+      signedExpiry: String,
+      signedService: String,
+      signedVersion: String,
+      value: String)
+
+  /**
+   * Fetch a User Delegation Key via the Azure Blob REST API.
+   * POST https://acct.blob.suffix/?restype=service&comp=userdelegationkey
+   */
+  def getUserDelegationKey(
+      accountName: String,
+      endpointSuffix: String,
+      accessToken: String,
+      keyStart: OffsetDateTime,
+      keyExpiry: OffsetDateTime): UserDelegationKeyInfo = {
+    val endpoint =
+      s"https://$accountName.blob.$endpointSuffix" +
+        "/?restype=service&comp=userdelegationkey"
+    val startStr = keyStart.format(ISO)
+    val expiryStr = keyExpiry.format(ISO)
+    val xmlBody = Seq(
+      "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+      "<KeyInfo>",
+      s"  <Start>$startStr</Start>",
+      s"  <Expiry>$expiryStr</Expiry>",
+      "</KeyInfo>"
+    ).mkString("\n")
+
+    val url = new URL(endpoint)
+    val conn =
+      url.openConnection().asInstanceOf[HttpURLConnection]
+    conn.setRequestMethod("POST")
+    conn.setRequestProperty(
+      "Authorization", s"Bearer $accessToken")
+    conn.setRequestProperty(
+      "x-ms-version", StorageApiVersion)
+    conn.setRequestProperty(
+      "Content-Type", "application/xml")
+    conn.setDoOutput(true)
+    conn.setConnectTimeout(10000)
+    conn.setReadTimeout(10000)
+    try {
+      val writer =
+        new OutputStreamWriter(conn.getOutputStream, UTF_8)
+      writer.write(xmlBody)
+      writer.close()
+      val code = conn.getResponseCode
+      val stream: InputStream =
+        if (code >= 200 && code < 300) conn.getInputStream
+        else conn.getErrorStream
+      val response = new Scanner(stream, UTF_8.name)
+        .useDelimiter("\\A").next()
+      if (code >= 300) {
+        throw new RuntimeException(
+          s"getUserDelegationKey failed ($code): $response")
+      }
+      parseUserDelegationKeyXml(response)
+    } finally {
+      conn.disconnect()
+    }
+  }
+
+  private def parseUserDelegationKeyXml(
+      xml: String): UserDelegationKeyInfo = {
+    // Strip UTF-8 BOM if present (Azure REST responses
+    // may include it)
+    val clean = if (xml.charAt(0) == 0xFEFF) {
+      xml.substring(1)
+    } else xml
+    val factory = DocumentBuilderFactory.newInstance()
+    val builder = factory.newDocumentBuilder()
+    val doc = builder.parse(
+      new InputSource(new java.io.StringReader(clean)))
+    def text(tag: String): String =
+      doc.getElementsByTagName(tag).item(0).getTextContent
+    UserDelegationKeyInfo(
+      signedOid = text("SignedOid"),
+      signedTid = text("SignedTid"),
+      signedStart = text("SignedStart"),
+      signedExpiry = text("SignedExpiry"),
+      signedService = text("SignedService"),
+      signedVersion = text("SignedVersion"),
+      value = text("Value")
+    )
   }
 
   /**
-   * Generate a container-scoped User Delegation SAS.
-   * @param accountName Storage account name (e.g. "mystorageaccount")
-   * @param endpointSuffix e.g. "core.windows.net" or "blob.core.windows.net"
-   * @param container Container name
-   * @param tenantId Azure AD tenant ID
-   * @param clientId Azure AD application (client) ID
-   * @param clientSecret Azure AD client secret
-   * @param validitySeconds SAS validity in seconds
-   * @return SAS query string (without leading "?")
+   * Compute a container-scoped User Delegation SAS locally.
+   * Follows the Azure Storage SAS spec for version 2022-11-02.
+   */
+  def computeUserDelegationSas(
+      accountName: String,
+      container: String,
+      key: UserDelegationKeyInfo,
+      permissions: String,
+      sasStart: OffsetDateTime,
+      sasExpiry: OffsetDateTime): String = {
+    val sv = StorageApiVersion
+    val sr = "c"
+    val sp = permissions
+    val st = sasStart.format(ISO)
+    val se = sasExpiry.format(ISO)
+    val spr = "https"
+    val cr = s"/blob/$accountName/$container"
+
+    // String-to-sign per Azure docs for sv=2022-11-02
+    val sts = Seq(
+      sp, st, se, cr,
+      key.signedOid, key.signedTid,
+      key.signedStart, key.signedExpiry,
+      key.signedService, key.signedVersion,
+      "", "", "", "", spr, sv, sr,
+      "", "", "", "", "", "", ""
+    ).mkString("\n")
+
+    val keyBytes = Base64.getDecoder.decode(key.value)
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(new SecretKeySpec(keyBytes, "HmacSHA256"))
+    val sig = Base64.getEncoder.encodeToString(
+      mac.doFinal(sts.getBytes(UTF_8)))
+
+    val e = java.net.URLEncoder.encode(_: String, UTF_8.name)
+    Seq(
+      s"sv=$sv", s"sr=$sr", s"sp=$sp",
+      s"st=${e(st)}", s"se=${e(se)}", s"spr=$spr",
+      s"skoid=${e(key.signedOid)}",
+      s"sktid=${e(key.signedTid)}",
+      s"skt=${e(key.signedStart)}",
+      s"ske=${e(key.signedExpiry)}",
+      s"sks=${key.signedService}",
+      s"skv=${key.signedVersion}",
+      s"sig=${e(sig)}"
+    ).mkString("&")
+  }
+
+  /**
+   * Generate a container-scoped User Delegation SAS from a raw
+   * access token. Fetches the delegation key via REST and computes
+   * the SAS locally (no Azure SDK HTTP pipeline).
+   */
+  def generateUserDelegationSasFromToken(
+      accountName: String,
+      endpointSuffix: String,
+      container: String,
+      accessToken: String,
+      validitySeconds: Long): String = {
+    val now = OffsetDateTime.now()
+    val keyExpiry = now.plusHours(1)
+    val key = getUserDelegationKey(
+      accountName, endpointSuffix, accessToken,
+      now, keyExpiry)
+    val sasExpiry = now.plusSeconds(validitySeconds)
+    computeUserDelegationSas(
+      accountName, container, key, "r", now, sasExpiry)
+  }
+
+  /**
+   * Generate a container-scoped User Delegation SAS using
+   * client_credentials (service principal).
    */
   def generateUserDelegationSas(
       accountName: String,
@@ -109,20 +314,10 @@ object AzureUserDelegationSasGenerator {
       clientId: String,
       clientSecret: String,
       validitySeconds: Long): String = {
-    val (accessToken, expiryMillis) = getAadToken(tenantId, clientId, clientSecret)
-    val credential = new StaticTokenCredential(accessToken, expiryMillis)
-    val endpoint = s"https://$accountName.blob.$endpointSuffix"
-    val blobServiceClient: BlobServiceClient = new BlobServiceClientBuilder()
-      .endpoint(endpoint)
-      .credential(credential)
-      .buildClient()
-    val now = OffsetDateTime.now()
-    val keyExpiry = now.plusHours(1)
-    val userDelegationKey = blobServiceClient.getUserDelegationKey(now, keyExpiry)
-    val sasExpiry = now.plusSeconds(validitySeconds)
-    val permission = new BlobContainerSasPermission().setReadPermission(true)
-    val values = new BlobServiceSasSignatureValues(sasExpiry, permission)
-    val containerClient = blobServiceClient.getBlobContainerClient(container)
-    containerClient.generateUserDelegationSas(values, userDelegationKey)
+    val (accessToken, _) =
+      getAadToken(tenantId, clientId, clientSecret)
+    generateUserDelegationSasFromToken(
+      accountName, endpointSuffix, container,
+      accessToken, validitySeconds)
   }
 }

--- a/server/src/main/scala/io/delta/sharing/server/common/CloudFileSigner.scala
+++ b/server/src/main/scala/io/delta/sharing/server/common/CloudFileSigner.scala
@@ -17,6 +17,7 @@
 package io.delta.sharing.server.common
 
 import java.net.URI
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Date
 import java.util.concurrent.TimeUnit.SECONDS
 
@@ -27,7 +28,8 @@ import com.google.cloud.storage.BlobId
 import com.google.cloud.storage.BlobInfo
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.StorageOptions
-import com.microsoft.azure.storage.{CloudStorageAccount, SharedAccessProtocols, StorageCredentialsSharedAccessSignature}
+import com.microsoft.azure.storage.{CloudStorageAccount, SharedAccessProtocols,
+  StorageCredentialsSharedAccessSignature}
 import com.microsoft.azure.storage.blob.{SharedAccessBlobPermissions, SharedAccessBlobPolicy}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -37,6 +39,8 @@ import org.apache.hadoop.fs.azurebfs.services.AuthType
 import org.apache.hadoop.fs.s3a.DefaultS3ClientFactory
 import org.apache.hadoop.fs.s3a.S3ClientFactory.S3ClientCreationParameters
 import org.apache.hadoop.util.ReflectionUtils
+
+import io.delta.sharing.server.credential.azure.AzureCredentialVendor
 
 /**
  * @param url The signed url.
@@ -203,17 +207,119 @@ object AbfsFileSigner {
     val abfsConfiguration = abfsStore.getAbfsConfiguration
     val accountName = abfsConfiguration.accountConf("dummy").stripPrefix("dummy.")
     val authType = abfsConfiguration.getAuthType(accountName)
-    if (authType != AuthType.SharedKey) {
-      throw new UnsupportedOperationException(s"unsupported auth type: $authType")
-    }
-    val accountKey = abfsConfiguration.getStorageAccountKey
     val container = authorityParts(abfsStore, uri)(0)
-    new AzureFileSigner(
-      accountName,
-      accountKey,
-      container,
-      preSignedUrlTimeoutSeconds,
-      getRelativePath(abfsStore, _))
+    authType match {
+      case AuthType.SharedKey =>
+        val accountKey = abfsConfiguration.getStorageAccountKey
+        new AzureFileSigner(
+          accountName,
+          accountKey,
+          container,
+          preSignedUrlTimeoutSeconds,
+          getRelativePath(abfsStore, _))
+      case AuthType.OAuth =>
+        // Fetch managed identity token via IMDS and use REST-based
+        // User Delegation SAS generation (avoids Azure SDK HTTP
+        // pipeline which requires Jackson 2.9+).
+        val conf = fs.getConf
+        val uamiClientId =
+          AzureCredentialVendor.getManagedIdentityClientId(conf)
+        val splits = accountName.split("\\.", 3)
+        if (splits.length != 3) {
+          throw new IllegalArgumentException(
+            s"Incorrect account name: $accountName")
+        }
+        val rawAccountName = splits(0)
+        val endpointSuffix = splits(2)
+        new AbfsUserDelegationFileSigner(
+          rawAccountName,
+          endpointSuffix,
+          container,
+          uamiClientId,
+          preSignedUrlTimeoutSeconds,
+          getRelativePath(abfsStore, _))
+      case _ =>
+        throw new UnsupportedOperationException(
+          s"unsupported auth type: $authType")
+    }
+  }
+}
+
+/**
+ * Signs ABFS file URLs using User Delegation SAS for
+ * OAuth-authenticated filesystems (e.g. managed identity).
+ * Uses REST calls to fetch the delegation key (cached 50 min)
+ * and computes the SAS locally via HMAC-SHA256.
+ *
+ * TODO: migrate to Azure Storage SDK when Jackson is upgraded
+ * (see delta-io/delta#5598).
+ */
+class AbfsUserDelegationFileSigner(
+    rawAccountName: String,
+    endpointSuffix: String,
+    container: String,
+    uamiClientId: Option[String],
+    preSignedUrlTimeoutSeconds: Long,
+    objectKeyExtractor: Path => String) extends CloudFileSigner {
+
+  private val blobEndpoint =
+    s"https://$rawAccountName.blob.$endpointSuffix"
+
+  // Cache delegation key to avoid a REST call per file.
+  // Keys are valid 1 hour; refresh after 50 min.
+  private val KEY_REFRESH_MINUTES = 50
+  @volatile private var cachedToken: String = _
+  @volatile private var cachedKey:
+    AzureUserDelegationSasGenerator.UserDelegationKeyInfo = _
+  @volatile private var cachedKeyRefreshAt:
+    java.time.OffsetDateTime = _
+
+  private def ensureKey(): (
+      String,
+      AzureUserDelegationSasGenerator.UserDelegationKeyInfo) = {
+    val now = java.time.OffsetDateTime.now()
+    if (cachedKey == null || now.isAfter(cachedKeyRefreshAt)) {
+      synchronized {
+        val nowInner = java.time.OffsetDateTime.now()
+        if (cachedKey == null ||
+            nowInner.isAfter(cachedKeyRefreshAt)) {
+          val (token, _) = AzureUserDelegationSasGenerator
+            .getManagedIdentityToken(uamiClientId)
+          val keyExpiry = nowInner.plusHours(1)
+          cachedToken = token
+          cachedKey = AzureUserDelegationSasGenerator
+            .getUserDelegationKey(
+              rawAccountName, endpointSuffix,
+              token, nowInner, keyExpiry)
+          cachedKeyRefreshAt =
+            nowInner.plusMinutes(KEY_REFRESH_MINUTES)
+        }
+      }
+    }
+    (cachedToken, cachedKey)
+  }
+
+  override def sign(path: Path): PreSignedUrl = {
+    val objectKey = objectKeyExtractor(path)
+    assert(objectKey.nonEmpty, s"cannot get object key from $path")
+    val now = java.time.OffsetDateTime.now()
+    val (_, key) = ensureKey()
+    val sasExpiry = now.plusSeconds(preSignedUrlTimeoutSeconds)
+    val sasToken = AzureUserDelegationSasGenerator
+      .computeUserDelegationSas(
+        rawAccountName, container, key, "r",
+        now, sasExpiry)
+    // Encode each path segment individually. URLEncoder
+    // would encode / as %2F which is a different blob path.
+    val encodedKey = objectKey.split("/").map(seg =>
+      java.net.URLEncoder.encode(seg, UTF_8.name)
+    ).mkString("/")
+    val blobUrl = s"$blobEndpoint/$container/$encodedKey"
+    PreSignedUrl(
+      s"$blobUrl?$sasToken",
+      System.currentTimeMillis() +
+        SECONDS.toMillis(preSignedUrlTimeoutSeconds)
+    )
   }
 }
 

--- a/server/src/main/scala/io/delta/sharing/server/credential/azure/AzureCredentialVendor.scala
+++ b/server/src/main/scala/io/delta/sharing/server/credential/azure/AzureCredentialVendor.scala
@@ -42,9 +42,15 @@ object AzureCredentialVendor {
   val CONF_TENANT_ID = "delta.sharing.azure.tenant.id"
   val CONF_CLIENT_ID = "delta.sharing.azure.client.id"
   val CONF_CLIENT_SECRET = "delta.sharing.azure.client.secret"
+  val CONF_AUTH_TYPE = "delta.sharing.azure.auth.type"
+  val CONF_MANAGED_IDENTITY_CLIENT_ID = "delta.sharing.azure.managed.identity.client.id"
   val HADOOP_OAUTH_CLIENT_ID = "fs.azure.account.oauth2.client.id"
   val HADOOP_OAUTH_CLIENT_SECRET = "fs.azure.account.oauth2.client.secret"
   val HADOOP_OAUTH_CLIENT_ENDPOINT = "fs.azure.account.oauth2.client.endpoint"
+
+  val AUTH_TYPE_MANAGED_IDENTITY = "managed_identity"
+  val AUTH_TYPE_CLIENT_CREDENTIALS = "client_credentials"
+  val AUTH_TYPE_SHARED_KEY = "shared_key"
 
   def parseLocation(uri: URI): AzureLocationParts = {
     val host = Option(uri.getHost).getOrElse("")
@@ -94,58 +100,153 @@ object AzureCredentialVendor {
     val idx = parts.indexWhere(_.contains("microsoftonline.com"))
     if (idx >= 0 && idx + 1 < parts.length) Some(parts(idx + 1)) else None
   }
+
+  def getAuthType(conf: Configuration): Option[String] =
+    Option(conf.get(CONF_AUTH_TYPE)).map(_.trim).filter(_.nonEmpty)
+
+  def getManagedIdentityClientId(conf: Configuration): Option[String] =
+    Option(conf.get(CONF_MANAGED_IDENTITY_CLIENT_ID)).map(_.trim).filter(_.nonEmpty)
+
+  /**
+   * Fetch an AAD token via the Azure IMDS managed identity endpoint.
+   * Uses direct HTTP (like getAadToken for client_credentials) to avoid
+   * the Azure SDK HTTP pipeline which requires Jackson 2.9+
+   * (incompatible with the delta-standalone Jackson 2.6.x pin).
+   * @param clientId optional UAMI client ID; if None, uses system-assigned.
+   * @return (accessToken, expiryMillis)
+   */
+  def getManagedIdentityToken(
+      clientId: Option[String]): (String, Long) = {
+    AzureUserDelegationSasGenerator.getManagedIdentityToken(clientId)
+  }
 }
 
 /**
  * Vends Azure User Delegation SAS or account-key SAS for the context location.
  * Mirrors Unity Catalog's AzureCredentialVendor + DatalakeCredentialGenerator.
+ *
+ * Supports three authentication modes configured via `delta.sharing.azure.auth.type`:
+ * `managed_identity` (SAMI/UAMI), `client_credentials` (service principal), or
+ * `shared_key` (account key). If not set, auto-detects existing behavior.
  */
 class AzureCredentialVendor(conf: Configuration) {
 
   def vendAzureCredential(context: CredentialContext, validitySeconds: Long): Credentials = {
     val location = context.locations.head
     val parts = AzureCredentialVendor.parseLocation(location)
-    val accountKey = AzureNativeFileSystemStore.getAccountKeyFromConfiguration(
-      parts.accountNameFull, conf)
-    val aadConfig = AzureCredentialVendor.getAadConfig(conf, parts.accountNameFull)
     val expirationTime = System.currentTimeMillis() + SECONDS.toMillis(validitySeconds)
-    val sasToken = aadConfig match {
-      case Some((tenantId, clientId, clientSecret)) =>
-        try {
-          AzureUserDelegationSasGenerator.generateUserDelegationSas(
-            parts.accountShort,
-            parts.endpointSuffix,
-            parts.container,
-            tenantId,
-            clientId,
-            clientSecret,
-            validitySeconds
-          )
-        } catch {
-          case e: Exception =>
-            throw new RuntimeException(
-              "Failed to generate Azure User Delegation SAS (check AAD config and RBAC). " +
-                "Ensure the app has Storage Blob Data Contributor or generateUserDelegationKey.", e)
-        }
+    val authType = AzureCredentialVendor.getAuthType(conf)
+
+    val sasToken = authType match {
+      case Some(AzureCredentialVendor.AUTH_TYPE_MANAGED_IDENTITY) =>
+        vendWithManagedIdentity(parts, validitySeconds)
+      case Some(AzureCredentialVendor.AUTH_TYPE_CLIENT_CREDENTIALS) =>
+        vendWithClientCredentials(parts, validitySeconds)
+      case Some(AzureCredentialVendor.AUTH_TYPE_SHARED_KEY) =>
+        vendWithSharedKey(parts, expirationTime)
+      case Some(other) =>
+        throw new IllegalArgumentException(
+          s"Unknown delta.sharing.azure.auth.type: '$other'. " +
+            "Supported values: managed_identity, client_credentials, shared_key.")
       case None =>
-        val connectionString = Seq(
-          "DefaultEndpointsProtocol=https",
-          s"AccountName=${parts.accountShort}",
-          s"AccountKey=$accountKey",
-          s"EndpointSuffix=${parts.endpointSuffix}"
-        ).mkString(";")
-        val account = CloudStorageAccount.parse(connectionString)
-        val blobClient = account.createCloudBlobClient()
-        val policy = new SharedAccessBlobPolicy()
-        policy.setPermissions(java.util.EnumSet.of(SharedAccessBlobPermissions.READ))
-        policy.setSharedAccessExpiryTime(new Date(expirationTime))
-        val containerRef = blobClient.getContainerReference(parts.container)
-        containerRef.generateSharedAccessSignature(policy, null)
+        // Auto-detect: try client_credentials, then fall back to shared_key
+        val aadConfig = AzureCredentialVendor.getAadConfig(conf, parts.accountNameFull)
+        aadConfig match {
+          case Some((tenantId, clientId, clientSecret)) =>
+            vendWithClientCredentialsParams(
+              parts, tenantId, clientId, clientSecret, validitySeconds)
+          case None =>
+            vendWithSharedKey(parts, expirationTime)
+        }
     }
     Credentials(
       location = location.toString,
       azureUserDelegationSas = AzureUserDelegationSas(sasToken = sasToken),
       expirationTime = expirationTime
     )
+  }
+
+  private def vendWithManagedIdentity(
+      parts: AzureLocationParts,
+      validitySeconds: Long): String = {
+    try {
+      val uamiClientId =
+        AzureCredentialVendor.getManagedIdentityClientId(conf)
+      val (accessToken, _) =
+        AzureCredentialVendor.getManagedIdentityToken(uamiClientId)
+      AzureUserDelegationSasGenerator
+        .generateUserDelegationSasFromToken(
+          parts.accountShort,
+          parts.endpointSuffix,
+          parts.container,
+          accessToken,
+          validitySeconds
+        )
+    } catch {
+      case e: Exception =>
+        throw new RuntimeException(
+          "Failed to generate Azure User Delegation SAS via managed identity. " +
+            "Ensure the VM has a managed identity assigned and it has " +
+            "Storage Blob Data Reader + Storage Blob Delegator RBAC roles.", e)
+    }
+  }
+
+  private def vendWithClientCredentials(
+      parts: AzureLocationParts,
+      validitySeconds: Long): String = {
+    val aadConfig = AzureCredentialVendor.getAadConfig(conf, parts.accountNameFull)
+    aadConfig match {
+      case Some((tenantId, clientId, clientSecret)) =>
+        vendWithClientCredentialsParams(parts, tenantId, clientId, clientSecret, validitySeconds)
+      case None =>
+        throw new RuntimeException(
+          "delta.sharing.azure.auth.type is set to 'client_credentials' but " +
+            "tenant/client/secret configuration is missing. Set delta.sharing.azure.tenant.id, " +
+            "delta.sharing.azure.client.id, and delta.sharing.azure.client.secret.")
+    }
+  }
+
+  private def vendWithClientCredentialsParams(
+      parts: AzureLocationParts,
+      tenantId: String,
+      clientId: String,
+      clientSecret: String,
+      validitySeconds: Long): String = {
+    try {
+      AzureUserDelegationSasGenerator.generateUserDelegationSas(
+        parts.accountShort,
+        parts.endpointSuffix,
+        parts.container,
+        tenantId,
+        clientId,
+        clientSecret,
+        validitySeconds
+      )
+    } catch {
+      case e: Exception =>
+        throw new RuntimeException(
+          "Failed to generate Azure User Delegation SAS (check AAD config and RBAC). " +
+            "Ensure the app has Storage Blob Data Contributor or generateUserDelegationKey.", e)
+    }
+  }
+
+  private def vendWithSharedKey(
+      parts: AzureLocationParts,
+      expirationTime: Long): String = {
+    val accountKey = AzureNativeFileSystemStore.getAccountKeyFromConfiguration(
+      parts.accountNameFull, conf)
+    val connectionString = Seq(
+      "DefaultEndpointsProtocol=https",
+      s"AccountName=${parts.accountShort}",
+      s"AccountKey=$accountKey",
+      s"EndpointSuffix=${parts.endpointSuffix}"
+    ).mkString(";")
+    val account = CloudStorageAccount.parse(connectionString)
+    val blobClient = account.createCloudBlobClient()
+    val policy = new SharedAccessBlobPolicy()
+    policy.setPermissions(java.util.EnumSet.of(SharedAccessBlobPermissions.READ))
+    policy.setSharedAccessExpiryTime(new Date(expirationTime))
+    val containerRef = blobClient.getContainerReference(parts.container)
+    containerRef.generateSharedAccessSignature(policy, null)
   }
 }

--- a/server/src/test/scala/io/delta/sharing/server/common/AzureUserDelegationSasGeneratorSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/common/AzureUserDelegationSasGeneratorSuite.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.server.common
+
+import java.time.{OffsetDateTime, ZoneOffset}
+import java.util.Base64
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+import org.scalatest.FunSuite
+
+class AzureUserDelegationSasGeneratorSuite extends FunSuite {
+
+  private val testKey =
+    AzureUserDelegationSasGenerator.UserDelegationKeyInfo(
+      signedOid = "oid-1234",
+      signedTid = "tid-5678",
+      signedStart = "2026-05-04T00:00:00Z",
+      signedExpiry = "2026-05-04T01:00:00Z",
+      signedService = "b",
+      signedVersion = "2022-11-02",
+      value = Base64.getEncoder.encodeToString(
+        "test-delegation-key-value-32b!".getBytes("UTF-8"))
+    )
+
+  private val fixedStart = OffsetDateTime.of(
+    2026, 5, 4, 0, 0, 0, 0, ZoneOffset.UTC)
+  private val fixedExpiry = OffsetDateTime.of(
+    2026, 5, 4, 1, 0, 0, 0, ZoneOffset.UTC)
+
+  test("computeUserDelegationSas produces valid SAS query") {
+    val sas = AzureUserDelegationSasGenerator
+      .computeUserDelegationSas(
+        "myaccount", "mycontainer", testKey,
+        "r", fixedStart, fixedExpiry)
+
+    // Verify required SAS parameters are present
+    assert(sas.contains("sv=2022-11-02"))
+    assert(sas.contains("sr=c"))
+    assert(sas.contains("sp=r"))
+    assert(sas.contains("spr=https"))
+    assert(sas.contains("skoid=oid-1234"))
+    assert(sas.contains("sktid=tid-5678"))
+    assert(sas.contains("sks=b"))
+    assert(sas.contains("skv=2022-11-02"))
+    assert(sas.contains("sig="))
+    // Verify start/expiry are URL-encoded ISO timestamps
+    assert(sas.contains("st=2026-05-04"))
+    assert(sas.contains("se=2026-05-04"))
+  }
+
+  test("computeUserDelegationSas signature is deterministic") {
+    val sas1 = AzureUserDelegationSasGenerator
+      .computeUserDelegationSas(
+        "acct", "ctr", testKey, "r",
+        fixedStart, fixedExpiry)
+    val sas2 = AzureUserDelegationSasGenerator
+      .computeUserDelegationSas(
+        "acct", "ctr", testKey, "r",
+        fixedStart, fixedExpiry)
+    assert(sas1 == sas2)
+  }
+
+  test("computeUserDelegationSas signature changes with account") {
+    val sas1 = AzureUserDelegationSasGenerator
+      .computeUserDelegationSas(
+        "account1", "ctr", testKey, "r",
+        fixedStart, fixedExpiry)
+    val sas2 = AzureUserDelegationSasGenerator
+      .computeUserDelegationSas(
+        "account2", "ctr", testKey, "r",
+        fixedStart, fixedExpiry)
+    assert(sas1 != sas2)
+  }
+
+  test("computeUserDelegationSas signature changes with container") {
+    val sas1 = AzureUserDelegationSasGenerator
+      .computeUserDelegationSas(
+        "acct", "container1", testKey, "r",
+        fixedStart, fixedExpiry)
+    val sas2 = AzureUserDelegationSasGenerator
+      .computeUserDelegationSas(
+        "acct", "container2", testKey, "r",
+        fixedStart, fixedExpiry)
+    assert(sas1 != sas2)
+  }
+
+  test("computeUserDelegationSas signature changes with key") {
+    val key2 = testKey.copy(
+      value = Base64.getEncoder.encodeToString(
+        "different-key-value-32bytes!!".getBytes("UTF-8")))
+    val sas1 = AzureUserDelegationSasGenerator
+      .computeUserDelegationSas(
+        "acct", "ctr", testKey, "r",
+        fixedStart, fixedExpiry)
+    val sas2 = AzureUserDelegationSasGenerator
+      .computeUserDelegationSas(
+        "acct", "ctr", key2, "r",
+        fixedStart, fixedExpiry)
+    assert(sas1 != sas2)
+  }
+
+  test("computeUserDelegationSas string-to-sign has 24 fields") {
+    // The Azure spec for sv=2022-11-02 requires exactly 24 values
+    // separated by 23 newlines in the string-to-sign.
+    // We verify by computing HMAC manually and comparing.
+    val sv = "2022-11-02"
+    val sp = "r"
+    val st = "2026-05-04T00:00:00Z"
+    val se = "2026-05-04T01:00:00Z"
+    val cr = "/blob/myaccount/mycontainer"
+    val spr = "https"
+
+    val expectedSts = Seq(
+      sp, st, se, cr,
+      testKey.signedOid, testKey.signedTid,
+      testKey.signedStart, testKey.signedExpiry,
+      testKey.signedService, testKey.signedVersion,
+      "", "", "", "", spr, sv, "c",
+      "", "", "", "", "", "", ""
+    ).mkString("\n")
+
+    // Verify 24 values = 23 newlines
+    assert(expectedSts.count(_ == '\n') == 23,
+      s"Expected 23 newlines, got ${expectedSts.count(_ == '\n')}")
+
+    // Compute expected signature
+    val keyBytes = Base64.getDecoder.decode(testKey.value)
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(new SecretKeySpec(keyBytes, "HmacSHA256"))
+    val expectedSig = Base64.getEncoder.encodeToString(
+      mac.doFinal(expectedSts.getBytes("UTF-8")))
+
+    // Get actual SAS and extract sig parameter
+    val sas = AzureUserDelegationSasGenerator
+      .computeUserDelegationSas(
+        "myaccount", "mycontainer", testKey,
+        "r", fixedStart, fixedExpiry)
+    val sigParam = sas.split("&")
+      .find(_.startsWith("sig=")).get
+    val actualSig = java.net.URLDecoder.decode(
+      sigParam.stripPrefix("sig="), "UTF-8")
+
+    assert(actualSig == expectedSig,
+      s"Signature mismatch.\n" +
+        s"Expected: $expectedSig\n" +
+        s"Actual:   $actualSig")
+  }
+
+  test("parseUserDelegationKeyXml handles BOM") {
+    // Verify BOM stripping logic: charAt(0) == 0xFEFF
+    val bom = 0xFEFF.toChar
+    assert(bom.toInt == 0xFEFF)
+    val testStr = s"${bom}hello"
+    assert(testStr.charAt(0) == 0xFEFF)
+    assert(testStr.substring(1) == "hello")
+  }
+}

--- a/server/src/test/scala/io/delta/sharing/server/credential/azure/AzureCredentialVendorSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/credential/azure/AzureCredentialVendorSuite.scala
@@ -93,4 +93,88 @@ class AzureCredentialVendorSuite extends FunSuite {
     val result = AzureCredentialVendor.getAadConfig(conf, account)
     assert(result == Some(("tenant-abc", "cid", "csecret")))
   }
+
+  // --- Managed identity config tests ---
+
+  test("getAuthType returns None when not configured") {
+    val conf = new Configuration()
+    assert(AzureCredentialVendor.getAuthType(conf).isEmpty)
+  }
+
+  test("getAuthType returns managed_identity") {
+    val conf = new Configuration()
+    conf.set(AzureCredentialVendor.CONF_AUTH_TYPE, "managed_identity")
+    assert(AzureCredentialVendor.getAuthType(conf) == Some("managed_identity"))
+  }
+
+  test("getAuthType returns client_credentials") {
+    val conf = new Configuration()
+    conf.set(AzureCredentialVendor.CONF_AUTH_TYPE, "client_credentials")
+    assert(AzureCredentialVendor.getAuthType(conf) == Some("client_credentials"))
+  }
+
+  test("getAuthType returns shared_key") {
+    val conf = new Configuration()
+    conf.set(AzureCredentialVendor.CONF_AUTH_TYPE, "shared_key")
+    assert(AzureCredentialVendor.getAuthType(conf) == Some("shared_key"))
+  }
+
+  test("getAuthType trims whitespace") {
+    val conf = new Configuration()
+    conf.set(AzureCredentialVendor.CONF_AUTH_TYPE, "  managed_identity  ")
+    assert(AzureCredentialVendor.getAuthType(conf) == Some("managed_identity"))
+  }
+
+  test("getAuthType returns None for empty string") {
+    val conf = new Configuration()
+    conf.set(AzureCredentialVendor.CONF_AUTH_TYPE, "")
+    assert(AzureCredentialVendor.getAuthType(conf).isEmpty)
+  }
+
+  test("getManagedIdentityClientId returns None when not configured") {
+    val conf = new Configuration()
+    assert(AzureCredentialVendor.getManagedIdentityClientId(conf).isEmpty)
+  }
+
+  test("getManagedIdentityClientId returns UAMI client ID") {
+    val conf = new Configuration()
+    conf.set(AzureCredentialVendor.CONF_MANAGED_IDENTITY_CLIENT_ID, "uami-client-id-123")
+    assert(AzureCredentialVendor.getManagedIdentityClientId(conf) == Some("uami-client-id-123"))
+  }
+
+  test("getManagedIdentityClientId trims whitespace") {
+    val conf = new Configuration()
+    conf.set(AzureCredentialVendor.CONF_MANAGED_IDENTITY_CLIENT_ID, "  uami-123  ")
+    assert(AzureCredentialVendor.getManagedIdentityClientId(conf) == Some("uami-123"))
+  }
+
+  test("vendAzureCredential throws for unknown auth type") {
+    val conf = new Configuration()
+    conf.set(AzureCredentialVendor.CONF_AUTH_TYPE, "invalid_type")
+    val vendor = new AzureCredentialVendor(conf)
+    val context = io.delta.sharing.server.credential.CredentialContext.create(
+      new URI("abfss://container@account.dfs.core.windows.net/path"),
+      Set(io.delta.sharing.server.credential.Privilege.SELECT)
+    )
+    val e = intercept[IllegalArgumentException] {
+      vendor.vendAzureCredential(context, 3600)
+    }
+    assert(e.getMessage.contains("Unknown delta.sharing.azure.auth.type"))
+    assert(e.getMessage.contains("invalid_type"))
+  }
+
+  test("vendAzureCredential throws for client_credentials without config") {
+    val conf = new Configuration()
+    conf.set(AzureCredentialVendor.CONF_AUTH_TYPE, "client_credentials")
+    val vendor = new AzureCredentialVendor(conf)
+    val context = io.delta.sharing.server.credential.CredentialContext.create(
+      new URI("abfss://container@account.dfs.core.windows.net/path"),
+      Set(io.delta.sharing.server.credential.Privilege.SELECT)
+    )
+    val e = intercept[RuntimeException] {
+      vendor.vendAzureCredential(context, 3600)
+    }
+    assert(e.getMessage.contains("client_credentials"))
+    assert(e.getMessage.contains("tenant/client/secret configuration is missing"))
+  }
 }

--- a/server/src/universal/conf/delta-sharing-server.yaml.template
+++ b/server/src/universal/conf/delta-sharing-server.yaml.template
@@ -50,6 +50,15 @@ endpoint: "/delta-sharing"
 preSignedUrlTimeoutSeconds: 3600
 # Set the validity in seconds of temporary table credentials (STS/SAS/OAuth) returned by the server (default: 3600 = 1 hour)
 temporaryCredentialValiditySeconds: 3600
+# Azure Managed Identity: To use managed identity instead of account keys or service principal
+# credentials for ADLS Gen2, configure the following in conf/core-site.xml:
+#   fs.azure.account.auth.type.<account>.dfs.core.windows.net = OAuth
+#   fs.azure.account.oauth.provider.type.<account>.dfs.core.windows.net = org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider
+#   delta.sharing.azure.auth.type = managed_identity
+# For User-Assigned Managed Identity (UAMI), also set:
+#   fs.azure.account.oauth2.client.id.<account>.dfs.core.windows.net = <uami-client-id>
+#   delta.sharing.azure.managed.identity.client.id = <uami-client-id>
+# The identity must have Storage Blob Data Reader + Storage Blob Delegator RBAC roles.
 # How many tables to cache in the server
 deltaTableCacheSize: 10
 # Whether we can accept working with a stale version of the table. This is useful when sharing


### PR DESCRIPTION
Adds managed identity authentication for the server accessing ADLS Gen2 storage, enabling secretless operation on Azure VMs. Closes #945.

**Changes:**
- `AzureCredentialVendor`: new `managed_identity` auth type with config keys
- `AzureUserDelegationSasGenerator`: REST-based IMDS token, User Delegation Key, and local HMAC-SHA256 SAS (avoids Azure SDK HTTP pipeline / Jackson 2.9+ conflict with delta-standalone 2.6.x pin)
- `CloudFileSigner`: `AbfsUserDelegationFileSigner` for OAuth ABFS with cached delegation keys
- Existing SharedKey and client_credentials paths unchanged

**Tests:** 17 new unit tests (103 total pass). Integration tested with SAMI/UAMI, hardened storage (no shared key, private endpoints), partitioned tables, Python client, Power BI.

Related: #666 (client-side MI), delta-io/delta#5598 (Jackson upgrade)