### PR TITLE
[Python] Add Arrow materializers for table snapshots

### DIFF
--- a/python/delta_sharing/__init__.py
+++ b/python/delta_sharing/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from delta_sharing.delta_sharing import SharingClient, load_as_pandas, load_as_spark
+from delta_sharing.delta_sharing import SharingClient, load_as_arrow, load_as_pandas, load_as_spark
 from delta_sharing.delta_sharing import get_table_metadata, get_table_protocol, get_table_version
 from delta_sharing.delta_sharing import load_table_changes_as_pandas, load_table_changes_as_spark
 from delta_sharing.protocol import Share, Schema, Table
@@ -28,6 +28,7 @@ __all__ = [
     "get_table_metadata",
     "get_table_protocol",
     "get_table_version",
+    "load_as_arrow",
     "load_as_pandas",
     "load_as_spark",
     "load_table_changes_as_pandas",

--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 
 
 def _get_dummy_column(schema_type):
@@ -113,5 +114,59 @@ def to_converter(schema_type) -> Callable[[str], Any]:
         return None  # partition on binary column not supported
     elif isinstance(schema_type, dict) and schema_type["type"] in ("array", "struct", "map"):
         return None  # partition on complex column not supported
+
+    raise ValueError(f"Could not parse datatype: {schema_type}")
+
+
+def to_arrow_schema(schema_json: dict) -> pa.Schema:
+    assert schema_json["type"] == "struct"
+
+    return pa.schema(
+        [pa.field(field["name"], to_arrow_type(field["type"])) for field in schema_json["fields"]]
+    )
+
+
+def to_arrow_type(schema_type):
+    if schema_type == "boolean":
+        return pa.bool_()
+    elif schema_type == "byte":
+        return pa.int8()
+    elif schema_type == "short":
+        return pa.int16()
+    elif schema_type == "integer":
+        return pa.int32()
+    elif schema_type == "long":
+        return pa.int64()
+    elif schema_type == "float":
+        return pa.float32()
+    elif schema_type == "double":
+        return pa.float64()
+    elif isinstance(schema_type, str) and schema_type.startswith("decimal("):
+        precision, scale = schema_type[len("decimal(") : -1].split(",")
+        return pa.decimal128(int(precision), int(scale))
+    elif schema_type == "string":
+        return pa.string()
+    elif schema_type == "date":
+        return pa.date32()
+    elif schema_type == "timestamp":
+        # Delta `timestamp` is microsecond precision, adjusted to UTC. Using the
+        # same type here keeps the parquet and delta-kernel paths consistent.
+        return pa.timestamp("us", tz="UTC")
+    elif schema_type == "binary":
+        return pa.binary()
+    elif isinstance(schema_type, dict) and schema_type["type"] == "array":
+        return pa.list_(to_arrow_type(schema_type["elementType"]))
+    elif isinstance(schema_type, dict) and schema_type["type"] == "struct":
+        return pa.struct(
+            [
+                pa.field(field["name"], to_arrow_type(field["type"]))
+                for field in schema_type["fields"]
+            ]
+        )
+    elif isinstance(schema_type, dict) and schema_type["type"] == "map":
+        return pa.map_(
+            to_arrow_type(schema_type["keyType"]),
+            to_arrow_type(schema_type["valueType"]),
+        )
 
     raise ValueError(f"Could not parse datatype: {schema_type}")

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 from itertools import chain
-from typing import BinaryIO, List, Optional, Sequence, TextIO, Tuple, Union
+from typing import BinaryIO, Iterator, List, Optional, Sequence, TextIO, Tuple, Union
 from pathlib import Path
 
 import pandas as pd
+import pyarrow as pa
 
 from delta_sharing.protocol import CdfOptions, Protocol, Metadata
 
@@ -155,6 +156,43 @@ def load_as_pandas(
     ).to_pandas()
 
 
+def load_as_arrow(
+    url: str,
+    limit: Optional[int] = None,
+    version: Optional[int] = None,
+    timestamp: Optional[str] = None,
+    jsonPredicateHints: Optional[str] = None,
+    use_delta_format: Optional[bool] = None,
+) -> pa.Table:
+    """
+    Load the shared table using the given url as a PyArrow Table.
+
+    :param url: a url under the format "<profile>#<share>.<schema>.<table>"
+    :param limit: a non-negative int. Load only the ``limit`` rows if the parameter is specified.
+      Use this optional parameter to explore the shared table without loading the entire table to
+      the memory.
+    :param version: an optional non-negative int. Load the snapshot of table at version
+    :param timestamp: an optional string. Load the snapshot of table at version corresponding
+      to the timestamp.
+    :param jsonPredicateHints: Predicate hints to be applied to the table. For more details see:
+      https://github.com/delta-io/delta-sharing/blob/main/PROTOCOL.md#json-predicates-for-filtering
+    :param use_delta_format: Whether to use delta format or parquet format. If not set, table
+      metadata will be used to determine whether to use delta or parquet format.
+    :return: A PyArrow Table representing the shared table.
+    """
+    profile_json, share, schema, table = _parse_url(url)
+    profile = DeltaSharingProfile.read_from_file(profile_json)
+    return DeltaSharingReader(
+        table=Table(name=table, share=share, schema=schema),
+        rest_client=DataSharingRestClient(profile),
+        jsonPredicateHints=jsonPredicateHints,
+        limit=limit,
+        version=version,
+        timestamp=timestamp,
+        use_delta_format=use_delta_format,
+    ).to_arrow()
+
+
 class TableSnapshot:
     def __init__(
         self,
@@ -189,6 +227,15 @@ class TableSnapshot:
 
     def to_pandas(self, convert_in_batches: bool = False) -> pd.DataFrame:
         return self._reader(convert_in_batches=convert_in_batches).to_pandas()
+
+    def to_arrow(self) -> pa.Table:
+        return self._reader().to_arrow()
+
+    def to_record_batches(self) -> Iterator[pa.RecordBatch]:
+        return self._reader().to_record_batches()
+
+    def to_record_batch_reader(self) -> pa.RecordBatchReader:
+        return self._reader().to_record_batch_reader()
 
     def _table_name(self) -> str:
         return f"{self._table.share}.{self._table.schema}.{self._table.name}"
@@ -341,6 +388,15 @@ class DeltaSharingTable:
 
     def to_pandas(self, convert_in_batches: bool = False) -> pd.DataFrame:
         return self.snapshot().to_pandas(convert_in_batches=convert_in_batches)
+
+    def to_arrow(self) -> pa.Table:
+        return self.snapshot().to_arrow()
+
+    def to_record_batches(self) -> Iterator[pa.RecordBatch]:
+        return self.snapshot().to_record_batches()
+
+    def to_record_batch_reader(self) -> pa.RecordBatchReader:
+        return self.snapshot().to_record_batch_reader()
 
     def to_spark(self) -> "PySparkDataFrame":  # noqa: F821
         return self.snapshot().to_spark()

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -170,7 +170,7 @@ def load_as_arrow(
     :param url: a url under the format "<profile>#<share>.<schema>.<table>"
     :param limit: a non-negative int. Load only the ``limit`` rows if the parameter is specified.
       Use this optional parameter to explore the shared table without loading the entire table to
-      the memory.
+      memory.
     :param version: an optional non-negative int. Load the snapshot of table at version
     :param timestamp: an optional string. Load the snapshot of table at version corresponding
       to the timestamp.

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -286,6 +286,8 @@ class DeltaSharingReader:
             left = self._limit
             for index, file in enumerate(response.add_files):
                 file_limit = left
+                # Reuse the first dataset opened above to resolve column casing;
+                # each remaining file needs its own dataset for batch scanning.
                 pa_dataset = (
                     first_dataset if index == 0 else DeltaSharingReader._parquet_dataset(file.url)
                 )

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -266,7 +266,6 @@ class DeltaSharingReader:
 
         response, schema_json = self._list_files()
         schema = to_arrow_schema(schema_json)
-        converters = to_converters(schema_json)
 
         if len(response.add_files) == 0 or self._limit == 0:
             return schema, iter(())
@@ -275,9 +274,7 @@ class DeltaSharingReader:
             left = self._limit
             for file in response.add_files:
                 file_limit = left
-                for batch in DeltaSharingReader._to_record_batches(
-                    file, schema_json, converters, file_limit
-                ):
+                for batch in DeltaSharingReader._to_record_batches(file, schema_json, file_limit):
                     yield batch
                     if left is not None:
                         left -= batch.num_rows
@@ -597,7 +594,6 @@ class DeltaSharingReader:
     def _to_record_batches(
         action: FileAction,
         schema_json: dict,
-        converters: Dict[str, Callable[[str], Any]],
         limit: Optional[int],
     ) -> Iterator[pa.RecordBatch]:
         filesystem = DeltaSharingReader._parquet_filesystem(action.url)
@@ -612,7 +608,7 @@ class DeltaSharingReader:
             if limit is not None and rows_read + batch.num_rows > limit:
                 batch = batch.slice(0, limit - rows_read)
 
-            yield DeltaSharingReader._normalize_record_batch(batch, action, schema_json, converters)
+            yield DeltaSharingReader._normalize_record_batch(batch, action, schema_json)
             rows_read += batch.num_rows
 
     @staticmethod
@@ -635,7 +631,6 @@ class DeltaSharingReader:
         batch: pa.RecordBatch,
         action: FileAction,
         schema_json: dict,
-        converters: Dict[str, Callable[[str], Any]],
     ) -> pa.RecordBatch:
         columns = []
         names = []
@@ -656,11 +651,18 @@ class DeltaSharingReader:
                 continue
 
             if field_name in action.partition_values:
-                converter = converters[field_name]
-                if converter is None:
+                schema_type = field["type"]
+                if schema_type == "binary" or isinstance(schema_type, dict):
                     raise ValueError("Cannot partition on binary or complex columns")
-                value = converter(action.partition_values[field_name])
-                columns.append(pa.array([value] * num_rows, type=field_type))
+                value = action.partition_values[field_name]
+                if value is None or value == "":
+                    columns.append(pa.nulls(num_rows, type=field_type))
+                    continue
+
+                values = pa.array([value] * num_rows)
+                if schema_type == "timestamp":
+                    values = values.cast(pa.timestamp("us"))
+                columns.append(values.cast(field_type))
             else:
                 columns.append(pa.nulls(num_rows, type=field_type))
 

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -270,11 +270,32 @@ class DeltaSharingReader:
         if len(response.add_files) == 0 or self._limit == 0:
             return schema, iter(())
 
+        first_dataset = DeltaSharingReader._parquet_dataset(response.add_files[0].url)
+        physical_names = {name.lower(): name for name in first_dataset.schema.names}
+        # Match pandas column naming: preserve physical Parquet casing for data
+        # columns, while columns synthesized from Delta metadata (such as
+        # partition columns) retain their Delta schema casing.
+        schema = pa.schema(
+            [
+                field.with_name(physical_names.get(field.name.lower(), field.name))
+                for field in schema
+            ]
+        )
+
         def iterator() -> Iterator[pa.RecordBatch]:
             left = self._limit
-            for file in response.add_files:
+            for index, file in enumerate(response.add_files):
                 file_limit = left
-                for batch in DeltaSharingReader._to_record_batches(file, schema_json, file_limit):
+                pa_dataset = (
+                    first_dataset if index == 0 else DeltaSharingReader._parquet_dataset(file.url)
+                )
+                for batch in DeltaSharingReader._to_record_batches(
+                    pa_dataset,
+                    file,
+                    schema_json,
+                    schema.names,
+                    file_limit,
+                ):
                     yield batch
                     if left is not None:
                         left -= batch.num_rows
@@ -592,12 +613,12 @@ class DeltaSharingReader:
 
     @staticmethod
     def _to_record_batches(
+        pa_dataset,
         action: FileAction,
         schema_json: dict,
+        output_names: List[str],
         limit: Optional[int],
     ) -> Iterator[pa.RecordBatch]:
-        filesystem = DeltaSharingReader._parquet_filesystem(action.url)
-        pa_dataset = dataset(source=action.url, format="parquet", filesystem=filesystem)
         scanner = pa_dataset.scanner()
         rows_read = 0
 
@@ -608,8 +629,18 @@ class DeltaSharingReader:
             if limit is not None and rows_read + batch.num_rows > limit:
                 batch = batch.slice(0, limit - rows_read)
 
-            yield DeltaSharingReader._normalize_record_batch(batch, action, schema_json)
+            yield DeltaSharingReader._normalize_record_batch(
+                batch,
+                action,
+                schema_json,
+                output_names,
+            )
             rows_read += batch.num_rows
+
+    @staticmethod
+    def _parquet_dataset(action_url: str):
+        filesystem = DeltaSharingReader._parquet_filesystem(action_url)
+        return dataset(source=action_url, format="parquet", filesystem=filesystem)
 
     @staticmethod
     def _parquet_filesystem(action_url: str):
@@ -631,16 +662,17 @@ class DeltaSharingReader:
         batch: pa.RecordBatch,
         action: FileAction,
         schema_json: dict,
+        output_names: List[str],
     ) -> pa.RecordBatch:
         columns = []
         names = []
         lower_to_index = {name.lower(): index for index, name in enumerate(batch.schema.names)}
         num_rows = batch.num_rows
 
-        for field in schema_json["fields"]:
+        for field, output_name in zip(schema_json["fields"], output_names):
             field_name = field["name"]
             lower_name = field_name.lower()
-            names.append(field_name)
+            names.append(output_name)
             field_type = to_arrow_type(field["type"])
 
             if lower_name in lower_to_index:

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -192,16 +192,7 @@ class DeltaSharingReader:
             return self.__to_pandas_kernel()
 
         # Otherwise use the standard approach
-        response = self._rest_client.list_files_in_table(
-            self._table,
-            predicateHints=self._predicateHints,
-            jsonPredicateHints=self._jsonPredicateHints,
-            limitHint=self._limit,
-            version=self._version,
-            timestamp=self._timestamp,
-        )
-
-        schema_json = loads(response.metadata.schema_string)
+        response, schema_json = self._list_files()
 
         if len(response.add_files) == 0 or self._limit == 0:
             return get_empty_table(schema_json)
@@ -273,7 +264,9 @@ class DeltaSharingReader:
         if response_format == DataSharingRestClient.DELTA_FORMAT:
             return self.__record_batches_kernel()
 
-        response, schema_json, schema, converters = self._list_files_for_arrow()
+        response, schema_json = self._list_files()
+        schema = to_arrow_schema(schema_json)
+        converters = to_converters(schema_json)
 
         if len(response.add_files) == 0 or self._limit == 0:
             return schema, iter(())
@@ -298,7 +291,7 @@ class DeltaSharingReader:
 
         return schema, iterator()
 
-    def _list_files_for_arrow(self):
+    def _list_files(self):
         response = self._rest_client.list_files_in_table(
             self._table,
             predicateHints=self._predicateHints,
@@ -308,12 +301,7 @@ class DeltaSharingReader:
             timestamp=self._timestamp,
         )
         schema_json = loads(response.metadata.schema_string)
-        return (
-            response,
-            schema_json,
-            to_arrow_schema(schema_json),
-            to_converters(schema_json),
-        )
+        return response, schema_json
 
     def __write_temp_delta_log_snapshot(self, temp_dir: str, lines: List[str]) -> str:
         delta_log_dir_name = temp_dir

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional, Sequence
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple
 from urllib.parse import urlparse
 from json import loads, dump
 from urllib.request import getproxies
@@ -28,7 +28,7 @@ import tempfile
 from pyarrow.dataset import dataset
 from pyarrow.parquet import ParquetFile
 
-from delta_sharing.converter import to_converters, get_empty_table
+from delta_sharing.converter import get_empty_table, to_arrow_schema, to_arrow_type, to_converters
 from delta_sharing.protocol import AddCdcFile, CdfOptions, FileAction, Table
 from delta_sharing.rest_client import DataSharingRestClient
 from delta_sharing.fake_checkpoint import get_fake_checkpoint_byte_array
@@ -96,6 +96,39 @@ class DeltaSharingReader:
             timestamp=self._timestamp,
         )
 
+    def __snapshot_scan_kernel(self):
+        """
+        Build a delta-kernel snapshot scan. The caller owns the returned temp dir
+        and must keep it alive until the scan result is fully consumed.
+        """
+        temp_dir = tempfile.TemporaryDirectory()
+        try:
+            self._rest_client.set_delta_format_header()
+            try:
+                response = self._rest_client.list_files_in_table(
+                    self._table,
+                    predicateHints=self._predicateHints,
+                    jsonPredicateHints=self._jsonPredicateHints,
+                    limitHint=self._limit,
+                    version=self._version,
+                    timestamp=self._timestamp,
+                )
+            finally:
+                self._rest_client.remove_delta_format_header()
+
+            lines = list(response.lines)
+            table_path = self.__write_temp_delta_log_snapshot(temp_dir.name, lines)
+            num_files = len(lines)
+
+            interface = delta_kernel_rust_sharing_wrapper.PythonInterface(table_path)
+            table = delta_kernel_rust_sharing_wrapper.Table(table_path)
+            snapshot = table.snapshot(interface)
+            scan = delta_kernel_rust_sharing_wrapper.ScanBuilder(snapshot).build()
+            return temp_dir, scan.execute(interface), num_files
+        except Exception:
+            temp_dir.cleanup()
+            raise
+
     def __to_pandas_kernel(self):
         """
         This function calls delta-kernel-rust python wrapper to load a df for a table
@@ -106,34 +139,13 @@ class DeltaSharingReader:
 
         Returns: a pandas df
         """
-        temp_dir = tempfile.TemporaryDirectory()
-        self._rest_client.set_delta_format_header()
+        temp_dir, batches, num_files = self.__snapshot_scan_kernel()
         try:
-            response = self._rest_client.list_files_in_table(
-                self._table,
-                predicateHints=self._predicateHints,
-                jsonPredicateHints=self._jsonPredicateHints,
-                limitHint=self._limit,
-                version=self._version,
-                timestamp=self._timestamp,
-            )
-
-            lines = response.lines
-            table_path = self.__write_temp_delta_log_snapshot(temp_dir.name, lines)
-            num_files = len(lines)
-
-            # Invoke delta-kernel-rust to return the pandas dataframe
-            interface = delta_kernel_rust_sharing_wrapper.PythonInterface(table_path)
-            table = delta_kernel_rust_sharing_wrapper.Table(table_path)
-            snapshot = table.snapshot(interface)
-            scan = delta_kernel_rust_sharing_wrapper.ScanBuilder(snapshot).build()
-
             # The table is empty so use the schema to return an empty table with correct col names
             if num_files == 0:
-                schema = scan.execute(interface).schema
+                schema = batches.schema
                 return pd.DataFrame(columns=schema.names)
 
-            batches = scan.execute(interface)
             if self._convert_in_batches:
                 pdfs = [batch.to_pandas(self_destruct=True) for batch in batches]
                 print(f"Received {len(pdfs)} batches of data.")
@@ -144,9 +156,27 @@ class DeltaSharingReader:
             # Apply residual limit that was not handled from server pushdown
             return result.head(self._limit)
         finally:
-            # Delete the temp folder explicitly and remove the delta format from header
+            # Delete the temp folder explicitly.
             temp_dir.cleanup()
-            self._rest_client.remove_delta_format_header()
+
+    def __record_batches_kernel(self) -> Tuple[pa.Schema, Iterator[pa.RecordBatch]]:
+        temp_dir, scan_result, _ = self.__snapshot_scan_kernel()
+
+        def iterator() -> Iterator[pa.RecordBatch]:
+            left = self._limit
+            try:
+                for batch in scan_result:
+                    if left is not None and left == 0:
+                        return
+                    if left is not None and batch.num_rows > left:
+                        batch = batch.slice(0, left)
+                    yield batch
+                    if left is not None:
+                        left -= batch.num_rows
+            finally:
+                temp_dir.cleanup()
+
+        return scan_result.schema, iterator()
 
     def to_pandas(self) -> pd.DataFrame:
         response_format = ""
@@ -212,6 +242,78 @@ class DeltaSharingReader:
             col_map[col.lower()] = col
 
         return merged[[col_map[field["name"].lower()] for field in schema_json["fields"]]]
+
+    def to_arrow(self) -> pa.Table:
+        schema, batches = self._to_arrow_stream()
+        return pa.Table.from_batches(list(batches), schema=schema)
+
+    def to_record_batches(self) -> Iterator[pa.RecordBatch]:
+        """
+        Batches are produced lazily; consume the iterator fully (or close it) so
+        that temporary resources backing the stream are released promptly.
+        """
+        _, batches = self._to_arrow_stream()
+        return batches
+
+    def to_record_batch_reader(self) -> pa.RecordBatchReader:
+        """
+        Batches are produced lazily; read the reader fully (or close it) so that
+        temporary resources backing the stream are released promptly.
+        """
+        schema, batches = self._to_arrow_stream()
+        return pa.RecordBatchReader.from_batches(schema, batches)
+
+    def _to_arrow_stream(self) -> Tuple[pa.Schema, Iterator[pa.RecordBatch]]:
+        response_format = ""
+        if self._use_delta_format is None:
+            response_format = self._rest_client.autoresolve_query_format(self._table)
+        elif self._use_delta_format:
+            response_format = DataSharingRestClient.DELTA_FORMAT
+
+        if response_format == DataSharingRestClient.DELTA_FORMAT:
+            return self.__record_batches_kernel()
+
+        response, schema_json, schema, converters = self._list_files_for_arrow()
+
+        if len(response.add_files) == 0 or self._limit == 0:
+            return schema, iter(())
+
+        def iterator() -> Iterator[pa.RecordBatch]:
+            left = self._limit
+            for file in response.add_files:
+                file_limit = left
+                for batch in DeltaSharingReader._to_record_batches(
+                    file, schema_json, converters, file_limit
+                ):
+                    yield batch
+                    if left is not None:
+                        left -= batch.num_rows
+                        if left < 0:
+                            raise RuntimeError(
+                                "'_to_record_batches' returned more rows than the "
+                                f"requested limit of {file_limit}"
+                            )
+                        if left == 0:
+                            return
+
+        return schema, iterator()
+
+    def _list_files_for_arrow(self):
+        response = self._rest_client.list_files_in_table(
+            self._table,
+            predicateHints=self._predicateHints,
+            jsonPredicateHints=self._jsonPredicateHints,
+            limitHint=self._limit,
+            version=self._version,
+            timestamp=self._timestamp,
+        )
+        schema_json = loads(response.metadata.schema_string)
+        return (
+            response,
+            schema_json,
+            to_arrow_schema(schema_json),
+            to_converters(schema_json),
+        )
 
     def __write_temp_delta_log_snapshot(self, temp_dir: str, lines: List[str]) -> str:
         delta_log_dir_name = temp_dir
@@ -442,18 +544,7 @@ class DeltaSharingReader:
         limit: Optional[int],
         convert_in_batches: bool,
     ) -> pd.DataFrame:
-        url = urlparse(action.url)
-        if "storage.googleapis.com" in (url.netloc.lower()):
-            # Apply the yarl patch for GCS pre-signed urls
-            import delta_sharing._yarl_patch  # noqa: F401
-
-        protocol = url.scheme
-        proxy = getproxies()
-        if len(proxy) != 0:
-            filesystem = fsspec.filesystem(protocol, client_kwargs={"trust_env": True})
-        else:
-            filesystem = fsspec.filesystem(protocol)
-
+        filesystem = DeltaSharingReader._parquet_filesystem(action.url)
         pa_file = ParquetFile(action.url, filesystem=filesystem)
 
         if convert_in_batches:
@@ -513,6 +604,79 @@ class DeltaSharingReader:
                 assert DeltaSharingReader._commit_timestamp_col_name() not in pdf.columns
                 pdf[DeltaSharingReader._commit_timestamp_col_name()] = action.timestamp
         return pdf
+
+    @staticmethod
+    def _to_record_batches(
+        action: FileAction,
+        schema_json: dict,
+        converters: Dict[str, Callable[[str], Any]],
+        limit: Optional[int],
+    ) -> Iterator[pa.RecordBatch]:
+        filesystem = DeltaSharingReader._parquet_filesystem(action.url)
+        pa_dataset = dataset(source=action.url, format="parquet", filesystem=filesystem)
+        scanner = pa_dataset.scanner()
+        rows_read = 0
+
+        for batch in scanner.to_batches():
+            if limit is not None and rows_read == limit:
+                return
+
+            if limit is not None and rows_read + batch.num_rows > limit:
+                batch = batch.slice(0, limit - rows_read)
+
+            yield DeltaSharingReader._normalize_record_batch(batch, action, schema_json, converters)
+            rows_read += batch.num_rows
+
+    @staticmethod
+    def _parquet_filesystem(action_url: str):
+        url = urlparse(action_url)
+        if "storage.googleapis.com" in (url.netloc.lower()):
+            import delta_sharing._yarl_patch  # noqa: F401
+
+        protocol = url.scheme
+        proxy = getproxies()
+        if len(proxy) != 0:
+            filesystem = fsspec.filesystem(protocol, client_kwargs={"trust_env": True})
+        else:
+            filesystem = fsspec.filesystem(protocol)
+
+        return filesystem
+
+    @staticmethod
+    def _normalize_record_batch(
+        batch: pa.RecordBatch,
+        action: FileAction,
+        schema_json: dict,
+        converters: Dict[str, Callable[[str], Any]],
+    ) -> pa.RecordBatch:
+        columns = []
+        names = []
+        lower_to_index = {name.lower(): index for index, name in enumerate(batch.schema.names)}
+        num_rows = batch.num_rows
+
+        for field in schema_json["fields"]:
+            field_name = field["name"]
+            lower_name = field_name.lower()
+            names.append(field_name)
+            field_type = to_arrow_type(field["type"])
+
+            if lower_name in lower_to_index:
+                column = batch.column(lower_to_index[lower_name])
+                if column.type != field_type:
+                    column = column.cast(field_type)
+                columns.append(column)
+                continue
+
+            if field_name in action.partition_values:
+                converter = converters[field_name]
+                if converter is None:
+                    raise ValueError("Cannot partition on binary or complex columns")
+                value = converter(action.partition_values[field_name])
+                columns.append(pa.array([value] * num_rows, type=field_type))
+            else:
+                columns.append(pa.nulls(num_rows, type=field_type))
+
+        return pa.RecordBatch.from_arrays(columns, names=names)
 
     # The names of special delta columns for cdf.
 

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -270,34 +270,11 @@ class DeltaSharingReader:
         if len(response.add_files) == 0 or self._limit == 0:
             return schema, iter(())
 
-        first_dataset = DeltaSharingReader._parquet_dataset(response.add_files[0].url)
-        physical_names = {name.lower(): name for name in first_dataset.schema.names}
-        # Match pandas column naming: preserve physical Parquet casing for data
-        # columns, while columns synthesized from Delta metadata (such as
-        # partition columns) retain their Delta schema casing.
-        schema = pa.schema(
-            [
-                field.with_name(physical_names.get(field.name.lower(), field.name))
-                for field in schema
-            ]
-        )
-
         def iterator() -> Iterator[pa.RecordBatch]:
             left = self._limit
-            for index, file in enumerate(response.add_files):
+            for file in response.add_files:
                 file_limit = left
-                # Reuse the first dataset opened above to resolve column casing;
-                # each remaining file needs its own dataset for batch scanning.
-                pa_dataset = (
-                    first_dataset if index == 0 else DeltaSharingReader._parquet_dataset(file.url)
-                )
-                for batch in DeltaSharingReader._to_record_batches(
-                    pa_dataset,
-                    file,
-                    schema_json,
-                    schema.names,
-                    file_limit,
-                ):
+                for batch in DeltaSharingReader._to_record_batches(file, schema_json, file_limit):
                     yield batch
                     if left is not None:
                         left -= batch.num_rows
@@ -615,12 +592,12 @@ class DeltaSharingReader:
 
     @staticmethod
     def _to_record_batches(
-        pa_dataset,
         action: FileAction,
         schema_json: dict,
-        output_names: List[str],
         limit: Optional[int],
     ) -> Iterator[pa.RecordBatch]:
+        filesystem = DeltaSharingReader._parquet_filesystem(action.url)
+        pa_dataset = dataset(source=action.url, format="parquet", filesystem=filesystem)
         scanner = pa_dataset.scanner()
         rows_read = 0
 
@@ -631,18 +608,8 @@ class DeltaSharingReader:
             if limit is not None and rows_read + batch.num_rows > limit:
                 batch = batch.slice(0, limit - rows_read)
 
-            yield DeltaSharingReader._normalize_record_batch(
-                batch,
-                action,
-                schema_json,
-                output_names,
-            )
+            yield DeltaSharingReader._normalize_record_batch(batch, action, schema_json)
             rows_read += batch.num_rows
-
-    @staticmethod
-    def _parquet_dataset(action_url: str):
-        filesystem = DeltaSharingReader._parquet_filesystem(action_url)
-        return dataset(source=action_url, format="parquet", filesystem=filesystem)
 
     @staticmethod
     def _parquet_filesystem(action_url: str):
@@ -664,17 +631,16 @@ class DeltaSharingReader:
         batch: pa.RecordBatch,
         action: FileAction,
         schema_json: dict,
-        output_names: List[str],
     ) -> pa.RecordBatch:
         columns = []
         names = []
         lower_to_index = {name.lower(): index for index, name in enumerate(batch.schema.names)}
         num_rows = batch.num_rows
 
-        for field, output_name in zip(schema_json["fields"], output_names):
+        for field in schema_json["fields"]:
             field_name = field["name"]
             lower_name = field_name.lower()
-            names.append(output_name)
+            names.append(field_name)
             field_type = to_arrow_type(field["type"])
 
             if lower_name in lower_to_index:

--- a/python/delta_sharing/tests/test_converter.py
+++ b/python/delta_sharing/tests/test_converter.py
@@ -20,9 +20,10 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 
-from delta_sharing.converter import to_converter, get_empty_table
+from delta_sharing.converter import get_empty_table, to_arrow_schema, to_converter
 
 
 def test_to_converter_boolean():
@@ -86,3 +87,73 @@ def test_get_empty_table():
     assert pdf.columns.values.size == 2
     assert pdf.columns.values[0] == "a"
     assert pdf.columns.values[1] == "b"
+
+
+def test_to_arrow_schema():
+    schema_json = {
+        "type": "struct",
+        "fields": [
+            {"name": "boolean", "type": "boolean"},
+            {"name": "byte", "type": "byte"},
+            {"name": "short", "type": "short"},
+            {"name": "integer", "type": "integer"},
+            {"name": "long", "type": "long"},
+            {"name": "float", "type": "float"},
+            {"name": "double", "type": "double"},
+            {"name": "decimal", "type": "decimal(5,2)"},
+            {"name": "string", "type": "string"},
+            {"name": "date", "type": "date"},
+            {"name": "timestamp", "type": "timestamp"},
+            {"name": "binary", "type": "binary"},
+            {
+                "name": "array",
+                "type": {"type": "array", "elementType": "string"},
+            },
+            {
+                "name": "struct",
+                "type": {
+                    "type": "struct",
+                    "fields": [
+                        {"name": "nested_string", "type": "string"},
+                        {"name": "nested_integer", "type": "integer"},
+                    ],
+                },
+            },
+            {
+                "name": "map",
+                "type": {
+                    "type": "map",
+                    "keyType": "string",
+                    "valueType": "integer",
+                },
+            },
+        ],
+    }
+
+    assert to_arrow_schema(schema_json) == pa.schema(
+        [
+            pa.field("boolean", pa.bool_()),
+            pa.field("byte", pa.int8()),
+            pa.field("short", pa.int16()),
+            pa.field("integer", pa.int32()),
+            pa.field("long", pa.int64()),
+            pa.field("float", pa.float32()),
+            pa.field("double", pa.float64()),
+            pa.field("decimal", pa.decimal128(5, 2)),
+            pa.field("string", pa.string()),
+            pa.field("date", pa.date32()),
+            pa.field("timestamp", pa.timestamp("us", tz="UTC")),
+            pa.field("binary", pa.binary()),
+            pa.field("array", pa.list_(pa.string())),
+            pa.field(
+                "struct",
+                pa.struct(
+                    [
+                        pa.field("nested_string", pa.string()),
+                        pa.field("nested_integer", pa.int32()),
+                    ]
+                ),
+            ),
+            pa.field("map", pa.map_(pa.string(), pa.int32())),
+        ]
+    )

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -2093,10 +2093,11 @@ def test_load_table_changes_as_spark(
     "fragments",
     [pytest.param("share8.default.12k_rows")],
 )
-def test_load_as_pandas_delta_batch_convert(
+def test_load_snapshot_delta_batch_convert(
     profile_path: str,
     fragments: str,
 ):
+    url = f"{profile_path}#{fragments}"
     ids = list(range(12000))
     expected = pd.DataFrame(
         {
@@ -2109,21 +2110,19 @@ def test_load_as_pandas_delta_batch_convert(
     expected["time"] = expected["time"].astype("datetime64[us, UTC]")
 
     pdf = (
-        load_as_pandas(
-            f"{profile_path}#{fragments}", use_delta_format=True, convert_in_batches=True
-        )
+        load_as_pandas(url, use_delta_format=True, convert_in_batches=True)
         .sort_values(by="id")
         .reset_index(drop=True)
     )
     pd.testing.assert_frame_equal(pdf, expected)
-    pdf = load_as_pandas(
-        f"{profile_path}#{fragments}", use_delta_format=True, convert_in_batches=True, limit=500
-    )
-    assert len(pdf) == 500
-    pdf = load_as_pandas(
-        f"{profile_path}#{fragments}", use_delta_format=True, convert_in_batches=True, limit=3000
-    )
-    assert len(pdf) == 3000
+    arrow_table = load_as_arrow(url, use_delta_format=True).sort_by([("id", "ascending")])
+    _assert_arrow_matches_pandas(pdf, arrow_table)
+
+    for limit in (500, 3000):
+        pdf = load_as_pandas(url, use_delta_format=True, convert_in_batches=True, limit=limit)
+        assert len(pdf) == limit
+        arrow_table = load_as_arrow(url, use_delta_format=True, limit=limit)
+        assert arrow_table.num_rows == limit
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -203,7 +203,7 @@ def test_sharing_client_table(profile: DeltaSharingProfile):
     assert isinstance(table_from_string.changes(starting_version=0), TableChanges)
 
 
-def test_delta_sharing_table_snapshot_to_pandas(tmp_path):
+def test_delta_sharing_table_snapshot_materializers(tmp_path):
     expected = pd.DataFrame({"value": [1, 2], "label": ["a", "b"]})
     parquet_path = tmp_path / "snapshot.parquet"
     expected.to_parquet(parquet_path)
@@ -1063,7 +1063,7 @@ def test_load_as_pandas_success_client_delta_kernel_enabled_with_normal_table(
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 @pytest.mark.parametrize("use_delta_format", [None, True, False])
-def test_load_as_pandas_legacy_and_table_handle_match(
+def test_snapshot_legacy_and_table_handle_materializers_match(
     profile_path: str, profile: DeltaSharingProfile, use_delta_format: Optional[bool]
 ):
     fragments = "share1.default.table1"

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -66,14 +66,28 @@ def _normalize_snapshot_pdf_for_comparison(pdf: pd.DataFrame) -> pd.DataFrame:
     for column in normalized.columns:
         if isinstance(normalized[column].dtype, pd.DatetimeTZDtype):
             normalized[column] = normalized[column].dt.tz_convert("UTC").dt.tz_localize(None)
+        if normalized[column].isna().any():
+            # Treat pandas None and Arrow-derived NaN as the same Delta null.
+            normalized[column] = (
+                normalized[column].astype(object).where(normalized[column].notna(), None)
+            )
     return normalized
 
 
-def _assert_arrow_matches_pandas(pdf: pd.DataFrame, arrow_table: pa.Table) -> None:
+def _assert_arrow_matches_pandas(
+    pdf: pd.DataFrame,
+    arrow_table: pa.Table,
+    *,
+    sort_by: Optional[Sequence[str]] = None,
+) -> None:
     # Arrow follows logical Delta dtypes and uses UTC-aware Delta timestamps, while
     # the legacy pandas path may preserve parquet dtypes and naive UTC timestamps.
+    arrow_pdf = arrow_table.to_pandas()
+    if sort_by is not None:
+        pdf = pdf.sort_values(by=sort_by).reset_index(drop=True)
+        arrow_pdf = arrow_pdf.sort_values(by=sort_by).reset_index(drop=True)
     pd.testing.assert_frame_equal(
-        _normalize_snapshot_pdf_for_comparison(arrow_table.to_pandas()),
+        _normalize_snapshot_pdf_for_comparison(arrow_pdf),
         _normalize_snapshot_pdf_for_comparison(pdf),
         check_dtype=False,
     )
@@ -2305,17 +2319,27 @@ def test_add_column_non_partitioned(
     version: Optional[int],
     expected: pd.DataFrame,
 ):
-    pdf = load_as_pandas(f"{profile_path}#{fragments}", version=version, use_delta_format=False)
+    url = f"{profile_path}#{fragments}"
+    sort_by = ["c1"]
+    pdf = load_as_pandas(url, version=version, use_delta_format=False)
     # sort to eliminate row order inconsistencies
-    pdf = pdf.sort_values(by="c1").reset_index(drop=True)
+    pdf = pdf.sort_values(by=sort_by).reset_index(drop=True)
     # check_dtype=False to deal with minor type discrepancies like float32 vs float64
     pd.testing.assert_frame_equal(pdf, expected, check_dtype=False)
-
-    pdf_delta = load_as_pandas(
-        f"{profile_path}#{fragments}", version=version, use_delta_format=True
+    _assert_arrow_matches_pandas(
+        pdf,
+        load_as_arrow(url, version=version, use_delta_format=False),
+        sort_by=sort_by,
     )
-    pdf_delta = pdf_delta.sort_values(by="c1").reset_index(drop=True)
+
+    pdf_delta = load_as_pandas(url, version=version, use_delta_format=True)
+    pdf_delta = pdf_delta.sort_values(by=sort_by).reset_index(drop=True)
     pd.testing.assert_frame_equal(pdf_delta, expected, check_dtype=False)
+    _assert_arrow_matches_pandas(
+        pdf_delta,
+        load_as_arrow(url, version=version, use_delta_format=True),
+        sort_by=sort_by,
+    )
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
@@ -2449,17 +2473,27 @@ def test_add_column_partitioned(
     version: Optional[int],
     expected: pd.DataFrame,
 ):
-    pdf = load_as_pandas(f"{profile_path}#{fragments}", version=version, use_delta_format=False)
+    url = f"{profile_path}#{fragments}"
+    sort_by = ["p1", "p2", "c1"]
+    pdf = load_as_pandas(url, version=version, use_delta_format=False)
     # sort to eliminate row order inconsistencies
-    pdf = pdf.sort_values(by=["p1", "p2", "c1"]).reset_index(drop=True)
+    pdf = pdf.sort_values(by=sort_by).reset_index(drop=True)
     # check_dtype=False to deal with minor type discrepancies like float32 vs float64
     pd.testing.assert_frame_equal(pdf, expected, check_dtype=False)
-
-    pdf_delta = load_as_pandas(
-        f"{profile_path}#{fragments}", version=version, use_delta_format=True
+    _assert_arrow_matches_pandas(
+        pdf,
+        load_as_arrow(url, version=version, use_delta_format=False),
+        sort_by=sort_by,
     )
-    pdf_delta = pdf_delta.sort_values(by=["p1", "p2", "c1"]).reset_index(drop=True)
+
+    pdf_delta = load_as_pandas(url, version=version, use_delta_format=True)
+    pdf_delta = pdf_delta.sort_values(by=sort_by).reset_index(drop=True)
     pd.testing.assert_frame_equal(pdf_delta, expected, check_dtype=False)
+    _assert_arrow_matches_pandas(
+        pdf_delta,
+        load_as_arrow(url, version=version, use_delta_format=True),
+        sort_by=sort_by,
+    )
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -255,15 +255,20 @@ def test_delta_sharing_table_snapshot_to_pandas(tmp_path):
         Table(name="table", share="share", schema="schema"),
         RestClientMock(),
     )
-    result = table.snapshot(
+    snapshot = table.snapshot(
         limit=10,
         version=2,
         timestamp="2024-01-01T00:00:00Z",
         jsonPredicateHints='{"op":"equal"}',
         use_delta_format=False,
-    ).to_pandas(convert_in_batches=True)
+    )
+    result = snapshot.to_pandas(convert_in_batches=True)
 
     pd.testing.assert_frame_equal(result, expected)
+    arrow_table = snapshot.to_arrow()
+    pd.testing.assert_frame_equal(arrow_table.to_pandas(), expected)
+    assert pa.Table.from_batches(list(snapshot.to_record_batches())).equals(arrow_table)
+    assert snapshot.to_record_batch_reader().read_all().equals(arrow_table)
     assert captured == {
         "table": Table(name="table", share="share", schema="schema"),
         "predicateHints": None,
@@ -272,49 +277,6 @@ def test_delta_sharing_table_snapshot_to_pandas(tmp_path):
         "version": 2,
         "timestamp": "2024-01-01T00:00:00Z",
     }
-
-
-def test_delta_sharing_table_snapshot_to_arrow():
-    class RestClientMock:
-        def list_files_in_table(
-            self,
-            table: Table,
-            *,
-            predicateHints: Optional[Sequence[str]] = None,
-            jsonPredicateHints: Optional[str] = None,
-            limitHint: Optional[int] = None,
-            version: Optional[int] = None,
-            timestamp: Optional[str] = None,
-        ) -> ListFilesInTableResponse:
-            assert table == Table(name="table", share="share", schema="schema")
-            return ListFilesInTableResponse(
-                delta_table_version=1,
-                protocol=None,
-                metadata=Metadata(
-                    schema_string=(
-                        '{"fields":['
-                        '{"metadata":{},"name":"value","nullable":true,"type":"long"},'
-                        '{"metadata":{},"name":"label","nullable":true,"type":"string"}'
-                        '],"type":"struct"}'
-                    )
-                ),
-                add_files=[],
-                lines=[],
-            )
-
-    table = DeltaSharingTable(
-        Table(name="table", share="share", schema="schema"),
-        RestClientMock(),
-    )
-    snapshot = table.snapshot(use_delta_format=False)
-    expected = pa.Table.from_arrays(
-        [pa.array([], type=pa.int64()), pa.array([], type=pa.string())],
-        names=["value", "label"],
-    )
-
-    assert snapshot.to_arrow().equals(expected)
-    assert list(snapshot.to_record_batches()) == []
-    assert snapshot.to_record_batch_reader().read_all().equals(expected)
 
 
 def test_delta_sharing_table_changes_to_pandas(tmp_path):
@@ -1117,26 +1079,15 @@ def test_load_as_pandas_legacy_and_table_handle_match(
     )
 
     pd.testing.assert_frame_equal(legacy_pdf, table_pdf)
-
-
-@pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
-@pytest.mark.parametrize("use_delta_format", [None, True, False])
-def test_load_as_arrow_legacy_and_table_handle_match(
-    profile_path: str, profile: DeltaSharingProfile, use_delta_format: Optional[bool]
-):
-    fragments = "share1.default.table1"
-    limit = 2
-
     legacy_table = load_as_arrow(
         f"{profile_path}#{fragments}", limit=limit, use_delta_format=use_delta_format
     )
-
-    client = SharingClient(profile)
     table_arrow = (
         client.table(fragments).snapshot(limit=limit, use_delta_format=use_delta_format).to_arrow()
     )
 
     assert legacy_table.equals(table_arrow)
+    pd.testing.assert_frame_equal(legacy_table.to_pandas(), legacy_pdf)
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -17,6 +17,7 @@ from datetime import date, datetime
 from typing import Optional, Sequence
 
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 from delta_sharing.delta_sharing import (
@@ -28,6 +29,7 @@ from delta_sharing.delta_sharing import (
     get_table_metadata,
     get_table_protocol,
     get_table_version,
+    load_as_arrow,
     load_as_pandas,
     load_as_spark,
     load_table_changes_as_spark,
@@ -270,6 +272,49 @@ def test_delta_sharing_table_snapshot_to_pandas(tmp_path):
         "version": 2,
         "timestamp": "2024-01-01T00:00:00Z",
     }
+
+
+def test_delta_sharing_table_snapshot_to_arrow():
+    class RestClientMock:
+        def list_files_in_table(
+            self,
+            table: Table,
+            *,
+            predicateHints: Optional[Sequence[str]] = None,
+            jsonPredicateHints: Optional[str] = None,
+            limitHint: Optional[int] = None,
+            version: Optional[int] = None,
+            timestamp: Optional[str] = None,
+        ) -> ListFilesInTableResponse:
+            assert table == Table(name="table", share="share", schema="schema")
+            return ListFilesInTableResponse(
+                delta_table_version=1,
+                protocol=None,
+                metadata=Metadata(
+                    schema_string=(
+                        '{"fields":['
+                        '{"metadata":{},"name":"value","nullable":true,"type":"long"},'
+                        '{"metadata":{},"name":"label","nullable":true,"type":"string"}'
+                        '],"type":"struct"}'
+                    )
+                ),
+                add_files=[],
+                lines=[],
+            )
+
+    table = DeltaSharingTable(
+        Table(name="table", share="share", schema="schema"),
+        RestClientMock(),
+    )
+    snapshot = table.snapshot(use_delta_format=False)
+    expected = pa.Table.from_arrays(
+        [pa.array([], type=pa.int64()), pa.array([], type=pa.string())],
+        names=["value", "label"],
+    )
+
+    assert snapshot.to_arrow().equals(expected)
+    assert list(snapshot.to_record_batches()) == []
+    assert snapshot.to_record_batch_reader().read_all().equals(expected)
 
 
 def test_delta_sharing_table_changes_to_pandas(tmp_path):
@@ -1072,6 +1117,26 @@ def test_load_as_pandas_legacy_and_table_handle_match(
     )
 
     pd.testing.assert_frame_equal(legacy_pdf, table_pdf)
+
+
+@pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
+@pytest.mark.parametrize("use_delta_format", [None, True, False])
+def test_load_as_arrow_legacy_and_table_handle_match(
+    profile_path: str, profile: DeltaSharingProfile, use_delta_format: Optional[bool]
+):
+    fragments = "share1.default.table1"
+    limit = 2
+
+    legacy_table = load_as_arrow(
+        f"{profile_path}#{fragments}", limit=limit, use_delta_format=use_delta_format
+    )
+
+    client = SharingClient(profile)
+    table_arrow = (
+        client.table(fragments).snapshot(limit=limit, use_delta_format=use_delta_format).to_arrow()
+    )
+
+    assert legacy_table.equals(table_arrow)
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 from datetime import date, datetime
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple
 
 import pandas as pd
 import pyarrow as pa
@@ -79,7 +79,7 @@ def _assert_arrow_matches_pandas(
     arrow_table: pa.Table,
     *,
     sort_by: Optional[Sequence[str]] = None,
-) -> None:
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
     # Arrow follows logical Delta dtypes and uses UTC-aware Delta timestamps, while
     # the legacy pandas path may preserve parquet dtypes and naive UTC timestamps.
     arrow_pdf = arrow_table.to_pandas()
@@ -91,6 +91,7 @@ def _assert_arrow_matches_pandas(
         _normalize_snapshot_pdf_for_comparison(pdf),
         check_dtype=False,
     )
+    return pdf, arrow_pdf
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
@@ -2336,24 +2337,21 @@ def test_add_column_non_partitioned(
     url = f"{profile_path}#{fragments}"
     sort_by = ["c1"]
     pdf = load_as_pandas(url, version=version, use_delta_format=False)
-    # sort to eliminate row order inconsistencies
-    pdf = pdf.sort_values(by=sort_by).reset_index(drop=True)
-    # check_dtype=False to deal with minor type discrepancies like float32 vs float64
-    pd.testing.assert_frame_equal(pdf, expected, check_dtype=False)
-    _assert_arrow_matches_pandas(
+    pdf, _ = _assert_arrow_matches_pandas(
         pdf,
         load_as_arrow(url, version=version, use_delta_format=False),
         sort_by=sort_by,
     )
+    # check_dtype=False to deal with minor type discrepancies like float32 vs float64
+    pd.testing.assert_frame_equal(pdf, expected, check_dtype=False)
 
     pdf_delta = load_as_pandas(url, version=version, use_delta_format=True)
-    pdf_delta = pdf_delta.sort_values(by=sort_by).reset_index(drop=True)
-    pd.testing.assert_frame_equal(pdf_delta, expected, check_dtype=False)
-    _assert_arrow_matches_pandas(
+    pdf_delta, _ = _assert_arrow_matches_pandas(
         pdf_delta,
         load_as_arrow(url, version=version, use_delta_format=True),
         sort_by=sort_by,
     )
+    pd.testing.assert_frame_equal(pdf_delta, expected, check_dtype=False)
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
@@ -2490,24 +2488,21 @@ def test_add_column_partitioned(
     url = f"{profile_path}#{fragments}"
     sort_by = ["p1", "p2", "c1"]
     pdf = load_as_pandas(url, version=version, use_delta_format=False)
-    # sort to eliminate row order inconsistencies
-    pdf = pdf.sort_values(by=sort_by).reset_index(drop=True)
-    # check_dtype=False to deal with minor type discrepancies like float32 vs float64
-    pd.testing.assert_frame_equal(pdf, expected, check_dtype=False)
-    _assert_arrow_matches_pandas(
+    pdf, _ = _assert_arrow_matches_pandas(
         pdf,
         load_as_arrow(url, version=version, use_delta_format=False),
         sort_by=sort_by,
     )
+    # check_dtype=False to deal with minor type discrepancies like float32 vs float64
+    pd.testing.assert_frame_equal(pdf, expected, check_dtype=False)
 
     pdf_delta = load_as_pandas(url, version=version, use_delta_format=True)
-    pdf_delta = pdf_delta.sort_values(by=sort_by).reset_index(drop=True)
-    pd.testing.assert_frame_equal(pdf_delta, expected, check_dtype=False)
-    _assert_arrow_matches_pandas(
+    pdf_delta, _ = _assert_arrow_matches_pandas(
         pdf_delta,
         load_as_arrow(url, version=version, use_delta_format=True),
         sort_by=sort_by,
     )
+    pd.testing.assert_frame_equal(pdf_delta, expected, check_dtype=False)
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -871,16 +871,18 @@ def test_load_snapshot_success(
         ),
     ],
 )
-def test_load_as_pandas_success_dv(
+def test_load_snapshot_success_dv(
     profile_path: str,
     fragments: str,
     limit: Optional[int],
     version: Optional[int],
     expected: pd.DataFrame,
 ):
-    pdf = load_as_pandas(f"{profile_path}#{fragments}", limit, version, None)
+    url = f"{profile_path}#{fragments}"
+    pdf = load_as_pandas(url, limit, version, None)
     expected["timestamp"] = expected["timestamp"].astype("datetime64[us, UTC]")
     pd.testing.assert_frame_equal(pdf, expected)
+    _assert_arrow_matches_pandas(pdf, load_as_arrow(url, limit, version, None))
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
@@ -948,16 +950,18 @@ def test_load_as_pandas_success_dv(
         ),
     ],
 )
-def test_load_as_pandas_success_cm(
+def test_load_snapshot_success_cm(
     profile_path: str,
     fragments: str,
     limit: Optional[int],
     version: Optional[int],
     expected: pd.DataFrame,
 ):
-    pdf = load_as_pandas(f"{profile_path}#{fragments}", limit, version, None)
+    url = f"{profile_path}#{fragments}"
+    pdf = load_as_pandas(url, limit, version, None)
     expected["eventTime"] = expected["eventTime"].astype("datetime64[us, UTC]")
     pd.testing.assert_frame_equal(pdf, expected)
+    _assert_arrow_matches_pandas(pdf, load_as_arrow(url, limit, version, None))
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
@@ -979,21 +983,26 @@ def test_load_as_pandas_success_cm(
         )
     ],
 )
-def test_load_as_pandas_success_dv_and_cm(
+def test_load_snapshot_success_dv_and_cm(
     profile_path: str,
     fragments: str,
     limit: Optional[int],
     version: Optional[int],
     expected: pd.DataFrame,
 ):
-    pdf = load_as_pandas(f"{profile_path}#{fragments}", limit, version, None)
+    url = f"{profile_path}#{fragments}"
+    pdf = load_as_pandas(url, limit, version, None)
     expected["rand"] = expected["rand"].astype("int32")
     expected["partition_col"] = expected["partition_col"].astype("int32")
     pd.testing.assert_frame_equal(pdf, expected)
+    _assert_arrow_matches_pandas(pdf, load_as_arrow(url, limit, version, None))
 
     # Test client specifying explicit delta format
-    pdf = load_as_pandas(f"{profile_path}#{fragments}", limit, version, None, None, True)
-    pd.testing.assert_frame_equal(pdf, expected)
+    pdf_delta = load_as_pandas(url, limit, version, use_delta_format=True)
+    pd.testing.assert_frame_equal(pdf_delta, expected)
+    _assert_arrow_matches_pandas(
+        pdf_delta, load_as_arrow(url, limit, version, use_delta_format=True)
+    )
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
@@ -1009,15 +1018,17 @@ def test_load_as_pandas_success_dv_and_cm(
         )
     ],
 )
-def test_load_as_pandas_success_empty_dv_and_cm(
+def test_load_snapshot_success_empty_dv_and_cm(
     profile_path: str,
     fragments: str,
     limit: Optional[int],
     version: Optional[int],
     expected: pd.DataFrame,
 ):
-    pdf = load_as_pandas(f"{profile_path}#{fragments}", limit, version, None)
+    url = f"{profile_path}#{fragments}"
+    pdf = load_as_pandas(url, limit, version, None)
     pd.testing.assert_frame_equal(pdf, expected)
+    _assert_arrow_matches_pandas(pdf, load_as_arrow(url, limit, version, None))
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -1298,19 +1298,23 @@ def test_load_snapshot_with_json_predicates(
         ),
     ],
 )
-def test_load_as_pandas_exception(
+@pytest.mark.parametrize(
+    "load_snapshot",
+    [
+        pytest.param(load_as_pandas, id="pandas"),
+        pytest.param(load_as_arrow, id="arrow"),
+    ],
+)
+def test_load_snapshot_exception(
     profile_path: str,
     fragments: str,
     version: Optional[int],
     timestamp: Optional[str],
     error: Optional[str],
+    load_snapshot,
 ):
-    try:
-        load_as_pandas(f"{profile_path}#{fragments}", None, version, timestamp)
-        assert False
-    except Exception as e:
-        assert isinstance(e, HTTPError)
-        assert error in str(e)
+    with pytest.raises(HTTPError, match=error):
+        load_snapshot(f"{profile_path}#{fragments}", version=version, timestamp=timestamp)
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
@@ -1326,18 +1330,28 @@ def test_load_as_pandas_exception(
         ),
     ],
 )
-def test_load_as_pandas_exception_client_delta_kernel_disabled_with_delta_table(
+@pytest.mark.parametrize(
+    "load_snapshot",
+    [
+        pytest.param(load_as_pandas, id="pandas"),
+        pytest.param(load_as_arrow, id="arrow"),
+    ],
+)
+def test_load_snapshot_exception_client_delta_kernel_disabled_with_delta_table(
     profile_path: str,
     fragments: str,
     version: Optional[int],
     timestamp: Optional[str],
     error: Optional[str],
+    load_snapshot,
 ):
-    try:
-        load_as_pandas(f"{profile_path}#{fragments}", None, version, timestamp, None, False)
-        assert False
-    except Exception as e:
-        assert error in str(e)
+    with pytest.raises(Exception, match=error):
+        load_snapshot(
+            f"{profile_path}#{fragments}",
+            version=version,
+            timestamp=timestamp,
+            use_delta_format=False,
+        )
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -1050,13 +1050,17 @@ def test_load_snapshot_success_empty_dv_and_cm(
         )
     ],
 )
-def test_load_as_pandas_success_timestampntz(
+def test_load_snapshot_success_timestampntz(
     profile_path: str, fragments: str, expected: pd.DataFrame
 ):
-    pdf = load_as_pandas(f"{profile_path}#{fragments}")
+    url = f"{profile_path}#{fragments}"
+    pdf = load_as_pandas(url)
     expected["time"] = expected["time"].values.astype("datetime64[us]")
     expected["id"] = expected["id"].astype("int32")
     pd.testing.assert_frame_equal(pdf, expected)
+    arrow_table = load_as_arrow(url)
+    assert arrow_table.schema.field("time").type == pa.timestamp("us")
+    _assert_arrow_matches_pandas(pdf, arrow_table)
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
@@ -1080,16 +1084,20 @@ def test_load_as_pandas_success_timestampntz(
         )
     ],
 )
-def test_load_as_pandas_success_client_delta_kernel_enabled_with_normal_table(
+def test_load_snapshot_success_client_delta_kernel_enabled_with_normal_table(
     profile_path: str,
     fragments: str,
     limit: Optional[int],
     version: Optional[int],
     expected: pd.DataFrame,
 ):
-    pdf = load_as_pandas(f"{profile_path}#{fragments}", limit, version, None, None, True)
+    url = f"{profile_path}#{fragments}"
+    pdf = load_as_pandas(url, limit, version, use_delta_format=True)
     expected["eventTime"] = expected["eventTime"].astype("datetime64[us, UTC]")
     pd.testing.assert_frame_equal(pdf, expected)
+    arrow_table = load_as_arrow(url, limit, version, use_delta_format=True)
+    assert arrow_table.schema.field("eventTime").type == pa.timestamp("us", tz="UTC")
+    _assert_arrow_matches_pandas(pdf, arrow_table)
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -1241,11 +1241,13 @@ def test_table_snapshot_materializers_on_real_table(profile: DeltaSharingProfile
         ),
     ],
 )
-def test_load_as_pandas_with_json_predicates(
+def test_load_snapshot_with_json_predicates(
     profile_path: str, fragments: str, jsonPredicateHints: Optional[str], expected: pd.DataFrame
 ):
-    pdf = load_as_pandas(f"{profile_path}#{fragments}", None, None, None, jsonPredicateHints)
+    url = f"{profile_path}#{fragments}"
+    pdf = load_as_pandas(url, jsonPredicateHints=jsonPredicateHints)
     pd.testing.assert_frame_equal(pdf, expected)
+    _assert_arrow_matches_pandas(pdf, load_as_arrow(url, jsonPredicateHints=jsonPredicateHints))
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -61,6 +61,24 @@ from requests.models import Response
 from requests.exceptions import HTTPError
 
 
+def _normalize_snapshot_pdf_for_comparison(pdf: pd.DataFrame) -> pd.DataFrame:
+    normalized = pdf.copy()
+    for column in normalized.columns:
+        if isinstance(normalized[column].dtype, pd.DatetimeTZDtype):
+            normalized[column] = normalized[column].dt.tz_convert("UTC").dt.tz_localize(None)
+    return normalized
+
+
+def _assert_arrow_matches_pandas(pdf: pd.DataFrame, arrow_table: pa.Table) -> None:
+    # Arrow follows logical Delta dtypes and uses UTC-aware Delta timestamps, while
+    # the legacy pandas path may preserve parquet dtypes and naive UTC timestamps.
+    pd.testing.assert_frame_equal(
+        _normalize_snapshot_pdf_for_comparison(arrow_table.to_pandas()),
+        _normalize_snapshot_pdf_for_comparison(pdf),
+        check_dtype=False,
+    )
+
+
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_list_shares(sharing_client: SharingClient):
     shares = sharing_client.list_shares()
@@ -741,15 +759,17 @@ def test_get_table_protocol(profile_path: str):
         ),
     ],
 )
-def test_load_as_pandas_success(
+def test_load_snapshot_success(
     profile_path: str,
     fragments: str,
     limit: Optional[int],
     version: Optional[int],
     expected: pd.DataFrame,
 ):
-    pdf = load_as_pandas(f"{profile_path}#{fragments}", limit, version, None)
+    url = f"{profile_path}#{fragments}"
+    pdf = load_as_pandas(url, limit, version, None)
     pd.testing.assert_frame_equal(pdf, expected)
+    _assert_arrow_matches_pandas(pdf, load_as_arrow(url, limit, version, None))
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
@@ -1087,11 +1107,11 @@ def test_snapshot_legacy_and_table_handle_materializers_match(
     )
 
     assert legacy_table.equals(table_arrow)
-    pd.testing.assert_frame_equal(legacy_table.to_pandas(), legacy_pdf)
+    _assert_arrow_matches_pandas(legacy_pdf, legacy_table)
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
-def test_table_snapshot_to_pandas_on_real_table(profile: DeltaSharingProfile):
+def test_table_snapshot_materializers_on_real_table(profile: DeltaSharingProfile):
     expected = pd.DataFrame(
         {
             "eventTime": [
@@ -1102,8 +1122,13 @@ def test_table_snapshot_to_pandas_on_real_table(profile: DeltaSharingProfile):
         }
     )
 
-    pdf = SharingClient(profile).table("share1.default.table1").snapshot(limit=2).to_pandas()
+    snapshot = SharingClient(profile).table("share1.default.table1").snapshot(limit=2)
+    pdf = snapshot.to_pandas()
     pd.testing.assert_frame_equal(pdf, expected)
+    arrow_table = snapshot.to_arrow()
+    _assert_arrow_matches_pandas(pdf, arrow_table)
+    assert pa.Table.from_batches(list(snapshot.to_record_batches())).equals(arrow_table)
+    assert snapshot.to_record_batch_reader().read_all().equals(arrow_table)
 
 
 # We will test predicates with the table share8.default.cdf_table_with_partition

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -285,55 +285,6 @@ def test_to_record_batches_delta_format_applies_limit(tmp_path):
     assert result.column("a").to_pylist() == [1, 2]
 
 
-def test_to_arrow_non_partitioned(tmp_path):
-    pdf1 = pd.DataFrame(
-        {
-            "a": [1, 2, 3],
-            "b": ["a", "b", "c"],
-            "ts": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]).tz_localize("UTC"),
-        }
-    )
-    pdf2 = pd.DataFrame(
-        {
-            "a": [4, 5, 6],
-            "b": ["d", "e", "f"],
-            "ts": pd.to_datetime(["2024-01-04", "2024-01-05", "2024-01-06"]).tz_localize("UTC"),
-        }
-    )
-    schema_string = (
-        '{"fields":['
-        '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
-        '{"metadata":{},"name":"b","nullable":true,"type":"string"},'
-        '{"metadata":{},"name":"ts","nullable":true,"type":"timestamp"}'
-        '],"type":"struct"}'
-    )
-
-    pdf1.to_parquet(tmp_path / "pdf1.parquet")
-    pdf2.to_parquet(tmp_path / "pdf2.parquet")
-
-    reader = DeltaSharingReader(
-        _TEST_TABLE,
-        _ListFilesRestClient(
-            _list_files_response(
-                [
-                    _add_file(tmp_path / "pdf1.parquet", "pdf1"),
-                    _add_file(tmp_path / "pdf2.parquet", "pdf2"),
-                ],
-                schema_string,
-            )
-        ),
-        limit=4,
-        use_delta_format=False,
-    )
-    result = reader.to_arrow()
-    expected = pa.Table.from_pandas(
-        pd.concat([pdf1, pdf2]).reset_index(drop=True).head(4), preserve_index=False
-    ).cast(result.schema)
-
-    assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
-    assert result.equals(expected)
-
-
 def test_to_arrow_naive_timestamps_normalized_to_utc(tmp_path):
     pdf = pd.DataFrame({"ts": pd.to_datetime(["2024-01-01", "2024-01-02"])})
     schema_string = (
@@ -504,6 +455,7 @@ def test_to_pandas_non_partitioned(tmp_path):
     pdf = reader.to_pandas()
     expected = pd.concat([pdf1, pdf2]).reset_index(drop=True)
     pd.testing.assert_frame_equal(pdf, expected)
+    pd.testing.assert_frame_equal(reader.to_arrow().to_pandas(), expected)
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True
@@ -595,6 +547,10 @@ def test_to_pandas_partitioned(tmp_path):
     expected = pd.concat([expected1, expected2]).reset_index(drop=True)
 
     pd.testing.assert_frame_equal(pdf, expected)
+    assert reader.to_arrow().to_pydict() == {
+        "A": [1, 2, 3, 4, 5, 6],
+        "B": ["x", "x", "x", "y", "y", "y"],
+    }
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True
@@ -669,6 +625,11 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
     expected = pd.concat([expected1, expected2])[["a", "b", "c"]].reset_index(drop=True)
 
     pd.testing.assert_frame_equal(pdf, expected)
+    assert reader.to_arrow().to_pydict() == {
+        "a": [1, 2, 3, 4, 5, 6],
+        "b": [None, None, None, "d", "e", "f"],
+        "c": [date(2021, 1, 1)] * 3 + [date(2021, 1, 2)] * 3,
+    }
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True
@@ -840,6 +801,13 @@ def test_to_pandas_empty(rest_client: DataSharingRestClient):
     expected = reader.to_pandas().iloc[0:0]
 
     pd.testing.assert_frame_equal(pdf, expected)
+
+    reader = DeltaSharingReader(
+        Table("table_name", "share_name", "schema_name"), RestClientMock()  # type: ignore
+    )
+    arrow_table = reader.to_arrow()
+    assert arrow_table.num_rows == 0
+    assert arrow_table.schema.names == list(pdf.columns)
 
 
 def test_table_changes_to_pandas_non_partitioned(tmp_path):

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -16,7 +16,7 @@
 import pytest
 
 from datetime import date
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple
 
 import pandas as pd
 import numpy as np
@@ -69,7 +69,7 @@ def _assert_snapshot_materializers(
     *,
     expected_arrow_pdf: Optional[pd.DataFrame] = None,
     check_arrow_dtype: bool = True,
-) -> pa.Table:
+) -> Tuple[pd.DataFrame, pa.Table]:
     pdf = reader.to_pandas()
     pd.testing.assert_frame_equal(pdf, expected)
 
@@ -79,7 +79,7 @@ def _assert_snapshot_materializers(
         pdf if expected_arrow_pdf is None else expected_arrow_pdf,
         check_dtype=check_arrow_dtype,
     )
-    return arrow_table
+    return pdf, arrow_table
 
 
 @pytest.mark.parametrize("materializer", ["to_pandas", "to_record_batches"])
@@ -525,7 +525,7 @@ def test_snapshot_partitioned_different_schemas(tmp_path):
 
     expected_arrow_pdf = expected.copy()
     expected_arrow_pdf["a"] = expected_arrow_pdf["a"].astype("int64")
-    arrow_table = _assert_snapshot_materializers(
+    _, arrow_table = _assert_snapshot_materializers(
         reader,
         expected,
         expected_arrow_pdf=expected_arrow_pdf,
@@ -707,7 +707,7 @@ def test_snapshot_empty(rest_client: DataSharingRestClient):
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock()  # type: ignore
     )
-    arrow_table = _assert_snapshot_materializers(
+    _, arrow_table = _assert_snapshot_materializers(
         reader,
         expected,
         check_arrow_dtype=False,

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -442,11 +442,9 @@ def test_snapshot_partitioned(tmp_path):
     expected2["B"] = "y"
     expected = pd.concat([expected1, expected2]).reset_index(drop=True)
 
-    _assert_snapshot_materializers(
-        reader,
-        expected,
-        expected_arrow_pdf=expected.rename(columns={"a": "A"}),
-    )
+    _, arrow_table = _assert_snapshot_materializers(reader, expected)
+    assert pa.Table.from_batches(list(reader.to_record_batches())).equals(arrow_table)
+    assert reader.to_record_batch_reader().read_all().equals(arrow_table)
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -43,34 +43,6 @@ _TEST_TABLE = Table("table_name", "share_name", "schema_name")
 _SCHEMA_A = (
     '{"type":"struct","fields":[' '{"metadata":{},"name":"a","nullable":true,"type":"long"}]}'
 )
-_SCHEMA_AB = (
-    '{"fields":['
-    '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
-    '{"metadata":{},"name":"b","nullable":true,"type":"string"}'
-    '],"type":"struct"}'
-)
-
-
-def _add_file(path, file_id, partition_values=None, timestamp=None, version=None):
-    return AddFile(
-        url=str(path),
-        id=file_id,
-        partition_values=partition_values or {},
-        size=0,
-        stats="",
-        timestamp=timestamp,
-        version=version,
-    )
-
-
-def _list_files_response(add_files, schema_string=_SCHEMA_AB, lines=None):
-    return ListFilesInTableResponse(
-        delta_table_version=1,
-        protocol=None,
-        metadata=Metadata(schema_string=schema_string),
-        add_files=add_files,
-        lines=[] if lines is None else lines,
-    )
 
 
 class _ListFilesRestClient:
@@ -91,43 +63,8 @@ class _ListFilesRestClient:
         return self._response
 
 
-def test_to_pandas_delta_format_removes_header_after_failure():
-    class RestClientMock:
-        delta_format_removed = False
-
-        def set_delta_format_header(self, for_cdf=False):
-            return
-
-        def list_files_in_table(
-            self,
-            table: Table,
-            *,
-            predicateHints: Optional[Sequence[str]] = None,
-            jsonPredicateHints: Optional[str] = None,
-            limitHint: Optional[int] = None,
-            version: Optional[int] = None,
-            timestamp: Optional[int] = None,
-        ) -> ListFilesInTableResponse:
-            assert table == Table("table_name", "share_name", "schema_name")
-            raise RuntimeError("list files failed")
-
-        def remove_delta_format_header(self):
-            self.delta_format_removed = True
-
-    rest_client = RestClientMock()
-    reader = DeltaSharingReader(
-        Table("table_name", "share_name", "schema_name"),
-        rest_client,
-        use_delta_format=True,
-    )
-
-    with pytest.raises(RuntimeError, match="list files failed"):
-        reader.to_pandas()
-
-    assert rest_client.delta_format_removed
-
-
-def test_to_record_batches_delta_format_removes_header_after_failure():
+@pytest.mark.parametrize("materializer", ["to_pandas", "to_record_batches"])
+def test_delta_format_removes_header_after_failure(materializer):
     class RestClientMock:
         delta_format_removed = False
 
@@ -158,7 +95,7 @@ def test_to_record_batches_delta_format_removes_header_after_failure():
     )
 
     with pytest.raises(RuntimeError, match="list files failed"):
-        reader.to_record_batches()
+        getattr(reader, materializer)()
 
     assert rest_client.delta_format_removed
 
@@ -286,108 +223,53 @@ def test_to_record_batches_delta_format_applies_limit(tmp_path):
 
 
 def test_to_arrow_naive_timestamps_normalized_to_utc(tmp_path):
-    pdf = pd.DataFrame({"ts": pd.to_datetime(["2024-01-01", "2024-01-02"])})
+    pdf1 = pd.DataFrame({"a": [1, 2], "ts": pd.to_datetime(["2024-01-01", "2024-01-02"])})
+    pdf2 = pd.DataFrame({"a": [3, 4]})
     schema_string = (
-        '{"fields":[{"metadata":{},"name":"ts","nullable":true,"type":"timestamp"}],'
+        '{"fields":['
+        '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
+        '{"metadata":{},"name":"ts","nullable":true,"type":"timestamp"}'
+        "],"
         '"type":"struct"}'
     )
 
-    pdf.to_parquet(tmp_path / "pdf.parquet")
+    pdf1.to_parquet(tmp_path / "pdf1.parquet")
+    pdf2.to_parquet(tmp_path / "pdf2.parquet")
+
+    response = ListFilesInTableResponse(
+        delta_table_version=1,
+        protocol=None,
+        metadata=Metadata(schema_string=schema_string),
+        add_files=[
+            AddFile(
+                url=str(tmp_path / "pdf1.parquet"),
+                id="pdf1",
+                partition_values={},
+                size=0,
+                stats="",
+            ),
+            AddFile(
+                url=str(tmp_path / "pdf2.parquet"),
+                id="pdf2",
+                partition_values={"ts": "2024-01-03"},
+                size=0,
+                stats="",
+            ),
+        ],
+        lines=[],
+    )
 
     reader = DeltaSharingReader(
         _TEST_TABLE,
-        _ListFilesRestClient(
-            _list_files_response([_add_file(tmp_path / "pdf.parquet", "pdf")], schema_string)
-        ),
+        _ListFilesRestClient(response),
         use_delta_format=False,
     )
     result = reader.to_arrow()
 
     assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
-    assert result.column("ts").to_pylist() == list(pdf["ts"].dt.tz_localize("UTC"))
-
-
-def test_to_record_batches_partitioned(tmp_path):
-    pdf1 = pd.DataFrame({"a": [1, 2, 3]})
-    pdf2 = pd.DataFrame({"a": [4, 5, 6]})
-
-    pdf1.to_parquet(tmp_path / "pdf1.parquet")
-    pdf2.to_parquet(tmp_path / "pdf2.parquet")
-    response = _list_files_response(
-        [
-            _add_file(tmp_path / "pdf1.parquet", "pdf1", {"b": "x"}),
-            _add_file(tmp_path / "pdf2.parquet", "pdf2", {"b": "y"}),
-        ]
-    )
-
-    reader = DeltaSharingReader(
-        _TEST_TABLE,
-        _ListFilesRestClient(response),
-        limit=4,
-        use_delta_format=False,
-    )
-    batches = list(reader.to_record_batches())
-    result = pa.Table.from_batches(batches)
-
-    expected1 = pdf1.copy()
-    expected1["b"] = "x"
-    expected2 = pdf2.copy()
-    expected2["b"] = "y"
-    expected = pa.Table.from_pandas(
-        pd.concat([expected1, expected2]).reset_index(drop=True).head(4),
-        preserve_index=False,
-    )
-
-    assert [batch.num_rows for batch in batches] == [3, 1]
-    assert result.equals(expected)
-
-    reader = DeltaSharingReader(
-        _TEST_TABLE,
-        _ListFilesRestClient(response),
-        use_delta_format=False,
-    )
-    assert (
-        reader.to_record_batch_reader()
-        .read_all()
-        .equals(
-            pa.Table.from_pandas(
-                pd.concat([expected1, expected2]).reset_index(drop=True),
-                preserve_index=False,
-            )
-        )
-    )
-
-
-def test_to_record_batches_preserves_schema_order_with_partition_column(tmp_path):
-    pdf = pd.DataFrame({"a": [1, 2], "c": ["x", "y"]})
-    pdf.to_parquet(tmp_path / "data.parquet")
-    schema_string = (
-        '{"fields":['
-        '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
-        '{"metadata":{},"name":"b","nullable":true,"type":"string"},'
-        '{"metadata":{},"name":"c","nullable":true,"type":"string"}'
-        '],"type":"struct"}'
-    )
-
-    reader = DeltaSharingReader(
-        _TEST_TABLE,
-        _ListFilesRestClient(
-            _list_files_response(
-                [_add_file(tmp_path / "data.parquet", "data", {"b": "partition"})],
-                schema_string,
-            )
-        ),
-        use_delta_format=False,
-    )
-
-    result = pa.Table.from_batches(list(reader.to_record_batches()))
-
-    assert result.schema.names == ["a", "b", "c"]
-    assert result.to_pydict() == {
-        "a": [1, 2],
-        "b": ["partition", "partition"],
-        "c": ["x", "y"],
-    }
+    assert result.column("ts").to_pylist() == list(pdf1["ts"].dt.tz_localize("UTC")) + [
+        pd.Timestamp("2024-01-03", tz="UTC")
+    ] * len(pdf2)
 
 
 def test_to_pandas_non_partitioned(tmp_path):
@@ -547,10 +429,9 @@ def test_to_pandas_partitioned(tmp_path):
     expected = pd.concat([expected1, expected2]).reset_index(drop=True)
 
     pd.testing.assert_frame_equal(pdf, expected)
-    assert reader.to_arrow().to_pydict() == {
-        "A": [1, 2, 3, 4, 5, 6],
-        "B": ["x", "x", "x", "y", "y", "y"],
-    }
+    pd.testing.assert_frame_equal(
+        reader.to_arrow().to_pandas(), expected.rename(columns={"a": "A"})
+    )
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True
@@ -583,8 +464,9 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
                 schema_string=(
                     '{"fields":['
                     '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
+                    '{"metadata":{},"name":"c","nullable":true,"type":"date"},'
                     '{"metadata":{},"name":"b","nullable":true,"type":"string"},'
-                    '{"metadata":{},"name":"c","nullable":true,"type":"date"}'
+                    '{"metadata":{},"name":"d","nullable":true,"type":"integer"}'
                     '],"type":"struct"}'
                 )
             )
@@ -592,14 +474,14 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
                 AddFile(
                     url=str(tmp_path / "pdf1.parquet"),
                     id="pdf1",
-                    partition_values={"c": "2021-01-01"},
+                    partition_values={"c": "2021-01-01", "d": "1"},
                     size=0,
                     stats="",
                 ),
                 AddFile(
                     url=str(tmp_path / "pdf2.parquet"),
                     id="pdf2",
-                    partition_values={"c": "2021-01-02"},
+                    partition_values={"c": "2021-01-02", "d": "2"},
                     size=0,
                     stats="",
                 ),
@@ -620,16 +502,26 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
 
     expected1 = pdf1.copy()
     expected1["c"] = date(2021, 1, 1)
+    expected1["d"] = np.int32(1)
     expected2 = pdf2.copy()
     expected2["c"] = date(2021, 1, 2)
-    expected = pd.concat([expected1, expected2])[["a", "b", "c"]].reset_index(drop=True)
+    expected2["d"] = np.int32(2)
+    expected = pd.concat([expected1, expected2])[["a", "c", "b", "d"]].reset_index(drop=True)
 
     pd.testing.assert_frame_equal(pdf, expected)
-    assert reader.to_arrow().to_pydict() == {
-        "a": [1, 2, 3, 4, 5, 6],
-        "b": [None, None, None, "d", "e", "f"],
-        "c": [date(2021, 1, 1)] * 3 + [date(2021, 1, 2)] * 3,
-    }
+    arrow_table = reader.to_arrow()
+    expected_arrow = expected.copy()
+    expected_arrow["a"] = expected_arrow["a"].astype("int64")
+    expected_arrow["b"] = expected_arrow["b"].where(expected_arrow["b"].notna(), None)
+    pd.testing.assert_frame_equal(arrow_table.to_pandas(), expected_arrow)
+    assert arrow_table.schema == pa.schema(
+        [
+            pa.field("a", pa.int64()),
+            pa.field("c", pa.date32()),
+            pa.field("b", pa.string()),
+            pa.field("d", pa.int32()),
+        ]
+    )
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True
@@ -714,6 +606,7 @@ def test_to_pandas_large_table_batch_convert(tmp_path):
     )
     pdf = reader.to_pandas()
     pd.testing.assert_frame_equal(pdf, expected_300k)
+    pd.testing.assert_frame_equal(reader.to_arrow().to_pandas(), expected_300k, check_dtype=False)
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -63,6 +63,25 @@ class _ListFilesRestClient:
         return self._response
 
 
+def _assert_snapshot_materializers(
+    reader: DeltaSharingReader,
+    expected: pd.DataFrame,
+    *,
+    expected_arrow_pdf: Optional[pd.DataFrame] = None,
+    check_arrow_dtype: bool = True,
+) -> pa.Table:
+    pdf = reader.to_pandas()
+    pd.testing.assert_frame_equal(pdf, expected)
+
+    arrow_table = reader.to_arrow()
+    pd.testing.assert_frame_equal(
+        arrow_table.to_pandas(),
+        pdf if expected_arrow_pdf is None else expected_arrow_pdf,
+        check_dtype=check_arrow_dtype,
+    )
+    return arrow_table
+
+
 @pytest.mark.parametrize("materializer", ["to_pandas", "to_record_batches"])
 def test_delta_format_removes_header_after_failure(materializer):
     class RestClientMock:
@@ -334,10 +353,8 @@ def test_snapshot_non_partitioned(tmp_path):
             return "parquet"
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
-    pdf = reader.to_pandas()
     expected = pd.concat([pdf1, pdf2]).reset_index(drop=True)
-    pd.testing.assert_frame_equal(pdf, expected)
-    pd.testing.assert_frame_equal(reader.to_arrow().to_pandas(), expected)
+    _assert_snapshot_materializers(reader, expected)
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True
@@ -350,18 +367,16 @@ def test_snapshot_non_partitioned(tmp_path):
         RestClientMock(),
         jsonPredicateHints="dummy_hints",
     )
-    pdf = reader.to_pandas()
     expected = pd.concat([pdf1]).reset_index(drop=True)
-    pd.testing.assert_frame_equal(pdf, expected)
+    _assert_snapshot_materializers(reader, expected)
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"),
         RestClientMock(),
         predicateHints="dummy_hints",
     )
-    pdf = reader.to_pandas()
     expected = pd.concat([pdf2]).reset_index(drop=True)
-    pd.testing.assert_frame_equal(pdf, expected)
+    _assert_snapshot_materializers(reader, expected)
 
 
 def test_snapshot_partitioned(tmp_path):
@@ -420,7 +435,6 @@ def test_snapshot_partitioned(tmp_path):
             return "parquet"
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
-    pdf = reader.to_pandas()
 
     expected1 = pdf1.copy()
     expected1["B"] = "x"
@@ -428,9 +442,10 @@ def test_snapshot_partitioned(tmp_path):
     expected2["B"] = "y"
     expected = pd.concat([expected1, expected2]).reset_index(drop=True)
 
-    pd.testing.assert_frame_equal(pdf, expected)
-    pd.testing.assert_frame_equal(
-        reader.to_arrow().to_pandas(), expected.rename(columns={"a": "A"})
+    _assert_snapshot_materializers(
+        reader,
+        expected,
+        expected_arrow_pdf=expected.rename(columns={"a": "A"}),
     )
 
     reader = DeltaSharingReader(
@@ -498,7 +513,6 @@ def test_snapshot_partitioned_different_schemas(tmp_path):
             return "parquet"
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
-    pdf = reader.to_pandas()
 
     expected1 = pdf1.copy()
     expected1["c"] = date(2021, 1, 1)
@@ -507,13 +521,15 @@ def test_snapshot_partitioned_different_schemas(tmp_path):
     expected2["c"] = date(2021, 1, 2)
     expected2["d"] = np.int32(2)
     expected = pd.concat([expected1, expected2])[["a", "c", "b", "d"]].reset_index(drop=True)
+    expected["b"] = expected["b"].astype(object).where(expected["b"].notna(), None)
 
-    pd.testing.assert_frame_equal(pdf, expected)
-    arrow_table = reader.to_arrow()
-    expected_arrow = expected.copy()
-    expected_arrow["a"] = expected_arrow["a"].astype("int64")
-    expected_arrow["b"] = expected_arrow["b"].where(expected_arrow["b"].notna(), None)
-    pd.testing.assert_frame_equal(arrow_table.to_pandas(), expected_arrow)
+    expected_arrow_pdf = expected.copy()
+    expected_arrow_pdf["a"] = expected_arrow_pdf["a"].astype("int64")
+    arrow_table = _assert_snapshot_materializers(
+        reader,
+        expected,
+        expected_arrow_pdf=expected_arrow_pdf,
+    )
     assert arrow_table.schema == pa.schema(
         [
             pa.field("a", pa.int64()),
@@ -531,8 +547,12 @@ def test_snapshot_partitioned_different_schemas(tmp_path):
 
 
 def test_snapshot_large_table(tmp_path):
-    pdf1 = pd.DataFrame(np.random.randint(0, 100, size=(200000, 4)), columns=list("abcd"))
-    pdf2 = pd.DataFrame(np.random.randint(0, 100, size=(200000, 4)), columns=list("abcd"))
+    pdf1 = pd.DataFrame(
+        np.random.randint(0, 100, size=(200000, 4), dtype=np.int32), columns=list("abcd")
+    )
+    pdf2 = pd.DataFrame(
+        np.random.randint(0, 100, size=(200000, 4), dtype=np.int32), columns=list("abcd")
+    )
 
     pdf1.to_parquet(tmp_path / "pdf1.parquet")
     pdf2.to_parquet(tmp_path / "pdf2.parquet")
@@ -592,21 +612,17 @@ def test_snapshot_large_table(tmp_path):
     expected_300k = pd.concat([pdf1, pdf2.head(100000)]).reset_index(drop=True)
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
-    pdf = reader.to_pandas()
-    pd.testing.assert_frame_equal(pdf, expected)
+    _assert_snapshot_materializers(reader, expected)
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), limit=100000
     )
-    pdf = reader.to_pandas()
-    pd.testing.assert_frame_equal(pdf, expected_100k)
+    _assert_snapshot_materializers(reader, expected_100k)
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), limit=300000
     )
-    pdf = reader.to_pandas()
-    pd.testing.assert_frame_equal(pdf, expected_300k)
-    pd.testing.assert_frame_equal(reader.to_arrow().to_pandas(), expected_300k, check_dtype=False)
+    _assert_snapshot_materializers(reader, expected_300k)
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True
@@ -685,22 +701,19 @@ def test_snapshot_empty(rest_client: DataSharingRestClient):
         def autoresolve_query_format(self, table: Table):
             return "parquet"
 
-    reader = DeltaSharingReader(
-        Table("table_name", "share_name", "schema_name"), RestClientMock()  # type: ignore
-    )
-    pdf = reader.to_pandas()
-
     reader = DeltaSharingReader(Table(name="table7", share="share1", schema="default"), rest_client)
     expected = reader.to_pandas().iloc[0:0]
 
-    pd.testing.assert_frame_equal(pdf, expected)
-
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock()  # type: ignore
     )
-    arrow_table = reader.to_arrow()
+    arrow_table = _assert_snapshot_materializers(
+        reader,
+        expected,
+        check_arrow_dtype=False,
+    )
     assert arrow_table.num_rows == 0
-    assert arrow_table.schema.names == list(pdf.columns)
+    assert arrow_table.schema.names == list(expected.columns)
 
 
 def test_table_changes_to_pandas_non_partitioned(tmp_path):

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -272,7 +272,7 @@ def test_to_arrow_naive_timestamps_normalized_to_utc(tmp_path):
     ] * len(pdf2)
 
 
-def test_to_pandas_non_partitioned(tmp_path):
+def test_snapshot_non_partitioned(tmp_path):
     pdf1 = pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
     pdf2 = pd.DataFrame({"a": [4, 5, 6], "b": ["d", "e", "f"]})
 
@@ -364,7 +364,7 @@ def test_to_pandas_non_partitioned(tmp_path):
     pd.testing.assert_frame_equal(pdf, expected)
 
 
-def test_to_pandas_partitioned(tmp_path):
+def test_snapshot_partitioned(tmp_path):
     pdf1 = pd.DataFrame({"a": [1, 2, 3]})
     pdf2 = pd.DataFrame({"a": [4, 5, 6]})
 
@@ -440,7 +440,7 @@ def test_to_pandas_partitioned(tmp_path):
     pd.testing.assert_frame_equal(pdf, expected)
 
 
-def test_to_pandas_partitioned_different_schemas(tmp_path):
+def test_snapshot_partitioned_different_schemas(tmp_path):
     pdf1 = pd.DataFrame({"a": [1, 2, 3]})
     pdf2 = pd.DataFrame({"a": [4.0, 5.0, 6.0], "b": ["d", "e", "f"]})
 
@@ -530,7 +530,7 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
     pd.testing.assert_frame_equal(pdf, expected)
 
 
-def test_to_pandas_large_table_batch_convert(tmp_path):
+def test_snapshot_large_table(tmp_path):
     pdf1 = pd.DataFrame(np.random.randint(0, 100, size=(200000, 4)), columns=list("abcd"))
     pdf2 = pd.DataFrame(np.random.randint(0, 100, size=(200000, 4)), columns=list("abcd"))
 
@@ -634,7 +634,7 @@ def test_to_pandas_large_table_batch_convert(tmp_path):
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
-def test_to_pandas_empty(rest_client: DataSharingRestClient):
+def test_snapshot_empty(rest_client: DataSharingRestClient):
     class RestClientMock:
         def list_files_in_table(
             self,

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -20,8 +20,17 @@ from typing import Optional, Sequence
 
 import pandas as pd
 import numpy as np
+import pyarrow as pa
 
-from delta_sharing.protocol import AddFile, AddCdcFile, CdfOptions, Metadata, RemoveFile, Table
+from delta_sharing.protocol import (
+    AddFile,
+    AddCdcFile,
+    CdfOptions,
+    Metadata,
+    Protocol,
+    RemoveFile,
+    Table,
+)
 from delta_sharing.reader import DeltaSharingReader
 from delta_sharing.rest_client import (
     ListFilesInTableResponse,
@@ -29,6 +38,57 @@ from delta_sharing.rest_client import (
     DataSharingRestClient,
 )
 from delta_sharing.tests.conftest import ENABLE_INTEGRATION, SKIP_MESSAGE
+
+_TEST_TABLE = Table("table_name", "share_name", "schema_name")
+_SCHEMA_A = (
+    '{"type":"struct","fields":[' '{"metadata":{},"name":"a","nullable":true,"type":"long"}]}'
+)
+_SCHEMA_AB = (
+    '{"fields":['
+    '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
+    '{"metadata":{},"name":"b","nullable":true,"type":"string"}'
+    '],"type":"struct"}'
+)
+
+
+def _add_file(path, file_id, partition_values=None, timestamp=None, version=None):
+    return AddFile(
+        url=str(path),
+        id=file_id,
+        partition_values=partition_values or {},
+        size=0,
+        stats="",
+        timestamp=timestamp,
+        version=version,
+    )
+
+
+def _list_files_response(add_files, schema_string=_SCHEMA_AB, lines=None):
+    return ListFilesInTableResponse(
+        delta_table_version=1,
+        protocol=None,
+        metadata=Metadata(schema_string=schema_string),
+        add_files=add_files,
+        lines=[] if lines is None else lines,
+    )
+
+
+class _ListFilesRestClient:
+    def __init__(self, response):
+        self._response = response
+
+    def list_files_in_table(
+        self,
+        table: Table,
+        *,
+        predicateHints: Optional[Sequence[str]] = None,
+        jsonPredicateHints: Optional[str] = None,
+        limitHint: Optional[int] = None,
+        version: Optional[int] = None,
+        timestamp: Optional[int] = None,
+    ) -> ListFilesInTableResponse:
+        assert table == _TEST_TABLE
+        return self._response
 
 
 def test_to_pandas_delta_format_removes_header_after_failure():
@@ -65,6 +125,318 @@ def test_to_pandas_delta_format_removes_header_after_failure():
         reader.to_pandas()
 
     assert rest_client.delta_format_removed
+
+
+def test_to_record_batches_delta_format_removes_header_after_failure():
+    class RestClientMock:
+        delta_format_removed = False
+
+        def set_delta_format_header(self, for_cdf=False):
+            return
+
+        def list_files_in_table(
+            self,
+            table: Table,
+            *,
+            predicateHints: Optional[Sequence[str]] = None,
+            jsonPredicateHints: Optional[str] = None,
+            limitHint: Optional[int] = None,
+            version: Optional[int] = None,
+            timestamp: Optional[int] = None,
+        ) -> ListFilesInTableResponse:
+            assert table == _TEST_TABLE
+            raise RuntimeError("list files failed")
+
+        def remove_delta_format_header(self):
+            self.delta_format_removed = True
+
+    rest_client = RestClientMock()
+    reader = DeltaSharingReader(
+        _TEST_TABLE,
+        rest_client,
+        use_delta_format=True,
+    )
+
+    with pytest.raises(RuntimeError, match="list files failed"):
+        reader.to_record_batches()
+
+    assert rest_client.delta_format_removed
+
+
+def test_to_record_batches_delta_format_removes_header_before_consumption():
+    escaped_schema_string = _SCHEMA_A.replace('"', '\\"')
+    lines = [
+        '{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}',
+        (
+            '{"metaData":{"deltaMetadata":{'
+            '"id":"id",'
+            '"format":{"provider":"parquet","options":{}},'
+            f'"schemaString":"{escaped_schema_string}",'
+            '"partitionColumns":[],'
+            '"configuration":{}'
+            "}}}"
+        ),
+    ]
+
+    class RestClientMock:
+        delta_format_removed = False
+
+        def set_delta_format_header(self, for_cdf=False):
+            assert not for_cdf
+
+        def list_files_in_table(
+            self,
+            table: Table,
+            *,
+            predicateHints: Optional[Sequence[str]] = None,
+            jsonPredicateHints: Optional[str] = None,
+            limitHint: Optional[int] = None,
+            version: Optional[int] = None,
+            timestamp: Optional[int] = None,
+        ) -> ListFilesInTableResponse:
+            assert table == _TEST_TABLE
+            return ListFilesInTableResponse(
+                delta_table_version=0,
+                protocol=Protocol(1),
+                metadata=Metadata(schema_string=_SCHEMA_A),
+                add_files=[],
+                lines=list(lines),
+            )
+
+        def remove_delta_format_header(self):
+            self.delta_format_removed = True
+
+    rest_client = RestClientMock()
+    reader = DeltaSharingReader(
+        _TEST_TABLE,
+        rest_client,
+        use_delta_format=True,
+    )
+
+    batches = reader.to_record_batches()
+
+    assert rest_client.delta_format_removed
+    assert list(batches) == []
+
+
+def test_to_record_batches_delta_format_applies_limit(tmp_path):
+    parquet_file = tmp_path / "data.parquet"
+    pd.DataFrame({"a": [1, 2, 3]}).to_parquet(parquet_file)
+
+    escaped_schema_string = _SCHEMA_A.replace('"', '\\"')
+    lines = [
+        '{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}',
+        (
+            '{"metaData":{"deltaMetadata":{'
+            '"id":"id",'
+            '"format":{"provider":"parquet","options":{}},'
+            f'"schemaString":"{escaped_schema_string}",'
+            '"partitionColumns":[],'
+            '"configuration":{}'
+            "}}}"
+        ),
+        (
+            '{"file":{"deltaSingleAction":{'
+            '"add":{'
+            f'"path":"{parquet_file}",'
+            '"partitionValues":{},'
+            '"modificationTime":1000,'
+            '"dataChange":true,'
+            '"size":0'
+            "}}}}"
+        ),
+    ]
+
+    class RestClientMock:
+        def set_delta_format_header(self, for_cdf=False):
+            assert not for_cdf
+
+        def list_files_in_table(
+            self,
+            table: Table,
+            *,
+            predicateHints: Optional[Sequence[str]] = None,
+            jsonPredicateHints: Optional[str] = None,
+            limitHint: Optional[int] = None,
+            version: Optional[int] = None,
+            timestamp: Optional[int] = None,
+        ) -> ListFilesInTableResponse:
+            assert table == _TEST_TABLE
+            assert limitHint == 2
+            return ListFilesInTableResponse(
+                delta_table_version=0,
+                protocol=Protocol(1),
+                metadata=Metadata(schema_string=_SCHEMA_A),
+                add_files=[],
+                lines=list(lines),
+            )
+
+        def remove_delta_format_header(self):
+            return
+
+    reader = DeltaSharingReader(
+        _TEST_TABLE,
+        RestClientMock(),
+        limit=2,
+        use_delta_format=True,
+    )
+
+    result = pa.Table.from_batches(list(reader.to_record_batches()))
+    assert result.column("a").to_pylist() == [1, 2]
+
+
+def test_to_arrow_non_partitioned(tmp_path):
+    pdf1 = pd.DataFrame(
+        {
+            "a": [1, 2, 3],
+            "b": ["a", "b", "c"],
+            "ts": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]).tz_localize("UTC"),
+        }
+    )
+    pdf2 = pd.DataFrame(
+        {
+            "a": [4, 5, 6],
+            "b": ["d", "e", "f"],
+            "ts": pd.to_datetime(["2024-01-04", "2024-01-05", "2024-01-06"]).tz_localize("UTC"),
+        }
+    )
+    schema_string = (
+        '{"fields":['
+        '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
+        '{"metadata":{},"name":"b","nullable":true,"type":"string"},'
+        '{"metadata":{},"name":"ts","nullable":true,"type":"timestamp"}'
+        '],"type":"struct"}'
+    )
+
+    pdf1.to_parquet(tmp_path / "pdf1.parquet")
+    pdf2.to_parquet(tmp_path / "pdf2.parquet")
+
+    reader = DeltaSharingReader(
+        _TEST_TABLE,
+        _ListFilesRestClient(
+            _list_files_response(
+                [
+                    _add_file(tmp_path / "pdf1.parquet", "pdf1"),
+                    _add_file(tmp_path / "pdf2.parquet", "pdf2"),
+                ],
+                schema_string,
+            )
+        ),
+        limit=4,
+        use_delta_format=False,
+    )
+    result = reader.to_arrow()
+    expected = pa.Table.from_pandas(
+        pd.concat([pdf1, pdf2]).reset_index(drop=True).head(4), preserve_index=False
+    ).cast(result.schema)
+
+    assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
+    assert result.equals(expected)
+
+
+def test_to_arrow_naive_timestamps_normalized_to_utc(tmp_path):
+    pdf = pd.DataFrame({"ts": pd.to_datetime(["2024-01-01", "2024-01-02"])})
+    schema_string = (
+        '{"fields":[{"metadata":{},"name":"ts","nullable":true,"type":"timestamp"}],'
+        '"type":"struct"}'
+    )
+
+    pdf.to_parquet(tmp_path / "pdf.parquet")
+
+    reader = DeltaSharingReader(
+        _TEST_TABLE,
+        _ListFilesRestClient(
+            _list_files_response([_add_file(tmp_path / "pdf.parquet", "pdf")], schema_string)
+        ),
+        use_delta_format=False,
+    )
+    result = reader.to_arrow()
+
+    assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
+    assert result.column("ts").to_pylist() == list(pdf["ts"].dt.tz_localize("UTC"))
+
+
+def test_to_record_batches_partitioned(tmp_path):
+    pdf1 = pd.DataFrame({"a": [1, 2, 3]})
+    pdf2 = pd.DataFrame({"a": [4, 5, 6]})
+
+    pdf1.to_parquet(tmp_path / "pdf1.parquet")
+    pdf2.to_parquet(tmp_path / "pdf2.parquet")
+    response = _list_files_response(
+        [
+            _add_file(tmp_path / "pdf1.parquet", "pdf1", {"b": "x"}),
+            _add_file(tmp_path / "pdf2.parquet", "pdf2", {"b": "y"}),
+        ]
+    )
+
+    reader = DeltaSharingReader(
+        _TEST_TABLE,
+        _ListFilesRestClient(response),
+        limit=4,
+        use_delta_format=False,
+    )
+    batches = list(reader.to_record_batches())
+    result = pa.Table.from_batches(batches)
+
+    expected1 = pdf1.copy()
+    expected1["b"] = "x"
+    expected2 = pdf2.copy()
+    expected2["b"] = "y"
+    expected = pa.Table.from_pandas(
+        pd.concat([expected1, expected2]).reset_index(drop=True).head(4),
+        preserve_index=False,
+    )
+
+    assert [batch.num_rows for batch in batches] == [3, 1]
+    assert result.equals(expected)
+
+    reader = DeltaSharingReader(
+        _TEST_TABLE,
+        _ListFilesRestClient(response),
+        use_delta_format=False,
+    )
+    assert (
+        reader.to_record_batch_reader()
+        .read_all()
+        .equals(
+            pa.Table.from_pandas(
+                pd.concat([expected1, expected2]).reset_index(drop=True),
+                preserve_index=False,
+            )
+        )
+    )
+
+
+def test_to_record_batches_preserves_schema_order_with_partition_column(tmp_path):
+    pdf = pd.DataFrame({"a": [1, 2], "c": ["x", "y"]})
+    pdf.to_parquet(tmp_path / "data.parquet")
+    schema_string = (
+        '{"fields":['
+        '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
+        '{"metadata":{},"name":"b","nullable":true,"type":"string"},'
+        '{"metadata":{},"name":"c","nullable":true,"type":"string"}'
+        '],"type":"struct"}'
+    )
+
+    reader = DeltaSharingReader(
+        _TEST_TABLE,
+        _ListFilesRestClient(
+            _list_files_response(
+                [_add_file(tmp_path / "data.parquet", "data", {"b": "partition"})],
+                schema_string,
+            )
+        ),
+        use_delta_format=False,
+    )
+
+    result = pa.Table.from_batches(list(reader.to_record_batches()))
+
+    assert result.schema.names == ["a", "b", "c"]
+    assert result.to_pydict() == {
+        "a": [1, 2],
+        "b": ["partition", "partition"],
+        "c": ["x", "y"],
+    }
 
 
 def test_to_pandas_non_partitioned(tmp_path):

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -442,9 +442,11 @@ def test_snapshot_partitioned(tmp_path):
     expected2["B"] = "y"
     expected = pd.concat([expected1, expected2]).reset_index(drop=True)
 
-    _, arrow_table = _assert_snapshot_materializers(reader, expected)
-    assert pa.Table.from_batches(list(reader.to_record_batches())).equals(arrow_table)
-    assert reader.to_record_batch_reader().read_all().equals(arrow_table)
+    _assert_snapshot_materializers(
+        reader,
+        expected,
+        expected_arrow_pdf=expected.rename(columns={"a": "A"}),
+    )
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True


### PR DESCRIPTION
**Summary**
Adds Arrow-native materializers to Python table snapshots, following the staged object API plan in #860 and building on the table-handle APIs from #862.

This PR adds snapshot support through:

- `to_arrow()`
- `to_record_batches()`
- `to_record_batch_reader()`

It also keeps the URL-based `load_as_arrow(...)` helper available for parity with the existing legacy read APIs.

**Scope**
- snapshot Arrow materialization
- lazy `RecordBatch` iteration and `RecordBatchReader` support
- Delta `timestamp` columns normalized to `timestamp[us, UTC]` so parquet and delta-kernel paths return consistent schemas
- focused coverage for object API wiring, legacy parity, schema normalization, partition columns, timestamp normalization, and kernel-path limits

CDF Arrow materialization is intentionally split into a follow-up PR.

**Not Included**
- CDF Arrow materialization
- table-handle interface changes already merged in #862
- docs and examples
- DuckDB quickstart
- dependency changes
- changes to existing pandas or Spark API behavior

**Testing**
- Python test suite: `87 passed, 126 skipped`
- `dev/lint-python` (compile, black, pycodestyle, flake8, mypy): passed
- pydoc checks skipped because `sphinx-build` is not installed
- `git diff --check upstream/main`: passed

Part of #860; builds on #862.
