### PR TITLE
Require delta-kernel-rust-sharing-wrapper >= 0.3.2

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,10 +128,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+        # workaround to install delta-kernel-rust-sharing-wrapper before running uv sync
+        # this allows uv sync to work even if the delta-kernel-rust-sharing-wrapper version
+        # specified in pyproject.toml has not been released to pypi
         run: |
           cd python
+          uv venv
+          uv pip install --group dev
+          uv run --no-sync maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml
+          uv add delta-kernel-rust-sharing-wrapper/target/wheels/*.whl
           uv sync
-          uv run maturin develop --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml
       - name: Build Server
         run: ./build/sbt package
       - name: Run tests

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "delta-kernel-rust-sharing-wrapper>=0.3.1,<1.0",
+    "delta-kernel-rust-sharing-wrapper>=0.3.2,<1.0",
     "pandas>=2.0.3,<3.0.0",
     "pyarrow>=16.1.0,<=23.0.1",
     "fsspec>=0.7.4,<=2026.2.0",
@@ -53,13 +53,16 @@ include = ["delta_sharing"]
 [tool.uv]
 exclude-newer = "2026-03-19T00:00:00Z"
 
+[tool.uv.sources]
+delta-kernel-rust-sharing-wrapper = { path = "delta-kernel-rust-sharing-wrapper/target/wheels/delta_kernel_rust_sharing_wrapper-0.3.2-cp310-abi3-linux_x86_64.whl" }
+
 [dependency-groups]
 dev = [
     "mypy==0.981",
-    "flake8<=7.3.0",                                                                                                                                                           
+    "flake8<=7.3.0",
     "black==26.3.1",
-    "pytest<=9.0.3",                                                                                                                                                           
-    "maturin<=1.12.6",                                                                                                                                                         
+    "pytest<=9.0.3",
+    "maturin<=1.12.6",
     "types-requests<=2.32.0.20260311",
     "setuptools>=64",
     "packaging",


### PR DESCRIPTION
This PR also adds a workaround to the CI jobs to make sure they still succeed even if the delta-kernel-rust-sharing-wrapper version specified is not released to PyPI.