### PR TITLE
Fix build-kernel-wheels workflow

### DIFF
--- a/.github/workflows/build-kernel-wheels.yml
+++ b/.github/workflows/build-kernel-wheels.yml
@@ -40,16 +40,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        # workaround to install delta-kernel-rust-sharing-wrapper before running uv sync
+        # this allows uv sync to work even if the delta-kernel-rust-sharing-wrapper version
+        # specified in pyproject.toml has not been released to pypi
         run: |
           cd python
-          uv sync
+          uv venv
+          uv pip install --group dev
 
       - name: Build wheel (x86_64 macOS)
         if: matrix.os == 'macos-latest' && matrix.arch == 'x86_64'
         run: |
           rustup target add x86_64-apple-darwin
           cd python
-          uv run maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release --target x86_64-apple-darwin
+          uv run --no-sync maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release --target x86_64-apple-darwin
         shell: bash
 
       - name: Build wheel (ARM macOS)
@@ -57,35 +61,35 @@ jobs:
         run: |
           rustup target add aarch64-apple-darwin
           cd python
-          uv run maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release --target aarch64-apple-darwin
+          uv run --no-sync maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release --target aarch64-apple-darwin
         shell: bash
 
       - name: Build wheel (x86_64 Windows)
         if: runner.os == 'Windows'
         run: |
           cd python
-          uv run maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release
+          uv run --no-sync maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release
         shell: powershell
 
       - name: Build wheel (x86_64 Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
           cd python
-          uv run maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release
+          uv run --no-sync maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release
         shell: bash
 
       - name: Build wheel (x86_64 Linux Ubuntu 24.04)
         if: matrix.os == 'ubuntu-24.04'
         run: |
           cd python
-          uv run maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release
+          uv run --no-sync maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release
         shell: bash
 
       - name: Build wheel (x86_64 Linux Ubuntu 22.04)
         if: matrix.os == 'ubuntu-22.04'
         run: |
           cd python
-          uv run maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release
+          uv run --no-sync maturin build --manifest-path delta-kernel-rust-sharing-wrapper/Cargo.toml --release
         shell: bash
 
       - name: Upload wheels


### PR DESCRIPTION
Reapplying a similar workaround used in https://github.com/delta-io/delta-sharing/pull/950 to build-kernel-wheels