### PR TITLE
Retry on HTTP 403 responses

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/util/RetryUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/RetryUtils.scala
@@ -68,7 +68,11 @@ private[sharing] object RetryUtils extends Logging {
   def shouldRetry(t: Throwable): Boolean = {
     t match {
       case DeltaSharingExceptionWithErrorCode(Some(statusCode)) =>
-        if (statusCode == 429) { // Too Many Requests
+        if (statusCode == 403) {
+          // Azure can intermittently return 403 AuthorizationFailure on pre-signed URLs;
+          // retrying sometimes helps mitigate this.
+          true
+        } else if (statusCode == 429) { // Too Many Requests
           true
         } else if (statusCode >= 500 && statusCode < 600) { // Internal Error
           true

--- a/client/src/test/scala/io/delta/sharing/client/util/RetryUtilsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/RetryUtilsSuite.scala
@@ -37,7 +37,8 @@ class RetryUtilsSuite extends SparkFunSuite {
     assert(shouldRetry(new java.net.SocketTimeoutException))
     assert(!shouldRetry(new RuntimeException))
     assert(shouldRetry(new MissingEndStreamActionException("missing")))
-    assert(!shouldRetry(new DeltaSharingServerException("error", Some(403))))
+    assert(shouldRetry(new UnexpectedHttpStatus("error", 403)))
+    assert(shouldRetry(new DeltaSharingServerException("error", Some(403))))
     assert(shouldRetry(new DeltaSharingServerException("error", Some(429))))
     assert(!shouldRetry(new DeltaSharingServerException("error", None)))
     assert(shouldRetry(new DeltaSharingServerException("error", Some(503))))
@@ -69,6 +70,45 @@ class RetryUtilsSuite extends SparkFunSuite {
       }
     }
     assert(sleeps == Seq())
+    RetryUtils.sleeper = (sleepMs: Long) => Thread.sleep(sleepMs)
+  }
+
+  test("runWithExponentialBackoff retries on 403 and succeeds on later attempt") {
+    val sleeps = new ArrayBuffer[Long]()
+    RetryUtils.sleeper = (sleepMs: Long) => sleeps += sleepMs
+
+    // A realistic Azure 403 message as thrown from RandomAccessHttpInputStream when an Azure
+    // pre-signed URL transiently returns AuthorizationFailure.
+    val azure403Message =
+      "HTTP request failed with status: HTTP/1.1 403 This request is not authorized to perform " +
+        "this operation. {\"error\":{\"code\":\"AuthorizationFailure\",\"message\":\"This " +
+        "request is not authorized to perform this operation.\"}}, while accessing URI of " +
+        "shared table file"
+
+    // Throw 403 twice then succeed on the third attempt.
+    var attempts = 0
+    val result = runWithExponentialBackoff(5) {
+      attempts += 1
+      if (attempts < 3) {
+        throw new UnexpectedHttpStatus(azure403Message, 403)
+      }
+      "ok"
+    }
+    assert(result == "ok")
+    assert(attempts == 3)
+    assert(sleeps == Seq(1000, 2000))
+
+    // Exhaust retries on a persistent 403 and ensure the final exception is propagated.
+    sleeps.clear()
+    val ex = intercept[UnexpectedHttpStatus] {
+      runWithExponentialBackoff(3) {
+        throw new UnexpectedHttpStatus(azure403Message, 403)
+      }
+    }
+    assert(ex.statusCode == 403)
+    // Run 4 times should sleep 3 times
+    assert(sleeps == Seq(1000, 2000, 4000))
+
     RetryUtils.sleeper = (sleepMs: Long) => Thread.sleep(sleepMs)
   }
 


### PR DESCRIPTION
## Summary

- Add HTTP `403` to the list of retryable status codes in `RetryUtils.shouldRetry`. Azure can intermittently return `403 AuthorizationFailure` on pre-signed URL access for shared table files, and retrying often mitigates the transient failure. `429` and `5xx` retry behavior is unchanged.
- Update `RetryUtilsSuite`:
  - Flip the existing `shouldRetry(403)` assertions to expect `true` for both `UnexpectedHttpStatus` and `DeltaSharingServerException`.
  - Add a new `runWithExponentialBackoff retries on 403 and succeeds on later attempt` test that verifies (a) a transient 403 is retried and the call eventually succeeds and (b) a persistent 403 exhausts the configured retries and propagates the original `UnexpectedHttpStatus`.

## Test plan

- [ ] `build/sbt "client/testOnly io.delta.sharing.client.util.RetryUtilsSuite"`
- [ ] Manual verification against a workspace that has previously hit transient Azure 403s on `RandomAccessHttpInputStream` reads.