### PR TITLE
Retry transient errors during RandomAccessHttpInputStream stream reads

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystem.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingFileSystem.scala
@@ -46,6 +46,7 @@ private[sharing] class DeltaSharingFileSystem extends FileSystem with Logging {
   lazy private val maxRetryDurationMillis = ConfUtils.maxRetryDurationMillis(getConf)
   lazy private val timeoutInSeconds = ConfUtils.timeoutInSeconds(getConf)
   lazy private val logPreSignedUrlAccess = ConfUtils.logPreSignedUrlAccessEnabled(getConf)
+  lazy private val streamReadRetryEnabled = ConfUtils.streamReadRetryEnabled(getConf)
   lazy private val httpClient = createHttpClient()
 
   private[sharing] def createHttpClient() = {
@@ -118,7 +119,8 @@ private[sharing] class DeltaSharingFileSystem extends FileSystem with Logging {
           statistics,
           numRetries,
           maxRetryDurationMillis,
-          logPreSignedUrlAccess
+          logPreSignedUrlAccess,
+          streamReadRetryEnabled
         )
       )
     }

--- a/client/src/main/scala/io/delta/sharing/client/RandomAccessHttpInputStream.scala
+++ b/client/src/main/scala/io/delta/sharing/client/RandomAccessHttpInputStream.scala
@@ -44,7 +44,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.fs.{FileSystem, FSExceptionMessages, FSInputStream}
-import org.apache.http.HttpStatus
+import org.apache.http.{HttpEntity, HttpStatus}
 import org.apache.http.client.HttpClient
 import org.apache.http.client.methods.{HttpGet, HttpRequestBase}
 import org.apache.http.conn.EofSensorInputStream
@@ -115,7 +115,7 @@ private[sharing] class RandomAccessHttpInputStream(
               s"error: ${e.getMessage}")
           }
           if (retryStreamReadOnError) {
-            // Drop the broken stream so the next retry attempt opens a fresh connection
+            // Drop the broken stream so the retry attempt opens a fresh connection
             // at the still-unchanged `pos`.
             abortCurrentStream()
           }
@@ -153,7 +153,7 @@ private[sharing] class RandomAccessHttpInputStream(
               s"length: $len, error: ${e.getMessage}")
           }
           if (retryStreamReadOnError) {
-            // Drop the broken stream so the next retry attempt opens a fresh connection
+            // Drop the broken stream so the retry attempt opens a fresh connection
             // at the still-unchanged `pos`.
             abortCurrentStream()
           }
@@ -170,16 +170,18 @@ private[sharing] class RandomAccessHttpInputStream(
   }
 
   /**
-   * Wraps a single underlying-stream read in `RetryUtils.runWithExponentialBackoff` when
-   * `retryStreamReadOnError` is enabled. The read is logically idempotent: `pos` is only
-   * advanced on a successful read, so re-issuing the byte-range request from the unchanged
-   * `pos` yields the bytes the caller still needs. The caller is responsible for aborting the
-   * broken `currentStream` (so that the next attempt reopens a fresh connection at `pos`)
-   * before letting the exception propagate.
+   * When `retryStreamReadOnError` is enabled, retries a failed stream read. The read is
+   * idempotent because `pos` only advances on success, and the caller aborts the broken
+   * stream so the retry reopens a fresh connection at `pos`. The short `retrySleepInterval`
+   * keeps a concurrent `close()` from blocking on the monitor during the retry sleep.
    */
   private def doStreamRead(readOp: => Int): Int = {
     if (retryStreamReadOnError) {
-      RetryUtils.runWithExponentialBackoff(numRetries, maxRetryDuration) {
+      RetryUtils.runWithExponentialBackoff(
+        numRetries,
+        maxRetryDuration,
+        retrySleepInterval = 500L
+      ) {
         readOp
       }
     } else {
@@ -215,11 +217,7 @@ private[sharing] class RandomAccessHttpInputStream(
         None
       }
 
-      val entity = RetryUtils.runWithExponentialBackoff(
-        numRetries,
-        maxRetryDuration,
-        onError = errorLogger
-      ) {
+      def openRequest(): HttpEntity = {
         val httpRequest = createHttpRequest(pos)
         val response = client.execute(httpRequest)
         val status = response.getStatusLine()
@@ -260,6 +258,26 @@ private[sharing] class RandomAccessHttpInputStream(
             s"requestId: $requestId, headers: [$headers]")
         }
         entity
+      }
+
+      val entity = if (retryStreamReadOnError) {
+        // The outer `doStreamRead` retry covers reopen failures, so make a single attempt
+        // here to avoid nesting two retry loops.
+        try {
+          openRequest()
+        } catch {
+          case e: Exception =>
+            errorLogger.foreach(_(e))
+            throw e
+        }
+      } else {
+        RetryUtils.runWithExponentialBackoff(
+          numRetries,
+          maxRetryDuration,
+          onError = errorLogger
+        ) {
+          openRequest()
+        }
       }
       currentStream = entity.getContent()
       this.pos = pos

--- a/client/src/main/scala/io/delta/sharing/client/RandomAccessHttpInputStream.scala
+++ b/client/src/main/scala/io/delta/sharing/client/RandomAccessHttpInputStream.scala
@@ -64,7 +64,8 @@ private[sharing] class RandomAccessHttpInputStream(
     stats: FileSystem.Statistics,
     numRetries: Int,
     maxRetryDuration: Long = Long.MaxValue,
-    logPreSignedUrlAccess: Boolean = false) extends FSInputStream with Logging {
+    logPreSignedUrlAccess: Boolean = false,
+    retryStreamReadOnError: Boolean = false) extends FSInputStream with Logging {
 
   private var closed = false
   private var pos = 0L
@@ -100,19 +101,26 @@ private[sharing] class RandomAccessHttpInputStream(
   }
 
   override def read(): Int = synchronized {
-    assertNotClosed()
-    if (currentStream == null) {
-      reopen(pos)
-    }
-    val byte = try {
-      currentStream.read()
-    } catch {
-      case e: Exception =>
-        if (logPreSignedUrlAccess) {
-          logInfo(s"Error reading from stream - uri: $uri, position: $pos, " +
-            s"error: ${e.getMessage}")
-        }
-        throw e
+    val byte = doStreamRead {
+      assertNotClosed()
+      if (currentStream == null) {
+        reopen(pos)
+      }
+      try {
+        currentStream.read()
+      } catch {
+        case e: Exception =>
+          if (logPreSignedUrlAccess) {
+            logInfo(s"Error reading from stream - uri: $uri, position: $pos, " +
+              s"error: ${e.getMessage}")
+          }
+          if (retryStreamReadOnError) {
+            // Drop the broken stream so the next retry attempt opens a fresh connection
+            // at the still-unchanged `pos`.
+            abortCurrentStream()
+          }
+          throw e
+      }
     }
     if (byte >= 0) {
       pos += 1
@@ -131,19 +139,26 @@ private[sharing] class RandomAccessHttpInputStream(
   }
 
   override def read(buf: Array[Byte], off: Int, len: Int): Int = synchronized {
-    assertNotClosed()
-    if (currentStream == null) {
-      reopen(pos)
-    }
-    val byteRead = try {
-      currentStream.read(buf, off, len)
-    } catch {
-      case e: Exception =>
-        if (logPreSignedUrlAccess) {
-          logInfo(s"Error reading from stream - uri: $uri, position: $pos, offset: $off, " +
-            s"length: $len, error: ${e.getMessage}")
-        }
-        throw e
+    val byteRead = doStreamRead {
+      assertNotClosed()
+      if (currentStream == null) {
+        reopen(pos)
+      }
+      try {
+        currentStream.read(buf, off, len)
+      } catch {
+        case e: Exception =>
+          if (logPreSignedUrlAccess) {
+            logInfo(s"Error reading from stream - uri: $uri, position: $pos, offset: $off, " +
+              s"length: $len, error: ${e.getMessage}")
+          }
+          if (retryStreamReadOnError) {
+            // Drop the broken stream so the next retry attempt opens a fresh connection
+            // at the still-unchanged `pos`.
+            abortCurrentStream()
+          }
+          throw e
+      }
     }
     if (byteRead > 0) {
       pos += byteRead
@@ -152,6 +167,24 @@ private[sharing] class RandomAccessHttpInputStream(
       stats.incrementBytesRead(byteRead)
     }
     byteRead
+  }
+
+  /**
+   * Wraps a single underlying-stream read in `RetryUtils.runWithExponentialBackoff` when
+   * `retryStreamReadOnError` is enabled. The read is logically idempotent: `pos` is only
+   * advanced on a successful read, so re-issuing the byte-range request from the unchanged
+   * `pos` yields the bytes the caller still needs. The caller is responsible for aborting the
+   * broken `currentStream` (so that the next attempt reopens a fresh connection at `pos`)
+   * before letting the exception propagate.
+   */
+  private def doStreamRead(readOp: => Int): Int = {
+    if (retryStreamReadOnError) {
+      RetryUtils.runWithExponentialBackoff(numRetries, maxRetryDuration) {
+        readOp
+      }
+    } else {
+      readOp
+    }
   }
 
   private def reopen(pos: Long): Unit = {

--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -111,6 +111,13 @@ object ConfUtils {
   val LOG_PRESIGNED_URL_ACCESS_CONF = "spark.delta.sharing.client.logPreSignedUrlAccess.enabled"
   val LOG_PRESIGNED_URL_ACCESS_DEFAULT = false
 
+  // When enabled, retry transient failures of the underlying HTTP stream `read` calls in
+  // `RandomAccessHttpInputStream`. The position in the stream is only advanced after a
+  // successful read, so re-issuing the byte-range request from the unchanged position yields
+  // the bytes the caller still needs.
+  val STREAM_READ_RETRY_ENABLED_CONF = "spark.delta.sharing.client.streamReadRetry.enabled"
+  val STREAM_READ_RETRY_ENABLED_DEFAULT = false
+
   val OPTIONS_PROFILE_PROVIDER_ENABLED_CONF = "spark.delta.sharing.profile.optionsProvider.enabled"
   val OPTIONS_PROFILE_PROVIDER_ENABLED_DEFAULT = true
 
@@ -343,6 +350,15 @@ object ConfUtils {
   def logPreSignedUrlAccessEnabled(conf: SQLConf): Boolean = {
     conf.getConfString(
       LOG_PRESIGNED_URL_ACCESS_CONF, LOG_PRESIGNED_URL_ACCESS_DEFAULT.toString).toBoolean
+  }
+
+  def streamReadRetryEnabled(conf: Configuration): Boolean = {
+    conf.getBoolean(STREAM_READ_RETRY_ENABLED_CONF, STREAM_READ_RETRY_ENABLED_DEFAULT)
+  }
+
+  def streamReadRetryEnabled(conf: SQLConf): Boolean = {
+    conf.getConfString(
+      STREAM_READ_RETRY_ENABLED_CONF, STREAM_READ_RETRY_ENABLED_DEFAULT.toString).toBoolean
   }
 
   def optionsProfileProviderEnabled(conf: Configuration): Boolean = {

--- a/client/src/test/scala/io/delta/sharing/client/RandomAccessHttpInputStreamSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/RandomAccessHttpInputStreamSuite.scala
@@ -17,7 +17,7 @@
 package io.delta.sharing.client
 
 import java.io.{ByteArrayInputStream, InputStream}
-import java.net.SocketTimeoutException
+import java.net.{SocketException, SocketTimeoutException}
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -151,6 +151,62 @@ class RandomAccessHttpInputStreamSuite extends SparkFunSuite with MockitoSugar {
     // Stream was opened exactly once; the read failure was propagated without retry.
     assert(callCount.get() == 1)
     assert(stream.getPos == 0L)
+  }
+
+  test("read(buf, off, len) recovers after partial bytes followed by connection reset") {
+    val data = "hello-world-this-is-a-longer-payload".getBytes(StandardCharsets.UTF_8)
+    val splitAt = 10
+    val callCount = new AtomicInteger(0)
+    // First underlying stream serves `data[0, splitAt)` then throws SocketException
+    // ("Connection reset") on the next read. Second stream serves the remainder.
+    val client = createPartialContentClient { () =>
+      val attempt = callCount.getAndIncrement()
+      if (attempt == 0) {
+        val backing = new ByteArrayInputStream(data, 0, splitAt)
+        new InputStream {
+          override def read(): Int = {
+            val b = backing.read()
+            if (b == -1) throw new SocketException("Connection reset")
+            b
+          }
+          override def read(b: Array[Byte], off: Int, len: Int): Int = {
+            val n = backing.read(b, off, len)
+            if (n == -1) throw new SocketException("Connection reset")
+            n
+          }
+        }
+      } else {
+        new ByteArrayInputStream(data, splitAt, data.length - splitAt)
+      }
+    }
+
+    val stream = new RandomAccessHttpInputStream(
+      client,
+      createMockFetcher("test.uri"),
+      data.length.toLong,
+      new FileSystem.Statistics("idbfs"),
+      numRetries = 3,
+      maxRetryDuration = Long.MaxValue,
+      logPreSignedUrlAccess = false,
+      retryStreamReadOnError = true
+    )
+
+    val buf = new Array[Byte](data.length)
+    withInstantRetrySleep {
+      var totalRead = 0
+      while (totalRead < data.length) {
+        val n = stream.read(buf, totalRead, data.length - totalRead)
+        assert(n > 0, s"read returned $n after $totalRead bytes")
+        totalRead += n
+      }
+      assert(totalRead == data.length)
+    }
+    assert(new String(buf, StandardCharsets.UTF_8) ==
+      new String(data, StandardCharsets.UTF_8))
+    assert(stream.getPos == data.length.toLong)
+    // Exactly two underlying streams opened: original (delivered prefix then errored)
+    // and the post-retry stream (delivered the remainder from the advanced pos).
+    assert(callCount.get() == 2)
   }
 
   test("read() (single byte) retries on transient stream errors when enabled") {

--- a/client/src/test/scala/io/delta/sharing/client/RandomAccessHttpInputStreamSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/RandomAccessHttpInputStreamSuite.scala
@@ -16,8 +16,13 @@
 
 package io.delta.sharing.client
 
+import java.io.{ByteArrayInputStream, InputStream}
+import java.net.SocketTimeoutException
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicInteger
+
 import org.apache.hadoop.fs.FileSystem
-import org.apache.http.{HttpStatus, ProtocolVersion}
+import org.apache.http.{HttpEntity, HttpStatus, ProtocolVersion}
 import org.apache.http.client.HttpClient
 import org.apache.http.message.BasicHttpResponse
 import org.apache.spark.SparkFunSuite
@@ -26,7 +31,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 
-import io.delta.sharing.client.util.UnexpectedHttpStatus
+import io.delta.sharing.client.util.{RetryUtils, UnexpectedHttpStatus}
 
 class RandomAccessHttpInputStreamSuite extends SparkFunSuite with MockitoSugar {
 
@@ -46,6 +51,29 @@ class RandomAccessHttpInputStreamSuite extends SparkFunSuite with MockitoSugar {
     fetcher
   }
 
+  /**
+   * Build a mocked `HttpClient` whose 206 responses return a fresh `InputStream` for each call,
+   * supplied by `contentFactory`. This mirrors how `RandomAccessHttpInputStream` reopens the
+   * stream on each retry attempt.
+   */
+  private def createPartialContentClient(contentFactory: () => InputStream): HttpClient = {
+    val entity = mock[HttpEntity]
+    when(entity.getContent).thenAnswer(_ => contentFactory())
+    val response = new BasicHttpResponse(
+      new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_PARTIAL_CONTENT, "")
+    response.setEntity(entity)
+    val client = mock[HttpClient]
+    when(client.execute(any())).thenReturn(response)
+    client
+  }
+
+  /** Run `body` with a no-op `RetryUtils.sleeper` to keep tests fast. */
+  private def withInstantRetrySleep[T](body: => T): T = {
+    val previous = RetryUtils.sleeper
+    RetryUtils.sleeper = (_: Long) => ()
+    try body finally RetryUtils.sleeper = previous
+  }
+
   test("Failed HTTP requests should not show URI") {
     val uri = "test.uri"
     val stream = new RandomAccessHttpInputStream(
@@ -59,5 +87,99 @@ class RandomAccessHttpInputStreamSuite extends SparkFunSuite with MockitoSugar {
       stream.seek(100L)
     }
     assert(!error.getMessage().contains(uri))
+  }
+
+  test("read(buf, off, len) retries on transient stream errors when enabled") {
+    val data = "hello-world".getBytes(StandardCharsets.UTF_8)
+    val callCount = new AtomicInteger(0)
+    val client = createPartialContentClient { () =>
+      if (callCount.getAndIncrement() == 0) {
+        new InputStream {
+          override def read(): Int = throw new SocketTimeoutException("transient failure")
+          override def read(b: Array[Byte], off: Int, len: Int): Int =
+            throw new SocketTimeoutException("transient failure")
+        }
+      } else {
+        new ByteArrayInputStream(data)
+      }
+    }
+    val stream = new RandomAccessHttpInputStream(
+      client,
+      createMockFetcher("test.uri"),
+      data.length.toLong,
+      new FileSystem.Statistics("idbfs"),
+      numRetries = 3,
+      maxRetryDuration = Long.MaxValue,
+      logPreSignedUrlAccess = false,
+      retryStreamReadOnError = true
+    )
+
+    val buf = new Array[Byte](data.length)
+    withInstantRetrySleep {
+      val n = stream.read(buf, 0, data.length)
+      assert(n == data.length)
+    }
+    assert(new String(buf, StandardCharsets.UTF_8) == "hello-world")
+    assert(stream.getPos == data.length.toLong)
+    // First attempt failed and reopened the stream once, second attempt succeeded.
+    assert(callCount.get() == 2)
+  }
+
+  test("read(buf, off, len) does not retry stream errors by default") {
+    val data = "hello-world".getBytes(StandardCharsets.UTF_8)
+    val callCount = new AtomicInteger(0)
+    val client = createPartialContentClient { () =>
+      callCount.incrementAndGet()
+      new InputStream {
+        override def read(): Int = throw new SocketTimeoutException("transient failure")
+        override def read(b: Array[Byte], off: Int, len: Int): Int =
+          throw new SocketTimeoutException("transient failure")
+      }
+    }
+    val stream = new RandomAccessHttpInputStream(
+      client,
+      createMockFetcher("test.uri"),
+      data.length.toLong,
+      new FileSystem.Statistics("idbfs"),
+      numRetries = 3
+    )
+
+    val buf = new Array[Byte](data.length)
+    intercept[SocketTimeoutException] {
+      stream.read(buf, 0, data.length)
+    }
+    // Stream was opened exactly once; the read failure was propagated without retry.
+    assert(callCount.get() == 1)
+    assert(stream.getPos == 0L)
+  }
+
+  test("read() (single byte) retries on transient stream errors when enabled") {
+    val data = Array[Byte]('A'.toByte)
+    val callCount = new AtomicInteger(0)
+    val client = createPartialContentClient { () =>
+      if (callCount.getAndIncrement() == 0) {
+        new InputStream {
+          override def read(): Int = throw new SocketTimeoutException("transient failure")
+        }
+      } else {
+        new ByteArrayInputStream(data)
+      }
+    }
+    val stream = new RandomAccessHttpInputStream(
+      client,
+      createMockFetcher("test.uri"),
+      data.length.toLong,
+      new FileSystem.Statistics("idbfs"),
+      numRetries = 3,
+      maxRetryDuration = Long.MaxValue,
+      logPreSignedUrlAccess = false,
+      retryStreamReadOnError = true
+    )
+
+    withInstantRetrySleep {
+      assert(stream.read() == 'A'.toInt)
+    }
+    assert(callCount.get() == 2)
+    assert(stream.getPos == 1L)
   }
 }

--- a/client/src/test/scala/io/delta/sharing/client/RandomAccessHttpInputStreamSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/RandomAccessHttpInputStreamSuite.scala
@@ -238,4 +238,37 @@ class RandomAccessHttpInputStreamSuite extends SparkFunSuite with MockitoSugar {
     assert(callCount.get() == 2)
     assert(stream.getPos == 1L)
   }
+
+  test("persistent failures use a single retry loop (no nested (n+1)^2 blowup)") {
+    val numRetries = 3
+    val executeCount = new AtomicInteger(0)
+    val client = mock[HttpClient]
+    // Always fail the underlying HTTP request with a retryable transient error. Because the
+    // read path calls `reopen(retry = false)`, only the outer `doStreamRead` loop retries.
+    when(client.execute(any())).thenAnswer { _ =>
+      executeCount.incrementAndGet()
+      throw new SocketTimeoutException("persistent failure")
+    }
+    val stream = new RandomAccessHttpInputStream(
+      client,
+      createMockFetcher("test.uri"),
+      1024L,
+      new FileSystem.Statistics("idbfs"),
+      numRetries = numRetries,
+      maxRetryDuration = Long.MaxValue,
+      logPreSignedUrlAccess = false,
+      retryStreamReadOnError = true
+    )
+
+    val buf = new Array[Byte](16)
+    withInstantRetrySleep {
+      intercept[SocketTimeoutException] {
+        stream.read(buf, 0, buf.length)
+      }
+    }
+    // A single retry loop: each outer attempt does one (non-retrying) reopen, so total HTTP
+    // attempts are exactly `numRetries + 1` (4), not the `(numRetries + 1)^2 = 16` blowup.
+    assert(executeCount.get() == numRetries + 1,
+      s"Expected ${numRetries + 1} HTTP attempts, got ${executeCount.get()}")
+  }
 }

--- a/client/src/test/scala/io/delta/sharing/client/util/ConfUtilsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/ConfUtilsSuite.scala
@@ -286,4 +286,16 @@ class ConfUtilsSuite extends SparkFunSuite {
       skipFileIdHashVerification(newSqlConf(Map(SKIP_FILE_ID_HASH_VERIFICATION_CONF -> "false")))
         == false)
   }
+
+  test("streamReadRetryEnabled") {
+    assert(streamReadRetryEnabled(newConf()) == STREAM_READ_RETRY_ENABLED_DEFAULT)
+    assert(streamReadRetryEnabled(newConf(Map(STREAM_READ_RETRY_ENABLED_CONF -> "true"))) == true)
+    assert(streamReadRetryEnabled(newConf(Map(STREAM_READ_RETRY_ENABLED_CONF -> "false"))) == false)
+
+    assert(streamReadRetryEnabled(newSqlConf()) == STREAM_READ_RETRY_ENABLED_DEFAULT)
+    assert(
+      streamReadRetryEnabled(newSqlConf(Map(STREAM_READ_RETRY_ENABLED_CONF -> "true"))) == true)
+    assert(
+      streamReadRetryEnabled(newSqlConf(Map(STREAM_READ_RETRY_ENABLED_CONF -> "false"))) == false)
+  }
 }


### PR DESCRIPTION
## Summary

- Failures thrown from `currentStream.read(...)` in `RandomAccessHttpInputStream` (e.g. `SocketTimeoutException`, connection-reset `SocketException`, mid-stream `IOException`) are currently propagated to the caller without retry, even though the read is logically idempotent: `pos` is only advanced after a successful read, so re-issuing the byte-range request from the unchanged `pos` yields the bytes the caller still needs.
- Add an opt-in retry that wraps both `read()` and `read(buf, off, len)` in `RetryUtils.runWithExponentialBackoff` and aborts the broken `currentStream` on failure so the next attempt reopens a fresh HTTP connection at the same `pos`. The exception is propagated to `RetryUtils.shouldRetry`, so only its existing transient set (timeouts, connection resets, retryable HTTP statuses, generic `IOException`) is retried, while `InterruptedException` / `InterruptedIOException` / non-retryable status codes still surface immediately.
- The new behavior is gated by a new conf, `spark.delta.sharing.client.streamReadRetry.enabled` (default `false`), and reuses the existing `spark.delta.sharing.network.numRetries` / `spark.delta.sharing.network.maxRetryDuration` budget.

## Why this is safe to retry

- `pos` advances only when `currentStream.read` returns successfully, so a retry re-issues the same byte range from the byte the caller still needs.
- On exception we explicitly abort the broken stream (`abortCurrentStream()`) so each retry attempt goes through `reopen(pos)` and gets a fresh HTTP connection rather than reusing a half-broken one.
- `RetryUtils.shouldRetry` already filters non-transient exceptions (e.g. `InterruptedException`, `ConnectionClosedException`, non-retryable HTTP statuses).
- `assertNotClosed()` runs on every attempt, so a refreshed pre-signed URL or a stream close racing with the read is still observed.

## Test plan

- [x] `client/testOnly io.delta.sharing.client.RandomAccessHttpInputStreamSuite` &mdash; new tests cover retry-on-success, no-retry-by-default, and the single-byte `read()` path.
- [x] `client/testOnly io.delta.sharing.client.util.ConfUtilsSuite` &mdash; new test covers the conf accessors for both `Configuration` and `SQLConf`.
- [x] `client/testOnly io.delta.sharing.client.util.RetryUtilsSuite` &mdash; existing retry behavior still passes.
- [x] `client/Test/compile` &mdash; scalastyle and compilation clean.
- Other client suite failures observed locally (`DeltaSharingFileSystemSuite::"file system should be cached"`, `DeltaSharing*Suite` integration tests) reproduce on `origin/main` without this change and are unrelated.