### PR TITLE
[PROTOCOL] Document version/timestamp query params on Query Table Metadata

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1576,7 +1576,7 @@ Optional: `delta-sharing-capabilities: responseformat=delta;readerfeatures=delet
 <td>URL</td>
 <td>
 
-`{prefix}/shares/{share}/schemas/{schema}/tables/{table}/metadata`
+`{prefix}/shares/{share}/schemas/{schema}/tables/{table}/metadata[?version={version}|&timestamp={timestamp}]`
 
 </td>
 </tr>
@@ -1589,6 +1589,17 @@ Optional: `delta-sharing-capabilities: responseformat=delta;readerfeatures=delet
 **{schema}**: The schema name to query. It's case-insensitive.
 
 **{table}**: The table name to query. It's case-insensitive.
+</td>
+</tr>
+<tr>
+<td>Query Parameters</td>
+<td>
+
+**{version}** (type: Long, optional): an optional version number. If set, will return the table metadata as of the specified version of the table. This is only supported on tables with history sharing enabled.
+
+**{timestamp}** (type: String, optional): an optional timestamp string in the [Timestamp Format](#timestamp-format). If set, will return the table metadata as of the table version corresponding to the specified timestamp. This is only supported on tables with history sharing enabled.
+
+`version` and `timestamp` are mutually exclusive; at most one of them may be provided in a single request. When neither is set, the server returns the metadata of the latest table version.
 </td>
 </tr>
 </table>

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1576,7 +1576,7 @@ Optional: `delta-sharing-capabilities: responseformat=delta;readerfeatures=delet
 <td>URL</td>
 <td>
 
-`{prefix}/shares/{share}/schemas/{schema}/tables/{table}/metadata[?version={version}|&timestamp={timestamp}]`
+`{prefix}/shares/{share}/schemas/{schema}/tables/{table}/metadata`
 
 </td>
 </tr>


### PR DESCRIPTION
## Summary
- The Delta Sharing reference client issues `GET .../tables/{table}/metadata` with optional `version=<v>` or `timestamp=<t>` URL query parameters (see `getEncodedMetadataParams` in `client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala`), but the **Query Table Metadata** section of `PROTOCOL.md` only documented the path segments.
- This PR adds documentation for those optional query parameters, their semantics, and the fact that `version` and `timestamp` are mutually exclusive — mirroring how the corresponding `version` / `timestamp` fields are described on the Read Data from a Table request body.
- No code or wire-format changes; documentation only.

## Test plan
- [x] `git diff` reviewed — only `PROTOCOL.md` changed.
- [ ] Rendered Markdown reviewed on the PR page to confirm the new "Query Parameters" row renders correctly inside the existing HTML `<table>`.