### PR TITLE
fix(server): honor fs.s3a.endpoint + path-style in S3FileSigner so presigned URLs target custom S3 endpoints (#753)

### DIFF
--- a/server/src/main/scala/io/delta/sharing/server/common/CloudFileSigner.scala
+++ b/server/src/main/scala/io/delta/sharing/server/common/CloudFileSigner.scala
@@ -55,7 +55,13 @@ class S3FileSigner(
     preSignedUrlTimeoutSeconds: Long) extends CloudFileSigner {
 
   private val s3Client = ReflectionUtils.newInstance(classOf[DefaultS3ClientFactory], conf)
-    .createS3Client(name, new S3ClientCreationParameters())
+    .createS3Client(name, {
+        val p = new S3ClientCreationParameters()
+        val ep = conf.get("fs.s3a.endpoint", "")
+        if (ep != null && ep.nonEmpty) p.withEndpoint(ep)
+        p.withPathStyleAccess(conf.getBoolean("fs.s3a.path.style.access", false))
+        p
+      })
 
   override def sign(path: Path): PreSignedUrl = {
     val absPath = path.toUri


### PR DESCRIPTION
## Problem

Against a custom (non-AWS) S3-compatible endpoint, the server reads table metadata
correctly, but the **presigned data-file URLs point at `<bucket>.s3.amazonaws.com`**, so
recipients get `403` fetching the data. The control plane (shares/schemas/tables) looks
healthy — only the data path breaks. Reported in #753 (Dell ECS); also reproduces on
MinIO, Ceph/RGW, and Scality.

## Root cause

`S3FileSigner` (`server/.../common/CloudFileSigner.scala`) constructs its signing client
with an **empty** `S3ClientCreationParameters`:

```scala
.createS3Client(name, new S3ClientCreationParameters())
```

`DefaultS3ClientFactory.createS3Client` reads the endpoint and path-style from the
**parameters**, not from `conf`. `S3AFileSystem` normally populates those parameters from
`fs.s3a.endpoint` / `fs.s3a.path.style.access` before calling the factory; `S3FileSigner`
skips that step, so the SDK falls back to the default AWS S3 endpoint + virtual-hosted
addressing.

## Fix

Populate the parameters from `conf` (endpoint + path-style), mirroring what
`S3AFileSystem` does. No behavior change for AWS users (empty endpoint → SDK default);
custom-endpoint users now get correctly-targeted presigned URLs.

## How to reproduce / verify

1. Stand up any S3-compatible store (MinIO is easiest); create a Delta table in a bucket.
2. Server `core-site.xml`: `fs.s3a.endpoint=https://<host>`, `fs.s3a.path.style.access=true`;
   point a share at `s3a://<bucket>/<table>`.
3. `POST .../tables/<t>/query` → **before:** `file.url` host is `<bucket>.s3.amazonaws.com`
   (403 on fetch); **after:** host is `<host>` and the Parquet fetches (`200`, `PAR1`).

Validated end-to-end against a Scality ARTESCA S3-compatible endpoint.

## Notes

- A follow-up could honor **per-bucket** overrides (`fs.s3a.bucket.<name>.endpoint`) via
  `S3AUtils.propagateBucketOptions(conf, bucket)` — happy to extend if preferred.
- Credentials are unaffected (the signer still uses the AWS default chain); only endpoint
  resolution is fixed.

Fixes #753
