### PR TITLE
Add includeHistoricalProtocol CDF query parameter (delta-format only)

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2349,7 +2349,8 @@ Optional: `delta-sharing-capabilities: responseformat=delta;readerfeatures=delet
  **startingTimestamp** (type: String, optional): The starting timestamp of the query, a string in the [Timestamp Format](#timestamp-format), which will be converted to a version created greater or equal to this timestamp. <br>
  **endingVersion** (type: Long, optional): The ending version of the query, inclusive. <br>
  **endingTimestamp** (type: String, optional): The ending timestamp of the query, a string in the [Timestamp Format](#timestamp-format), which will be converted to a version created earlier than or at the timestamp. <br>
- **includeHistoricalMetadata** (type: Boolean, optional): If set to true, return the historical metadata if seen in the delta log. This is for the streaming client to check if the table schema is still read compatible.</td>
+ **includeHistoricalMetadata** (type: Boolean, optional): If set to true, return the historical metadata if seen in the delta log. This is for the streaming client to check if the table schema is still read compatible. <br>
+ **includeHistoricalProtocol** (type: Boolean, optional): If set to true, return historical [Protocol](#protocol-in-delta-format) actions seen in the delta log so the streaming client can check whether the table is still read compatible (e.g. when a new reader feature is enabled mid-stream). This only affects responses with `responseformat=delta`; for `responseformat=parquet` responses the flag is ignored and no additional Protocol actions are emitted.</td>
 </tr>
 </table>
 
@@ -2391,6 +2392,7 @@ When `responseformat=delta`, a sequence of JSON strings delimited by newline. Ea
 - The second line is [a JSON wrapper object](#json-wrapper-object-in-each-line-in-delta) containing the delta [Metadata](#metadata-in-delta-format) object.
 - The rest of the lines are [JSON wrapper objects](#json-wrapper-object-in-each-line) for [Files](#file-in-delta-format) of the change data feed.
   - Historical [Metadata](#metadata) will be returned if includeHistoricalMetadata is set to true.
+  - Historical [Protocol](#protocol-in-delta-format) actions will be returned if includeHistoricalProtocol is set to true. This is only supported for the delta response format.
   - The ordering of the lines doesn't matter.
 
 </td>

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -89,7 +89,8 @@ trait DeltaSharingClient {
       table: Table,
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
-      fileIdHash: Option[String]): DeltaTableFiles
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles
 
   def generateTemporaryTableCredential(
     table: Table,
@@ -737,12 +738,14 @@ class DeltaSharingRestClient(
       table: Table,
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
-      fileIdHash: Option[String]): DeltaTableFiles = {
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles = {
     val start = System.currentTimeMillis()
     val encodedShare = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchema = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTable = URLEncoder.encode(table.name, "UTF-8")
-    val encodedParams = getEncodedCDFParams(cdfOptions, includeHistoricalMetadata)
+    val encodedParams = getEncodedCDFParams(
+      cdfOptions, includeHistoricalMetadata, includeHistoricalProtocol)
 
     val target = getTargetUrl(
       s"/shares/$encodedShare/schemas/$encodedSchema/tables/$encodedTable/changes?$encodedParams")
@@ -964,12 +967,11 @@ class DeltaSharingRestClient(
 
   private def getEncodedCDFParams(
       cdfOptions: Map[String, String],
-      includeHistoricalMetadata: Boolean): String = {
-    val paramMap = cdfOptions ++ (if (includeHistoricalMetadata) {
-      Map("includeHistoricalMetadata" -> "true")
-    } else {
-      Map.empty
-    })
+      includeHistoricalMetadata: Boolean,
+      includeHistoricalProtocol: Boolean = false): String = {
+    val paramMap = cdfOptions ++
+      (if (includeHistoricalMetadata) Map("includeHistoricalMetadata" -> "true") else Map.empty) ++
+      (if (includeHistoricalProtocol) Map("includeHistoricalProtocol" -> "true") else Map.empty)
     paramMap.map {
       case (cdfKey, cdfValue) => s"$cdfKey=${URLEncoder.encode(cdfValue)}"
     }.mkString("&")

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -2279,4 +2279,76 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       client.close()
     }
   }
+
+  // Captures the URL passed to getNDJson so we can assert the URL query string the client built
+  // for getCDFFiles. Returns a minimal delta-format ndjson body so the call succeeds.
+  private class UrlCapturingRestClient(profileProvider: TestProfileProvider)
+    extends DeltaSharingRestClient(
+      profileProvider = profileProvider,
+      responseFormat = RESPONSE_FORMAT_DELTA
+    ) {
+    var capturedTarget: String = _
+
+    override def getNDJson(
+        target: String,
+        requireVersion: Boolean,
+        setIncludeEndStreamAction: Boolean,
+        requestFileIdHash: Option[String] = None): ParsedDeltaSharingResponse = {
+      capturedTarget = target
+      ParsedDeltaSharingResponse(
+        version = 0L,
+        respondedFormat = RESPONSE_FORMAT_DELTA,
+        lines = Seq(
+          """{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}""",
+          """{"metaData":{"deltaMetadata":{"id":"id","format":{"provider":"parquet"},"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}}"""
+        ),
+        capabilitiesMap = Map.empty,
+        fileIdHash = None
+      )
+    }
+  }
+
+  test("getCDFFiles - includeHistoricalProtocol=true sends URL param to server") {
+    val client = new UrlCapturingRestClient(new TestProfileProvider(false))
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getCDFFiles(
+        table,
+        cdfOptions = Map("startingVersion" -> "0"),
+        includeHistoricalMetadata = false,
+        fileIdHash = None,
+        includeHistoricalProtocol = true
+      )
+      assert(
+        client.capturedTarget != null && client.capturedTarget.contains("includeHistoricalProtocol=true"),
+        s"expected URL to contain includeHistoricalProtocol=true, got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
+
+  test("getCDFFiles - includeHistoricalProtocol is absent by default") {
+    val client = new UrlCapturingRestClient(new TestProfileProvider(false))
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getCDFFiles(
+        table,
+        cdfOptions = Map("startingVersion" -> "0"),
+        includeHistoricalMetadata = true,
+        fileIdHash = None
+      )
+      assert(client.capturedTarget != null)
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to contain includeHistoricalProtocol, got: ${client.capturedTarget}"
+      )
+      assert(
+        client.capturedTarget.contains("includeHistoricalMetadata=true"),
+        s"expected URL to contain includeHistoricalMetadata=true, got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
 }

--- a/delta-sharing-protocl-api-description.yml
+++ b/delta-sharing-protocl-api-description.yml
@@ -478,6 +478,12 @@ paths:
           description: 'If set to true, return the historical metadata if seen in the delta log. This is for the streaming client to check if the table schema is still read compatible.'
           schema:
             type: boolean
+        - in: query
+          name: includeHistoricalProtocol
+          required: false
+          description: 'If set to true, return historical Protocol actions seen in the delta log so the streaming client can check whether the table is still read compatible (e.g. when a new reader feature is enabled mid-stream). Only effective for responses with responseformat=delta; ignored for responseformat=parquet responses.'
+          schema:
+            type: boolean
       responses:
         '400':
           $ref: "#/components/responses/400"

--- a/server/src/main/scala/io/delta/sharing/kernel/internal/DeltaSharedTableKernel.scala
+++ b/server/src/main/scala/io/delta/sharing/kernel/internal/DeltaSharedTableKernel.scala
@@ -387,7 +387,8 @@ class DeltaSharedTableKernel(
       pageToken: Option[String],
       responseFormatSet: Set[String] = Set("parquet"),
       includeEndStreamAction: Boolean,
-      fileIdHash: Option[String] = None): QueryResult = {
+      fileIdHash: Option[String] = None,
+      includeHistoricalProtocol: Boolean = false): QueryResult = {
 
     throw new DeltaSharingUnsupportedOperationException("not implemented yet")
   }

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharedTableProtocol.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharedTableProtocol.scala
@@ -57,7 +57,8 @@ trait DeltaSharedTableProtocol {
       pageToken: Option[String],
       responseFormatSet: Set[String] = Set("parquet"),
       includeEndStreamAction: Boolean,
-      fileIdHash: Option[String] = None): QueryResult
+      fileIdHash: Option[String] = None,
+      includeHistoricalProtocol: Boolean = false): QueryResult
 
   def validateTable(inputFullHistoryShared: Boolean): Unit = {}
 

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -618,6 +618,7 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       @Param("startingTimestamp") @Nullable startingTimestamp: String,
       @Param("endingTimestamp") @Nullable endingTimestamp: String,
       @Param("includeHistoricalMetadata") @Nullable includeHistoricalMetadata: String,
+      @Param("includeHistoricalProtocol") @Nullable includeHistoricalProtocol: String,
       @Param("maxFiles") @Nullable maxFiles: java.lang.Integer,
       @Param("pageToken") @Nullable pageToken: String
   ): HttpResponse = processRequest {
@@ -650,7 +651,8 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       Option(pageToken),
       responseFormatSet = responseFormatSet,
       includeEndStreamAction = includeEndStreamAction,
-      fileIdHash = fileIdHash
+      fileIdHash = fileIdHash,
+      includeHistoricalProtocol = Try(includeHistoricalProtocol.toBoolean).getOrElse(false)
     )
     logger.info(s"Took ${System.currentTimeMillis - start} ms to load the table cdf " +
       s"and sign ${queryResult.actions.length - 2} urls for table $share/$schema/$table")

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTable.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTable.scala
@@ -58,7 +58,8 @@ private case class QueryParamChecksum(
     predicateHints: Seq[String],
     jsonPredicateHints: Option[String],
     limitHint: Option[Long],
-    includeHistoricalMetadata: Option[Boolean])
+    includeHistoricalMetadata: Option[Boolean],
+    includeHistoricalProtocol: Option[Boolean] = None)
 
 
 
@@ -672,7 +673,8 @@ class DeltaSharedTable(
       pageToken: Option[String],
       responseFormatSet: Set[String] = Set(DeltaSharedTable.RESPONSE_FORMAT_PARQUET),
       includeEndStreamAction: Boolean,
-      fileIdHash: Option[String] = None
+      fileIdHash: Option[String] = None,
+      includeHistoricalProtocol: Boolean = false
   ): QueryResult = withClassLoader {
     // Step 1: validate pageToken if it's specified
     lazy val queryParamChecksum = computeChecksum(
@@ -686,7 +688,8 @@ class DeltaSharedTable(
         predicateHints = Nil,
         jsonPredicateHints = None,
         limitHint = None,
-        includeHistoricalMetadata = Some(includeHistoricalMetadata)
+        includeHistoricalMetadata = Some(includeHistoricalMetadata),
+        includeHistoricalProtocol = Some(includeHistoricalProtocol)
       )
     )
     val pageTokenOpt = pageToken.map(decodeAndValidatePageToken(_, queryParamChecksum))
@@ -745,11 +748,16 @@ class DeltaSharedTable(
     // - Versions that are processed in previous pages can be skipped.
     // - Versions that are committed after the first page call should be ignored, especially
     //   when the endingVersion is not specified and resolved to latestVersion.
+    // Historical Protocol actions only have a representation in the delta format response.
+    // Suppress them for parquet responses to keep the wire shape backwards compatible.
+    val emitHistoricalProtocol =
+      includeHistoricalProtocol && responseFormat == DeltaSharedTable.RESPONSE_FORMAT_DELTA
     val changes = cdcReader.queryCDF(
       pageTokenOpt.map(_.getStartingVersion).getOrElse(start),
       pageTokenOpt.map(_.getEndingVersion).getOrElse(end).min(latestVersion),
       latestVersion,
-      includeHistoricalMetadata
+      includeHistoricalMetadata,
+      emitHistoricalProtocol
     )
     changes.foreach { cdcDataSpec =>
       val v = cdcDataSpec.version
@@ -760,6 +768,8 @@ class DeltaSharedTable(
         indexedActions = indexedActions.drop(pageTokenOpt.get.getStartingActionIndex)
       }
       indexedActions.foreach {
+        case (p: Protocol, _) =>
+          actions.append(getResponseProtocol(p, responseFormat))
         case (m: Metadata, _) =>
           actions.append(
             getResponseMetadata(

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharingCDCReader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharingCDCReader.scala
@@ -26,6 +26,7 @@ import io.delta.standalone.internal.actions.{
   AddFile,
   CommitInfo,
   Metadata,
+  Protocol,
   RemoveFile
 }
 import io.delta.standalone.internal.exception.DeltaErrors
@@ -184,12 +185,18 @@ class DeltaSharingCDCReader(val deltaLog: DeltaLogImpl, val conf: Configuration)
    *                      starting and ending versions.
    * @param includeHistoricalMetadata if true, it need to include metadata for schema compatibility
    *                                  check. Otherwise, no need to include metadata.
+   * @param includeHistoricalProtocol if true, include intermediate Protocol actions seen in the
+   *                                  delta log for protocol/reader-feature compatibility checks.
+   *                                  Callers should only set this when the response will be
+   *                                  serialized in the delta format, because the parquet response
+   *                                  has no representation for additional Protocol actions.
    */
   def queryCDF(
     start: Long,
     end: Long,
     latestVersion: Long,
-    includeHistoricalMetadata: Boolean): Seq[CDCDataSpec] = {
+    includeHistoricalMetadata: Boolean,
+    includeHistoricalProtocol: Boolean = false): Seq[CDCDataSpec] = {
     if (start > latestVersion) {
       throw DeltaCDFErrors.startVersionAfterLatestVersion(start, latestVersion)
     }
@@ -255,6 +262,8 @@ class DeltaSharingCDCReader(val deltaLog: DeltaLogImpl, val conf: Configuration)
               selectedActions.append(c)
             case m: Metadata if (includeHistoricalMetadata && v > start) =>
               selectedActions.append(m)
+            case p: Protocol if (includeHistoricalProtocol && v > start) =>
+              selectedActions.append(p)
             case _ => ()
           }
         } else {
@@ -264,6 +273,8 @@ class DeltaSharingCDCReader(val deltaLog: DeltaLogImpl, val conf: Configuration)
             actions.foreach {
               case m: Metadata if (includeHistoricalMetadata && v > start) =>
                 selectedActions.append(m)
+              case p: Protocol if (includeHistoricalProtocol && v > start) =>
+                selectedActions.append(p)
               case _ => ()
             }
           } else {
@@ -276,6 +287,8 @@ class DeltaSharingCDCReader(val deltaLog: DeltaLogImpl, val conf: Configuration)
                 selectedActions.append(r)
               case m: Metadata if (includeHistoricalMetadata && v > start) =>
                 selectedActions.append(m)
+              case p: Protocol if (includeHistoricalProtocol && v > start) =>
+                selectedActions.append(p)
               case _ => ()
             }
           }

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -3585,6 +3585,40 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(actions(3).add != null)
   }
 
+  integrationTest("streaming_notnull_to_null - includeHistoricalProtocol=true is accepted and does " +
+    "not add additional Protocol actions when the table has no historical Protocol changes") {
+    // The streaming_notnull_to_null table only has Metadata changes across versions, no Protocol
+    // upgrades. Requesting includeHistoricalProtocol=true should be accepted by the server and
+    // produce the exact same response as if the flag were not set (one Protocol + one Metadata
+    // + the two AddFile actions).
+    val response = readNDJson(
+      requestPath(
+        "/shares/share8/schemas/default/tables/streaming_notnull_to_null/changes" +
+          "?startingVersion=0&includeHistoricalProtocol=true"
+      ),
+      Some("GET"),
+      None,
+      Some(0)
+    )
+    val actions = response.split("\n").map(JsonUtils.fromJson[SingleAction](_))
+    assert(actions.size == 4)
+    val expectedProtocol = Protocol(minReaderVersion = 1)
+    // Exactly one Protocol action (the head of the response), no historical Protocol entries
+    // injected for this table.
+    assert(actions.count(_.protocol != null) == 1)
+    assert(expectedProtocol == actions(0).protocol)
+    val expectedMetadata = Metadata(
+      id = "1e2201ff-12ad-4c3b-a539-4d34e9e36680",
+      format = Format(),
+      schemaString = """{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}}]}""",
+      configuration = Map("enableChangeDataFeed" -> "true"),
+      partitionColumns = Nil,
+      version = 3)
+    assert(expectedMetadata == actions(1).metaData)
+    assert(actions(2).add != null)
+    assert(actions(3).add != null)
+  }
+
   integrationTest("streaming_notnull_to_null - paginated query with additional metadata not returned") {
     // additional metadata not returned when includeHistoricalMetadata is not set
     val expectedProtocol = Protocol(minReaderVersion = 1)

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -174,7 +174,8 @@ class TestDeltaSharingClient(
       table: Table,
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
-      fileIdHash: Option[String]): DeltaTableFiles = {
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles = {
     val addFiles: Seq[AddFileForCDF] = Seq(
       AddFileForCDF("cdf_add1.parquet", "cdf_add1", Map.empty, 100, 1, 1000)
     )


### PR DESCRIPTION
## Summary
Mirror the existing `includeHistoricalMetadata` plumbing for Protocol actions, so a streaming client can detect when a table's Protocol / reader features change across versions in a CDF (`/changes`) query.

The new flag only affects **`responseformat=delta`** responses. For `responseformat=parquet`, the parquet wire shape has no representation for additional Protocol lines, so the server silently drops the flag and keeps the response shape backwards compatible.

## Wire surface
- **Client** (`DeltaSharingClient.getCDFFiles`) takes a new `includeHistoricalProtocol: Boolean = false` parameter and (when true) emits `includeHistoricalProtocol=true` on the `/changes` URL alongside any `includeHistoricalMetadata=true`.
- **Server** (`DeltaSharingService.listCdfFiles`) accepts the new `includeHistoricalProtocol` query parameter and propagates it through `DeltaSharedTableProtocol.queryCDF` and the standalone implementation into `DeltaSharingCDCReader.queryCDF`. The kernel implementation just carries the new arg (it still throws \`Unsupported\`).
- **Cache key**: the new parameter is included in `QueryParamChecksum` so paginated queries with the flag don't collide with cached page tokens from requests without it.

## Reader semantics
`DeltaSharingCDCReader` emits intermediate `Protocol` actions seen in the delta log under the same `v > start` rule that already gates `Metadata`, in all three CDF branches (CDC, hotfix metadata-only, AddFile/RemoveFile). `DeltaSharedTable.queryCDF` gates the entire feature on the response format being `delta`.

## Backwards compatibility
- The new client parameter has a default of `false`, so existing call sites (`spark/RemoteDeltaCDFRelation`, `RemoteDeltaLogSuite`, `DeltaSharingSource`, the python client, etc.) compile and behave unchanged.
- The new server query param is optional and defaults to `false`.
- For parquet responses the server silently ignores the flag.

## Docs
- `PROTOCOL.md`: the **Read Change Data Feed from a Table** section now documents `includeHistoricalProtocol` and explicitly notes that it only affects `responseformat=delta`.
- `delta-sharing-protocl-api-description.yml`: added the new query parameter to the OpenAPI spec.

## Tests
- Two client unit tests assert the URL the REST client sends contains `includeHistoricalProtocol=true` only when requested, and that it is absent (while `includeHistoricalMetadata=true` is still present) when not.
- One server integration test confirms the new query parameter is accepted on `/changes` and produces an unchanged response shape for a table with no historical Protocol upgrades (no Protocol actions injected, single head Protocol preserved).

## Test plan
- [x] `client/src/main/scala/...` and `server/src/main/scala/...` compile under both scala 2.12 (server) and 2.13 (client/spark).
- [x] New client unit tests pass locally: \`testOnly io.delta.sharing.client.DeltaSharingRestClientSuite -- -z "includeHistoricalProtocol"\` -> 2 succeeded.
- [ ] Existing server integration tests under `streaming_notnull_to_null` need S3 credentials and only run in CI; they are unchanged.
- [ ] CI to run full client/server/spark test suites against the new flag.