### PR TITLE
[Client] Add includeHistoricalProtocol param on getCDFFiles

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -89,7 +89,8 @@ trait DeltaSharingClient {
       table: Table,
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
-      fileIdHash: Option[String]): DeltaTableFiles
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles
 
   def generateTemporaryTableCredential(
     table: Table,
@@ -737,12 +738,14 @@ class DeltaSharingRestClient(
       table: Table,
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
-      fileIdHash: Option[String]): DeltaTableFiles = {
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles = {
     val start = System.currentTimeMillis()
     val encodedShare = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchema = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTable = URLEncoder.encode(table.name, "UTF-8")
-    val encodedParams = getEncodedCDFParams(cdfOptions, includeHistoricalMetadata)
+    val encodedParams = getEncodedCDFParams(
+      cdfOptions, includeHistoricalMetadata, includeHistoricalProtocol)
 
     val target = getTargetUrl(
       s"/shares/$encodedShare/schemas/$encodedSchema/tables/$encodedTable/changes?$encodedParams")
@@ -964,12 +967,11 @@ class DeltaSharingRestClient(
 
   private def getEncodedCDFParams(
       cdfOptions: Map[String, String],
-      includeHistoricalMetadata: Boolean): String = {
-    val paramMap = cdfOptions ++ (if (includeHistoricalMetadata) {
-      Map("includeHistoricalMetadata" -> "true")
-    } else {
-      Map.empty
-    })
+      includeHistoricalMetadata: Boolean,
+      includeHistoricalProtocol: Boolean = false): String = {
+    val paramMap = cdfOptions ++
+      (if (includeHistoricalMetadata) Map("includeHistoricalMetadata" -> "true") else Map.empty) ++
+      (if (includeHistoricalProtocol) Map("includeHistoricalProtocol" -> "true") else Map.empty)
     paramMap.map {
       case (cdfKey, cdfValue) => s"$cdfKey=${URLEncoder.encode(cdfValue)}"
     }.mkString("&")

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -2279,4 +2279,76 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       client.close()
     }
   }
+
+  // Captures the URL passed to getNDJson so we can assert the URL query string the client built
+  // for getCDFFiles. Returns a minimal delta-format ndjson body so the call succeeds.
+  private class UrlCapturingRestClient(profileProvider: TestProfileProvider)
+    extends DeltaSharingRestClient(
+      profileProvider = profileProvider,
+      responseFormat = RESPONSE_FORMAT_DELTA
+    ) {
+    var capturedTarget: String = _
+
+    override def getNDJson(
+        target: String,
+        requireVersion: Boolean,
+        setIncludeEndStreamAction: Boolean,
+        requestFileIdHash: Option[String] = None): ParsedDeltaSharingResponse = {
+      capturedTarget = target
+      ParsedDeltaSharingResponse(
+        version = 0L,
+        respondedFormat = RESPONSE_FORMAT_DELTA,
+        lines = Seq(
+          """{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}""",
+          """{"metaData":{"deltaMetadata":{"id":"id","format":{"provider":"parquet"},"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}}"""
+        ),
+        capabilitiesMap = Map.empty,
+        fileIdHash = None
+      )
+    }
+  }
+
+  test("getCDFFiles - includeHistoricalProtocol=true sends URL param to server") {
+    val client = new UrlCapturingRestClient(new TestProfileProvider(false))
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getCDFFiles(
+        table,
+        cdfOptions = Map("startingVersion" -> "0"),
+        includeHistoricalMetadata = false,
+        fileIdHash = None,
+        includeHistoricalProtocol = true
+      )
+      assert(
+        client.capturedTarget != null && client.capturedTarget.contains("includeHistoricalProtocol=true"),
+        s"expected URL to contain includeHistoricalProtocol=true, got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
+
+  test("getCDFFiles - includeHistoricalProtocol is absent by default") {
+    val client = new UrlCapturingRestClient(new TestProfileProvider(false))
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getCDFFiles(
+        table,
+        cdfOptions = Map("startingVersion" -> "0"),
+        includeHistoricalMetadata = true,
+        fileIdHash = None
+      )
+      assert(client.capturedTarget != null)
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to contain includeHistoricalProtocol, got: ${client.capturedTarget}"
+      )
+      assert(
+        client.capturedTarget.contains("includeHistoricalMetadata=true"),
+        s"expected URL to contain includeHistoricalMetadata=true, got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
 }

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -174,7 +174,8 @@ class TestDeltaSharingClient(
       table: Table,
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
-      fileIdHash: Option[String]): DeltaTableFiles = {
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles = {
     val addFiles: Seq[AddFileForCDF] = Seq(
       AddFileForCDF("cdf_add1.parquet", "cdf_add1", Map.empty, 100, 1, 1000)
     )


### PR DESCRIPTION
## Summary
Client-side half of `includeHistoricalProtocol` support for the CDF endpoint. Adds a new `includeHistoricalProtocol: Boolean = false` parameter on `DeltaSharingClient.getCDFFiles`. When set, the REST client appends `includeHistoricalProtocol=true` to the `/changes` URL alongside any existing `includeHistoricalMetadata=true`, mirroring how `includeHistoricalMetadata` is encoded today.

The matching server change (parse the new query param and emit historical `Protocol` actions in delta-format CDF responses) is split into a companion PR.

## Backwards compatibility
- Default is `false`, so existing call sites (`RemoteDeltaCDFRelation`, `DeltaSharingSource`, `RemoteDeltaLogSuite`, etc.) compile and behave unchanged.
- When the flag is `false`, the URL byte-for-byte matches today's request, so old servers see no difference.
- When the flag is `true` against an old server, the unknown query param is ignored.
- `TestDeltaSharingClient` (a spark-test mock implementing the trait) is updated to match the new signature so the `spark` module still compiles.

## Test plan
- [x] `client` + `spark` modules compile and test-compile cleanly.
- [x] New client unit tests pass: `testOnly io.delta.sharing.client.DeltaSharingRestClientSuite -- -z "includeHistoricalProtocol"` -> 2 succeeded.
- [ ] CI to run the full client and spark suites.

## Companion PR
Server + protocol-doc half: forthcoming companion PR (will be linked here once opened).