### PR TITLE
[Server/PROTOCOL] Accept includeHistoricalProtocol on CDF (delta-format only)

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2349,7 +2349,8 @@ Optional: `delta-sharing-capabilities: responseformat=delta;readerfeatures=delet
  **startingTimestamp** (type: String, optional): The starting timestamp of the query, a string in the [Timestamp Format](#timestamp-format), which will be converted to a version created greater or equal to this timestamp. <br>
  **endingVersion** (type: Long, optional): The ending version of the query, inclusive. <br>
  **endingTimestamp** (type: String, optional): The ending timestamp of the query, a string in the [Timestamp Format](#timestamp-format), which will be converted to a version created earlier than or at the timestamp. <br>
- **includeHistoricalMetadata** (type: Boolean, optional): If set to true, return the historical metadata if seen in the delta log. This is for the streaming client to check if the table schema is still read compatible.</td>
+ **includeHistoricalMetadata** (type: Boolean, optional): If set to true, return the historical metadata if seen in the delta log. This is for the streaming client to check if the table schema is still read compatible. <br>
+ **includeHistoricalProtocol** (type: Boolean, optional): If set to true, return historical [Protocol](#protocol-in-delta-format) actions seen in the delta log so the streaming client can check whether the table is still read compatible (e.g. when a new reader feature is enabled mid-stream). This only affects responses with `responseformat=delta`; for `responseformat=parquet` responses the flag is ignored and no additional Protocol actions are emitted.</td>
 </tr>
 </table>
 
@@ -2391,6 +2392,7 @@ When `responseformat=delta`, a sequence of JSON strings delimited by newline. Ea
 - The second line is [a JSON wrapper object](#json-wrapper-object-in-each-line-in-delta) containing the delta [Metadata](#metadata-in-delta-format) object.
 - The rest of the lines are [JSON wrapper objects](#json-wrapper-object-in-each-line) for [Files](#file-in-delta-format) of the change data feed.
   - Historical [Metadata](#metadata) will be returned if includeHistoricalMetadata is set to true.
+  - Historical [Protocol](#protocol-in-delta-format) actions will be returned if includeHistoricalProtocol is set to true. This is only supported for the delta response format.
   - The ordering of the lines doesn't matter.
 
 </td>

--- a/delta-sharing-protocl-api-description.yml
+++ b/delta-sharing-protocl-api-description.yml
@@ -478,6 +478,12 @@ paths:
           description: 'If set to true, return the historical metadata if seen in the delta log. This is for the streaming client to check if the table schema is still read compatible.'
           schema:
             type: boolean
+        - in: query
+          name: includeHistoricalProtocol
+          required: false
+          description: 'If set to true, return historical Protocol actions seen in the delta log so the streaming client can check whether the table is still read compatible (e.g. when a new reader feature is enabled mid-stream). Only effective for responses with responseformat=delta; ignored for responseformat=parquet responses.'
+          schema:
+            type: boolean
       responses:
         '400':
           $ref: "#/components/responses/400"

--- a/server/src/main/scala/io/delta/sharing/kernel/internal/DeltaSharedTableKernel.scala
+++ b/server/src/main/scala/io/delta/sharing/kernel/internal/DeltaSharedTableKernel.scala
@@ -387,7 +387,8 @@ class DeltaSharedTableKernel(
       pageToken: Option[String],
       responseFormatSet: Set[String] = Set("parquet"),
       includeEndStreamAction: Boolean,
-      fileIdHash: Option[String] = None): QueryResult = {
+      fileIdHash: Option[String] = None,
+      includeHistoricalProtocol: Boolean = false): QueryResult = {
 
     throw new DeltaSharingUnsupportedOperationException("not implemented yet")
   }

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharedTableProtocol.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharedTableProtocol.scala
@@ -57,7 +57,8 @@ trait DeltaSharedTableProtocol {
       pageToken: Option[String],
       responseFormatSet: Set[String] = Set("parquet"),
       includeEndStreamAction: Boolean,
-      fileIdHash: Option[String] = None): QueryResult
+      fileIdHash: Option[String] = None,
+      includeHistoricalProtocol: Boolean = false): QueryResult
 
   def validateTable(inputFullHistoryShared: Boolean): Unit = {}
 

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -618,6 +618,7 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       @Param("startingTimestamp") @Nullable startingTimestamp: String,
       @Param("endingTimestamp") @Nullable endingTimestamp: String,
       @Param("includeHistoricalMetadata") @Nullable includeHistoricalMetadata: String,
+      @Param("includeHistoricalProtocol") @Nullable includeHistoricalProtocol: String,
       @Param("maxFiles") @Nullable maxFiles: java.lang.Integer,
       @Param("pageToken") @Nullable pageToken: String
   ): HttpResponse = processRequest {
@@ -650,7 +651,8 @@ class DeltaSharingService(serverConfig: ServerConfig) {
       Option(pageToken),
       responseFormatSet = responseFormatSet,
       includeEndStreamAction = includeEndStreamAction,
-      fileIdHash = fileIdHash
+      fileIdHash = fileIdHash,
+      includeHistoricalProtocol = Try(includeHistoricalProtocol.toBoolean).getOrElse(false)
     )
     logger.info(s"Took ${System.currentTimeMillis - start} ms to load the table cdf " +
       s"and sign ${queryResult.actions.length - 2} urls for table $share/$schema/$table")

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTable.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharedTable.scala
@@ -58,7 +58,8 @@ private case class QueryParamChecksum(
     predicateHints: Seq[String],
     jsonPredicateHints: Option[String],
     limitHint: Option[Long],
-    includeHistoricalMetadata: Option[Boolean])
+    includeHistoricalMetadata: Option[Boolean],
+    includeHistoricalProtocol: Option[Boolean] = None)
 
 
 
@@ -672,7 +673,8 @@ class DeltaSharedTable(
       pageToken: Option[String],
       responseFormatSet: Set[String] = Set(DeltaSharedTable.RESPONSE_FORMAT_PARQUET),
       includeEndStreamAction: Boolean,
-      fileIdHash: Option[String] = None
+      fileIdHash: Option[String] = None,
+      includeHistoricalProtocol: Boolean = false
   ): QueryResult = withClassLoader {
     // Step 1: validate pageToken if it's specified
     lazy val queryParamChecksum = computeChecksum(
@@ -686,7 +688,8 @@ class DeltaSharedTable(
         predicateHints = Nil,
         jsonPredicateHints = None,
         limitHint = None,
-        includeHistoricalMetadata = Some(includeHistoricalMetadata)
+        includeHistoricalMetadata = Some(includeHistoricalMetadata),
+        includeHistoricalProtocol = Some(includeHistoricalProtocol)
       )
     )
     val pageTokenOpt = pageToken.map(decodeAndValidatePageToken(_, queryParamChecksum))
@@ -745,11 +748,16 @@ class DeltaSharedTable(
     // - Versions that are processed in previous pages can be skipped.
     // - Versions that are committed after the first page call should be ignored, especially
     //   when the endingVersion is not specified and resolved to latestVersion.
+    // Historical Protocol actions only have a representation in the delta format response.
+    // Suppress them for parquet responses to keep the wire shape backwards compatible.
+    val emitHistoricalProtocol =
+      includeHistoricalProtocol && responseFormat == DeltaSharedTable.RESPONSE_FORMAT_DELTA
     val changes = cdcReader.queryCDF(
       pageTokenOpt.map(_.getStartingVersion).getOrElse(start),
       pageTokenOpt.map(_.getEndingVersion).getOrElse(end).min(latestVersion),
       latestVersion,
-      includeHistoricalMetadata
+      includeHistoricalMetadata,
+      emitHistoricalProtocol
     )
     changes.foreach { cdcDataSpec =>
       val v = cdcDataSpec.version
@@ -760,6 +768,8 @@ class DeltaSharedTable(
         indexedActions = indexedActions.drop(pageTokenOpt.get.getStartingActionIndex)
       }
       indexedActions.foreach {
+        case (p: Protocol, _) =>
+          actions.append(getResponseProtocol(p, responseFormat))
         case (m: Metadata, _) =>
           actions.append(
             getResponseMetadata(

--- a/server/src/main/scala/io/delta/standalone/internal/DeltaSharingCDCReader.scala
+++ b/server/src/main/scala/io/delta/standalone/internal/DeltaSharingCDCReader.scala
@@ -26,6 +26,7 @@ import io.delta.standalone.internal.actions.{
   AddFile,
   CommitInfo,
   Metadata,
+  Protocol,
   RemoveFile
 }
 import io.delta.standalone.internal.exception.DeltaErrors
@@ -184,12 +185,18 @@ class DeltaSharingCDCReader(val deltaLog: DeltaLogImpl, val conf: Configuration)
    *                      starting and ending versions.
    * @param includeHistoricalMetadata if true, it need to include metadata for schema compatibility
    *                                  check. Otherwise, no need to include metadata.
+   * @param includeHistoricalProtocol if true, include intermediate Protocol actions seen in the
+   *                                  delta log for protocol/reader-feature compatibility checks.
+   *                                  Callers should only set this when the response will be
+   *                                  serialized in the delta format, because the parquet response
+   *                                  has no representation for additional Protocol actions.
    */
   def queryCDF(
     start: Long,
     end: Long,
     latestVersion: Long,
-    includeHistoricalMetadata: Boolean): Seq[CDCDataSpec] = {
+    includeHistoricalMetadata: Boolean,
+    includeHistoricalProtocol: Boolean = false): Seq[CDCDataSpec] = {
     if (start > latestVersion) {
       throw DeltaCDFErrors.startVersionAfterLatestVersion(start, latestVersion)
     }
@@ -255,6 +262,8 @@ class DeltaSharingCDCReader(val deltaLog: DeltaLogImpl, val conf: Configuration)
               selectedActions.append(c)
             case m: Metadata if (includeHistoricalMetadata && v > start) =>
               selectedActions.append(m)
+            case p: Protocol if (includeHistoricalProtocol && v > start) =>
+              selectedActions.append(p)
             case _ => ()
           }
         } else {
@@ -264,6 +273,8 @@ class DeltaSharingCDCReader(val deltaLog: DeltaLogImpl, val conf: Configuration)
             actions.foreach {
               case m: Metadata if (includeHistoricalMetadata && v > start) =>
                 selectedActions.append(m)
+              case p: Protocol if (includeHistoricalProtocol && v > start) =>
+                selectedActions.append(p)
               case _ => ()
             }
           } else {
@@ -276,6 +287,8 @@ class DeltaSharingCDCReader(val deltaLog: DeltaLogImpl, val conf: Configuration)
                 selectedActions.append(r)
               case m: Metadata if (includeHistoricalMetadata && v > start) =>
                 selectedActions.append(m)
+              case p: Protocol if (includeHistoricalProtocol && v > start) =>
+                selectedActions.append(p)
               case _ => ()
             }
           }

--- a/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
+++ b/server/src/test/scala/io/delta/sharing/server/DeltaSharingServiceSuite.scala
@@ -3585,6 +3585,40 @@ class DeltaSharingServiceSuite extends FunSuite with BeforeAndAfterAll {
     assert(actions(3).add != null)
   }
 
+  integrationTest("streaming_notnull_to_null - includeHistoricalProtocol=true is accepted and does " +
+    "not add additional Protocol actions when the table has no historical Protocol changes") {
+    // The streaming_notnull_to_null table only has Metadata changes across versions, no Protocol
+    // upgrades. Requesting includeHistoricalProtocol=true should be accepted by the server and
+    // produce the exact same response as if the flag were not set (one Protocol + one Metadata
+    // + the two AddFile actions).
+    val response = readNDJson(
+      requestPath(
+        "/shares/share8/schemas/default/tables/streaming_notnull_to_null/changes" +
+          "?startingVersion=0&includeHistoricalProtocol=true"
+      ),
+      Some("GET"),
+      None,
+      Some(0)
+    )
+    val actions = response.split("\n").map(JsonUtils.fromJson[SingleAction](_))
+    assert(actions.size == 4)
+    val expectedProtocol = Protocol(minReaderVersion = 1)
+    // Exactly one Protocol action (the head of the response), no historical Protocol entries
+    // injected for this table.
+    assert(actions.count(_.protocol != null) == 1)
+    assert(expectedProtocol == actions(0).protocol)
+    val expectedMetadata = Metadata(
+      id = "1e2201ff-12ad-4c3b-a539-4d34e9e36680",
+      format = Format(),
+      schemaString = """{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}}]}""",
+      configuration = Map("enableChangeDataFeed" -> "true"),
+      partitionColumns = Nil,
+      version = 3)
+    assert(expectedMetadata == actions(1).metaData)
+    assert(actions(2).add != null)
+    assert(actions(3).add != null)
+  }
+
   integrationTest("streaming_notnull_to_null - paginated query with additional metadata not returned") {
     // additional metadata not returned when includeHistoricalMetadata is not set
     val expectedProtocol = Protocol(minReaderVersion = 1)


### PR DESCRIPTION
## Summary
Server-side half of `includeHistoricalProtocol` support for the CDF endpoint. Adds a new optional `includeHistoricalProtocol` query parameter to `GET .../changes` and plumbs it through `DeltaSharedTableProtocol.queryCDF`, `DeltaSharedTable.queryCDF`, and `DeltaSharingCDCReader.queryCDF`. The kernel implementation just carries the new arg (it still throws Unsupported).

The matching client-side wire encoding lands in a separate companion PR; this PR is fully usable on its own with a normal (older) client (the param defaults to `false`).

## Reader semantics
- `DeltaSharingCDCReader` emits intermediate `Protocol` actions seen in the delta log under the same `v > start` rule used today for `Metadata`, in all three CDF branches (CDC, hotfix metadata-only, AddFile/RemoveFile).
- `DeltaSharedTable.queryCDF` gates the entire feature on the response format being `delta`. For `parquet` responses the flag is silently dropped \u2014 the parquet wire shape has no representation for additional Protocol lines, so we keep it backwards compatible by never producing them.
- The new parameter is included in `QueryParamChecksum` so paginated queries with the flag don't collide with cached page tokens from requests without it.

## Docs
- `PROTOCOL.md`: the **Read Change Data Feed from a Table** section now documents `includeHistoricalProtocol` and explicitly notes that it only affects `responseformat=delta` responses.
- `delta-sharing-protocl-api-description.yml`: added the new query parameter to the OpenAPI spec.

## Backwards compatibility
- Existing clients don't send the parameter; the server treats it as `false`; behavior unchanged.
- For parquet responses the server silently ignores the flag.

## Test plan
- [x] `server` module compiles and test-compiles cleanly.
- [x] One server integration test added under `streaming_notnull_to_null` confirms the new query parameter is accepted on `/changes` and produces an unchanged response shape for a table with no historical Protocol upgrades. (Existing `streaming_notnull_to_null` integration tests need S3 credentials locally and only run in CI.)
- [ ] CI to run the full server suite against the new flag.

## Companion PR
Client-side wire encoding: forthcoming companion PR.