### PR TITLE
[Client] Add includeHistoricalProtocol param on getCDFFiles and streaming getFiles

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -161,8 +161,7 @@ private[sharing] case class QueryTableRequest(
   pageToken: Option[String],
   includeRefreshToken: Option[Boolean],
   refreshToken: Option[String],
-  idempotency_key: Option[String],
-  includeHistoricalProtocol: Option[Boolean] = None
+  idempotency_key: Option[String]
 ) extends NextPageRequest {
   override def clone(
         maxFiles: Option[Int],
@@ -553,8 +552,10 @@ class DeltaSharingRestClient(
     val encodedShareName = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchemaName = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTableName = URLEncoder.encode(table.name, "UTF-8")
+    val queryString = if (includeHistoricalProtocol) "?includeHistoricalProtocol=true" else ""
     val target = getTargetUrl(
-      s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query")
+      s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query" +
+        queryString)
     val request: QueryTableRequest = QueryTableRequest(
       predicateHints = Nil,
       limitHint = None,
@@ -567,8 +568,7 @@ class DeltaSharingRestClient(
       pageToken = None,
       includeRefreshToken = None,
       refreshToken = None,
-      idempotency_key = None,
-      includeHistoricalProtocol = if (includeHistoricalProtocol) Some(true) else None
+      idempotency_key = None
     )
 
     val (version, respondedFormat, lines, responseFileIdHash) = if (queryTablePaginationEnabled) {

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -83,7 +83,8 @@ trait DeltaSharingClient {
     table: Table,
     startingVersion: Long,
     endingVersion: Option[Long],
-    fileIdHash: Option[String]): DeltaTableFiles
+    fileIdHash: Option[String],
+    includeHistoricalProtocol: Boolean = false): DeltaTableFiles
 
   def getCDFFiles(
       table: Table,
@@ -160,7 +161,8 @@ private[sharing] case class QueryTableRequest(
   pageToken: Option[String],
   includeRefreshToken: Option[Boolean],
   refreshToken: Option[String],
-  idempotency_key: Option[String]
+  idempotency_key: Option[String],
+  includeHistoricalProtocol: Option[Boolean] = None
 ) extends NextPageRequest {
   override def clone(
         maxFiles: Option[Int],
@@ -545,7 +547,8 @@ class DeltaSharingRestClient(
       table: Table,
       startingVersion: Long,
       endingVersion: Option[Long],
-      fileIdHash: Option[String]): DeltaTableFiles = {
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles = {
     val start = System.currentTimeMillis()
     val encodedShareName = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchemaName = URLEncoder.encode(table.schema, "UTF-8")
@@ -564,7 +567,8 @@ class DeltaSharingRestClient(
       pageToken = None,
       includeRefreshToken = None,
       refreshToken = None,
-      idempotency_key = None
+      idempotency_key = None,
+      includeHistoricalProtocol = if (includeHistoricalProtocol) Some(true) else None
     )
 
     val (version, respondedFormat, lines, responseFileIdHash) = if (queryTablePaginationEnabled) {

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -552,7 +552,16 @@ class DeltaSharingRestClient(
     val encodedShareName = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchemaName = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTableName = URLEncoder.encode(table.name, "UTF-8")
-    val queryString = if (includeHistoricalProtocol) "?includeHistoricalProtocol=true" else ""
+    // `includeHistoricalProtocol` only has a meaningful representation in the delta-format
+    // response (parquet-format responses don't carry inlined Protocol actions), so only send
+    // the URL param when both the caller opted in and the client is configured to accept
+    // delta responses. This keeps the wire shape backwards compatible for parquet-only callers.
+    val queryString = if (
+      includeHistoricalProtocol && responseFormatSet.contains(RESPONSE_FORMAT_DELTA)) {
+      "?includeHistoricalProtocol=true"
+    } else {
+      ""
+    }
     val target = getTargetUrl(
       s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query" +
         queryString)
@@ -973,9 +982,18 @@ class DeltaSharingRestClient(
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
       includeHistoricalProtocol: Boolean = false): String = {
+    // `includeHistoricalProtocol` only has a meaningful representation in the delta-format
+    // response, so only forward it to the server when the client is configured to accept
+    // delta responses. Parquet-only callers continue to omit the flag entirely.
+    val sendIncludeHistoricalProtocol =
+      includeHistoricalProtocol && responseFormatSet.contains(RESPONSE_FORMAT_DELTA)
     val paramMap = cdfOptions ++
       (if (includeHistoricalMetadata) Map("includeHistoricalMetadata" -> "true") else Map.empty) ++
-      (if (includeHistoricalProtocol) Map("includeHistoricalProtocol" -> "true") else Map.empty)
+      (if (sendIncludeHistoricalProtocol) {
+        Map("includeHistoricalProtocol" -> "true")
+      } else {
+        Map.empty
+      })
     paramMap.map {
       case (cdfKey, cdfValue) => s"$cdfKey=${URLEncoder.encode(cdfValue)}"
     }.mkString("&")

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -89,7 +89,8 @@ trait DeltaSharingClient {
       table: Table,
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
-      fileIdHash: Option[String]): DeltaTableFiles
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles
 
   def generateTemporaryTableCredential(
     table: Table,
@@ -737,12 +738,14 @@ class DeltaSharingRestClient(
       table: Table,
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
-      fileIdHash: Option[String]): DeltaTableFiles = {
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles = {
     val start = System.currentTimeMillis()
     val encodedShare = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchema = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTable = URLEncoder.encode(table.name, "UTF-8")
-    val encodedParams = getEncodedCDFParams(cdfOptions, includeHistoricalMetadata)
+    val encodedParams = getEncodedCDFParams(
+      cdfOptions, includeHistoricalMetadata, includeHistoricalProtocol)
 
     val target = getTargetUrl(
       s"/shares/$encodedShare/schemas/$encodedSchema/tables/$encodedTable/changes?$encodedParams")
@@ -964,12 +967,11 @@ class DeltaSharingRestClient(
 
   private def getEncodedCDFParams(
       cdfOptions: Map[String, String],
-      includeHistoricalMetadata: Boolean): String = {
-    val paramMap = cdfOptions ++ (if (includeHistoricalMetadata) {
-      Map("includeHistoricalMetadata" -> "true")
-    } else {
-      Map.empty
-    })
+      includeHistoricalMetadata: Boolean,
+      includeHistoricalProtocol: Boolean = false): String = {
+    val paramMap = cdfOptions ++
+      (if (includeHistoricalMetadata) Map("includeHistoricalMetadata" -> "true") else Map.empty) ++
+      (if (includeHistoricalProtocol) Map("includeHistoricalProtocol" -> "true") else Map.empty)
     paramMap.map {
       case (cdfKey, cdfValue) => s"$cdfKey=${URLEncoder.encode(cdfValue)}"
     }.mkString("&")

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -552,10 +552,9 @@ class DeltaSharingRestClient(
     val encodedShareName = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchemaName = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTableName = URLEncoder.encode(table.name, "UTF-8")
-    // `includeHistoricalProtocol` only has a meaningful representation in the delta-format
-    // response (parquet-format responses don't carry inlined Protocol actions), so only send
-    // the URL param when both the caller opted in and the client is configured to accept
-    // delta responses. This keeps the wire shape backwards compatible for parquet-only callers.
+    // `includeHistoricalProtocol` only affects delta-format responses; parquet responses
+    // return the same single Protocol regardless of the flag, so only send the URL param
+    // when the client is configured to accept delta responses.
     val queryString = if (
       includeHistoricalProtocol && responseFormatSet.contains(RESPONSE_FORMAT_DELTA)) {
       "?includeHistoricalProtocol=true"
@@ -982,9 +981,9 @@ class DeltaSharingRestClient(
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
       includeHistoricalProtocol: Boolean = false): String = {
-    // `includeHistoricalProtocol` only has a meaningful representation in the delta-format
-    // response, so only forward it to the server when the client is configured to accept
-    // delta responses. Parquet-only callers continue to omit the flag entirely.
+    // `includeHistoricalProtocol` only affects delta-format responses; parquet responses
+    // return the same single Protocol regardless of the flag, so only forward it when the
+    // client is configured to accept delta responses.
     val sendIncludeHistoricalProtocol =
       includeHistoricalProtocol && responseFormatSet.contains(RESPONSE_FORMAT_DELTA)
     val paramMap = cdfOptions ++

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -161,7 +161,8 @@ private[sharing] case class QueryTableRequest(
   pageToken: Option[String],
   includeRefreshToken: Option[Boolean],
   refreshToken: Option[String],
-  idempotency_key: Option[String]
+  idempotency_key: Option[String],
+  includeHistoricalProtocol: Option[Boolean] = None
 ) extends NextPageRequest {
   override def clone(
         maxFiles: Option[Int],
@@ -552,18 +553,14 @@ class DeltaSharingRestClient(
     val encodedShareName = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchemaName = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTableName = URLEncoder.encode(table.name, "UTF-8")
-    // `includeHistoricalProtocol` only affects delta-format responses; parquet responses
-    // return the same single Protocol regardless of the flag, so only send the URL param
-    // when the client is configured to accept delta responses.
-    val queryString = if (
-      includeHistoricalProtocol && responseFormatSet.contains(RESPONSE_FORMAT_DELTA)) {
-      "?includeHistoricalProtocol=true"
-    } else {
-      ""
-    }
     val target = getTargetUrl(
-      s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query" +
-        queryString)
+      s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query")
+    // `includeHistoricalProtocol` only affects delta-format responses; parquet responses
+    // return the same single Protocol regardless of the flag, so only set the request body
+    // field when the client is configured to accept delta responses. Otherwise leave it as
+    // `None` so the serialized POST body is byte-identical to today's parquet-only request.
+    val sendIncludeHistoricalProtocol =
+      includeHistoricalProtocol && responseFormatSet.contains(RESPONSE_FORMAT_DELTA)
     val request: QueryTableRequest = QueryTableRequest(
       predicateHints = Nil,
       limitHint = None,
@@ -576,7 +573,8 @@ class DeltaSharingRestClient(
       pageToken = None,
       includeRefreshToken = None,
       refreshToken = None,
-      idempotency_key = None
+      idempotency_key = None,
+      includeHistoricalProtocol = if (sendIncludeHistoricalProtocol) Some(true) else None
     )
 
     val (version, respondedFormat, lines, responseFileIdHash) = if (queryTablePaginationEnabled) {

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -2352,13 +2352,14 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  // Captures the POSTed QueryTableRequest body so we can assert what the streaming getFiles
-  // overload sends on the wire. Returns a minimal delta-format ndjson body so the call succeeds.
-  private class PostBodyCapturingRestClient(profileProvider: TestProfileProvider)
+  // Captures the URL passed to getNDJsonPost so we can assert the URL query string the streaming
+  // getFiles overload builds. Returns a minimal delta-format ndjson body so the call succeeds.
+  private class PostUrlCapturingRestClient(profileProvider: TestProfileProvider)
     extends DeltaSharingRestClient(
       profileProvider = profileProvider,
       responseFormat = RESPONSE_FORMAT_DELTA
     ) {
+    var capturedTarget: String = _
     var capturedBodyJson: String = _
 
     override def getNDJsonPost[T: Manifest](
@@ -2367,6 +2368,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         setIncludeEndStreamAction: Boolean,
         requestFileIdHash: Option[String]
     ): ParsedDeltaSharingResponse = {
+      capturedTarget = target
       capturedBodyJson = JsonUtils.toJson(data)
       ParsedDeltaSharingResponse(
         version = 0L,
@@ -2381,8 +2383,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  test("getFiles(startingVersion, ...) - includeHistoricalProtocol=true is added to request body") {
-    val client = new PostBodyCapturingRestClient(new TestProfileProvider(false))
+  test("getFiles(startingVersion, ...) - includeHistoricalProtocol=true sends URL param to server") {
+    val client = new PostUrlCapturingRestClient(new TestProfileProvider(false))
     try {
       val table = Table(name = "t", schema = "s", share = "sh")
       client.getFiles(
@@ -2392,10 +2394,15 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         fileIdHash = None,
         includeHistoricalProtocol = true
       )
-      assert(client.capturedBodyJson != null)
+      assert(client.capturedTarget != null)
       assert(
-        client.capturedBodyJson.contains("\"includeHistoricalProtocol\":true"),
-        s"expected request body to contain includeHistoricalProtocol=true, got: " +
+        client.capturedTarget.contains("includeHistoricalProtocol=true"),
+        s"expected URL to contain includeHistoricalProtocol=true, got: ${client.capturedTarget}"
+      )
+      // The flag should ride on the URL, not the request body.
+      assert(
+        !client.capturedBodyJson.contains("includeHistoricalProtocol"),
+        s"expected request body not to mention includeHistoricalProtocol, got: " +
           client.capturedBodyJson
       )
     } finally {
@@ -2404,7 +2411,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
   }
 
   test("getFiles(startingVersion, ...) - includeHistoricalProtocol is absent by default") {
-    val client = new PostBodyCapturingRestClient(new TestProfileProvider(false))
+    val client = new PostUrlCapturingRestClient(new TestProfileProvider(false))
     try {
       val table = Table(name = "t", schema = "s", share = "sh")
       client.getFiles(
@@ -2413,7 +2420,11 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         endingVersion = Some(5L),
         fileIdHash = None
       )
-      assert(client.capturedBodyJson != null)
+      assert(client.capturedTarget != null)
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to contain includeHistoricalProtocol, got: ${client.capturedTarget}"
+      )
       assert(
         !client.capturedBodyJson.contains("includeHistoricalProtocol"),
         s"expected request body not to mention includeHistoricalProtocol, got: " +

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -2279,4 +2279,76 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       client.close()
     }
   }
+
+  // Captures the URL passed to getNDJson so we can assert the URL query string the client built
+  // for getCDFFiles. Returns a minimal delta-format ndjson body so the call succeeds.
+  private class UrlCapturingRestClient(profileProvider: TestProfileProvider)
+    extends DeltaSharingRestClient(
+      profileProvider = profileProvider,
+      responseFormat = RESPONSE_FORMAT_DELTA
+    ) {
+    var capturedTarget: String = _
+
+    override def getNDJson(
+        target: String,
+        requireVersion: Boolean,
+        setIncludeEndStreamAction: Boolean,
+        requestFileIdHash: Option[String] = None): ParsedDeltaSharingResponse = {
+      capturedTarget = target
+      ParsedDeltaSharingResponse(
+        version = 0L,
+        respondedFormat = RESPONSE_FORMAT_DELTA,
+        lines = Seq(
+          """{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}""",
+          """{"metaData":{"deltaMetadata":{"id":"id","format":{"provider":"parquet"},"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}}"""
+        ),
+        capabilitiesMap = Map.empty,
+        fileIdHash = None
+      )
+    }
+  }
+
+  test("getCDFFiles - includeHistoricalProtocol=true sends URL param to server") {
+    val client = new UrlCapturingRestClient(new TestProfileProvider(false))
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getCDFFiles(
+        table,
+        cdfOptions = Map("startingVersion" -> "0"),
+        includeHistoricalMetadata = false,
+        fileIdHash = None,
+        includeHistoricalProtocol = true
+      )
+      assert(
+        client.capturedTarget != null && client.capturedTarget.contains("includeHistoricalProtocol=true"),
+        s"expected URL to contain includeHistoricalProtocol=true, got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
+
+  test("getCDFFiles - includeHistoricalProtocol is absent by default") {
+    val client = new UrlCapturingRestClient(new TestProfileProvider(false))
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getCDFFiles(
+        table,
+        cdfOptions = Map("startingVersion" -> "0"),
+        includeHistoricalMetadata = true,
+        fileIdHash = None
+      )
+      assert(client.capturedTarget != null)
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to contain includeHistoricalProtocol, got: ${client.capturedTarget}"
+      )
+      assert(
+        client.capturedTarget.contains("includeHistoricalMetadata=true"),
+        s"expected URL to contain includeHistoricalMetadata=true, got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
 }

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -2365,9 +2365,10 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  // Captures the URL passed to getNDJsonPost so we can assert the URL query string the streaming
-  // getFiles overload builds. Returns a minimal ndjson body in the format the client is configured
-  // for so the call succeeds end-to-end.
+  // Captures both the target URL and the serialized POST body for the streaming `getFiles`
+  // overload so tests can assert on whichever transport (URL vs body) a given parameter rides
+  // on. Returns a minimal ndjson body in the format the client is configured for so the call
+  // succeeds end-to-end.
   private class PostUrlCapturingRestClient(
       profileProvider: TestProfileProvider,
       responseFormat: String = RESPONSE_FORMAT_DELTA)
@@ -2409,7 +2410,7 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  test("getFiles(startingVersion, ...) - includeHistoricalProtocol=true sends URL param to server") {
+  test("getFiles(startingVersion, ...) - includeHistoricalProtocol=true is added to request body") {
     val client = new PostUrlCapturingRestClient(new TestProfileProvider(false))
     try {
       val table = Table(name = "t", schema = "s", share = "sh")
@@ -2420,16 +2421,16 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         fileIdHash = None,
         includeHistoricalProtocol = true
       )
-      assert(client.capturedTarget != null)
+      assert(client.capturedBodyJson != null)
       assert(
-        client.capturedTarget.contains("includeHistoricalProtocol=true"),
-        s"expected URL to contain includeHistoricalProtocol=true, got: ${client.capturedTarget}"
-      )
-      // The flag should ride on the URL, not the request body.
-      assert(
-        !client.capturedBodyJson.contains("includeHistoricalProtocol"),
-        s"expected request body not to mention includeHistoricalProtocol, got: " +
+        client.capturedBodyJson.contains("\"includeHistoricalProtocol\":true"),
+        s"expected request body to contain includeHistoricalProtocol=true, got: " +
           client.capturedBodyJson
+      )
+      // The flag rides on the body for the streaming /query endpoint, not the URL.
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to mention includeHistoricalProtocol, got: ${client.capturedTarget}"
       )
     } finally {
       client.close()
@@ -2446,15 +2447,15 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         endingVersion = Some(5L),
         fileIdHash = None
       )
-      assert(client.capturedTarget != null)
-      assert(
-        !client.capturedTarget.contains("includeHistoricalProtocol"),
-        s"expected URL not to contain includeHistoricalProtocol, got: ${client.capturedTarget}"
-      )
+      assert(client.capturedBodyJson != null)
       assert(
         !client.capturedBodyJson.contains("includeHistoricalProtocol"),
         s"expected request body not to mention includeHistoricalProtocol, got: " +
           client.capturedBodyJson
+      )
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to mention includeHistoricalProtocol, got: ${client.capturedTarget}"
       )
     } finally {
       client.close()
@@ -2462,8 +2463,9 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
   }
 
   // For parquet-only clients the flag is a no-op on the server (the parquet response returns
-  // the same single Protocol regardless), so the client must suppress the URL param even when
-  // the caller sets `includeHistoricalProtocol = true` to keep parquet-format requests unchanged.
+  // the same single Protocol regardless), so the client must suppress the flag (whether it's
+  // carried in the URL on `/changes` or in the request body on `/query`) even when the caller
+  // sets `includeHistoricalProtocol = true`, to keep parquet-format requests unchanged.
   test("getCDFFiles - includeHistoricalProtocol is suppressed when responseFormat=parquet " +
       "even if caller asks for it") {
     val client = new UrlCapturingRestClient(
@@ -2501,16 +2503,15 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         fileIdHash = None,
         includeHistoricalProtocol = true
       )
-      assert(client.capturedTarget != null)
-      assert(
-        !client.capturedTarget.contains("includeHistoricalProtocol"),
-        s"expected URL not to contain includeHistoricalProtocol for parquet-only client, " +
-          s"got: ${client.capturedTarget}"
-      )
+      assert(client.capturedBodyJson != null)
       assert(
         !client.capturedBodyJson.contains("includeHistoricalProtocol"),
-        s"expected request body not to mention includeHistoricalProtocol, got: " +
-          client.capturedBodyJson
+        s"expected request body not to mention includeHistoricalProtocol for parquet-only " +
+          s"client, got: ${client.capturedBodyJson}"
+      )
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to mention includeHistoricalProtocol, got: ${client.capturedTarget}"
       )
     } finally {
       client.close()

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -2351,4 +2351,76 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       client.close()
     }
   }
+
+  // Captures the POSTed QueryTableRequest body so we can assert what the streaming getFiles
+  // overload sends on the wire. Returns a minimal delta-format ndjson body so the call succeeds.
+  private class PostBodyCapturingRestClient(profileProvider: TestProfileProvider)
+    extends DeltaSharingRestClient(
+      profileProvider = profileProvider,
+      responseFormat = RESPONSE_FORMAT_DELTA
+    ) {
+    var capturedBodyJson: String = _
+
+    override def getNDJsonPost[T: Manifest](
+        target: String,
+        data: T,
+        setIncludeEndStreamAction: Boolean,
+        requestFileIdHash: Option[String]
+    ): ParsedDeltaSharingResponse = {
+      capturedBodyJson = JsonUtils.toJson(data)
+      ParsedDeltaSharingResponse(
+        version = 0L,
+        respondedFormat = RESPONSE_FORMAT_DELTA,
+        lines = Seq(
+          """{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}""",
+          """{"metaData":{"deltaMetadata":{"id":"id","format":{"provider":"parquet"},"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}}"""
+        ),
+        capabilitiesMap = Map.empty,
+        fileIdHash = None
+      )
+    }
+  }
+
+  test("getFiles(startingVersion, ...) - includeHistoricalProtocol=true is added to request body") {
+    val client = new PostBodyCapturingRestClient(new TestProfileProvider(false))
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getFiles(
+        table,
+        startingVersion = 0L,
+        endingVersion = Some(5L),
+        fileIdHash = None,
+        includeHistoricalProtocol = true
+      )
+      assert(client.capturedBodyJson != null)
+      assert(
+        client.capturedBodyJson.contains("\"includeHistoricalProtocol\":true"),
+        s"expected request body to contain includeHistoricalProtocol=true, got: " +
+          client.capturedBodyJson
+      )
+    } finally {
+      client.close()
+    }
+  }
+
+  test("getFiles(startingVersion, ...) - includeHistoricalProtocol is absent by default") {
+    val client = new PostBodyCapturingRestClient(new TestProfileProvider(false))
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getFiles(
+        table,
+        startingVersion = 0L,
+        endingVersion = Some(5L),
+        fileIdHash = None
+      )
+      assert(client.capturedBodyJson != null)
+      assert(
+        !client.capturedBodyJson.contains("includeHistoricalProtocol"),
+        s"expected request body not to mention includeHistoricalProtocol, got: " +
+          client.capturedBodyJson
+      )
+    } finally {
+      client.close()
+    }
+  }
 }

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -2461,9 +2461,9 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
-  // Parquet-only clients have no way to interpret inlined historical Protocol actions (the wire
-  // format doesn't carry them), so the client must suppress the URL param even when the caller
-  // sets `includeHistoricalProtocol = true`, to keep parquet-format requests unchanged.
+  // For parquet-only clients the flag is a no-op on the server (the parquet response returns
+  // the same single Protocol regardless), so the client must suppress the URL param even when
+  // the caller sets `includeHistoricalProtocol = true` to keep parquet-format requests unchanged.
   test("getCDFFiles - includeHistoricalProtocol is suppressed when responseFormat=parquet " +
       "even if caller asks for it") {
     val client = new UrlCapturingRestClient(

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -2281,11 +2281,14 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
   }
 
   // Captures the URL passed to getNDJson so we can assert the URL query string the client built
-  // for getCDFFiles. Returns a minimal delta-format ndjson body so the call succeeds.
-  private class UrlCapturingRestClient(profileProvider: TestProfileProvider)
+  // for getCDFFiles. Returns a minimal ndjson body in the format the client is configured for
+  // so the call succeeds end-to-end.
+  private class UrlCapturingRestClient(
+      profileProvider: TestProfileProvider,
+      responseFormat: String = RESPONSE_FORMAT_DELTA)
     extends DeltaSharingRestClient(
       profileProvider = profileProvider,
-      responseFormat = RESPONSE_FORMAT_DELTA
+      responseFormat = responseFormat
     ) {
     var capturedTarget: String = _
 
@@ -2295,13 +2298,23 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         setIncludeEndStreamAction: Boolean,
         requestFileIdHash: Option[String] = None): ParsedDeltaSharingResponse = {
       capturedTarget = target
+      val (respondedFormat, lines) = if (responseFormat == RESPONSE_FORMAT_DELTA) {
+        (RESPONSE_FORMAT_DELTA, Seq(
+          """{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}""",
+          """{"metaData":{"deltaMetadata":{"id":"id","format":{"provider":"parquet"},""" +
+            """"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}}"""
+        ))
+      } else {
+        (RESPONSE_FORMAT_PARQUET, Seq(
+          """{"protocol":{"minReaderVersion":1}}""",
+          """{"metaData":{"id":"id","format":{"provider":"parquet"},""" +
+            """"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}"""
+        ))
+      }
       ParsedDeltaSharingResponse(
         version = 0L,
-        respondedFormat = RESPONSE_FORMAT_DELTA,
-        lines = Seq(
-          """{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}""",
-          """{"metaData":{"deltaMetadata":{"id":"id","format":{"provider":"parquet"},"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}}"""
-        ),
+        respondedFormat = respondedFormat,
+        lines = lines,
         capabilitiesMap = Map.empty,
         fileIdHash = None
       )
@@ -2353,11 +2366,14 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
   }
 
   // Captures the URL passed to getNDJsonPost so we can assert the URL query string the streaming
-  // getFiles overload builds. Returns a minimal delta-format ndjson body so the call succeeds.
-  private class PostUrlCapturingRestClient(profileProvider: TestProfileProvider)
+  // getFiles overload builds. Returns a minimal ndjson body in the format the client is configured
+  // for so the call succeeds end-to-end.
+  private class PostUrlCapturingRestClient(
+      profileProvider: TestProfileProvider,
+      responseFormat: String = RESPONSE_FORMAT_DELTA)
     extends DeltaSharingRestClient(
       profileProvider = profileProvider,
-      responseFormat = RESPONSE_FORMAT_DELTA
+      responseFormat = responseFormat
     ) {
     var capturedTarget: String = _
     var capturedBodyJson: String = _
@@ -2370,13 +2386,23 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     ): ParsedDeltaSharingResponse = {
       capturedTarget = target
       capturedBodyJson = JsonUtils.toJson(data)
+      val (respondedFormat, lines) = if (responseFormat == RESPONSE_FORMAT_DELTA) {
+        (RESPONSE_FORMAT_DELTA, Seq(
+          """{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}""",
+          """{"metaData":{"deltaMetadata":{"id":"id","format":{"provider":"parquet"},""" +
+            """"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}}"""
+        ))
+      } else {
+        (RESPONSE_FORMAT_PARQUET, Seq(
+          """{"protocol":{"minReaderVersion":1}}""",
+          """{"metaData":{"id":"id","format":{"provider":"parquet"},""" +
+            """"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}"""
+        ))
+      }
       ParsedDeltaSharingResponse(
         version = 0L,
-        respondedFormat = RESPONSE_FORMAT_DELTA,
-        lines = Seq(
-          """{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}""",
-          """{"metaData":{"deltaMetadata":{"id":"id","format":{"provider":"parquet"},"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}}"""
-        ),
+        respondedFormat = respondedFormat,
+        lines = lines,
         capabilitiesMap = Map.empty,
         fileIdHash = None
       )
@@ -2429,6 +2455,90 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         !client.capturedBodyJson.contains("includeHistoricalProtocol"),
         s"expected request body not to mention includeHistoricalProtocol, got: " +
           client.capturedBodyJson
+      )
+    } finally {
+      client.close()
+    }
+  }
+
+  // Parquet-only clients have no way to interpret inlined historical Protocol actions (the wire
+  // format doesn't carry them), so the client must suppress the URL param even when the caller
+  // sets `includeHistoricalProtocol = true`, to keep parquet-format requests unchanged.
+  test("getCDFFiles - includeHistoricalProtocol is suppressed when responseFormat=parquet " +
+      "even if caller asks for it") {
+    val client = new UrlCapturingRestClient(
+      new TestProfileProvider(false), responseFormat = RESPONSE_FORMAT_PARQUET)
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getCDFFiles(
+        table,
+        cdfOptions = Map("startingVersion" -> "0"),
+        includeHistoricalMetadata = false,
+        fileIdHash = None,
+        includeHistoricalProtocol = true
+      )
+      assert(client.capturedTarget != null)
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to contain includeHistoricalProtocol for parquet-only client, " +
+          s"got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
+
+  test("getFiles(startingVersion, ...) - includeHistoricalProtocol is suppressed when " +
+      "responseFormat=parquet even if caller asks for it") {
+    val client = new PostUrlCapturingRestClient(
+      new TestProfileProvider(false), responseFormat = RESPONSE_FORMAT_PARQUET)
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getFiles(
+        table,
+        startingVersion = 0L,
+        endingVersion = Some(5L),
+        fileIdHash = None,
+        includeHistoricalProtocol = true
+      )
+      assert(client.capturedTarget != null)
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to contain includeHistoricalProtocol for parquet-only client, " +
+          s"got: ${client.capturedTarget}"
+      )
+      assert(
+        !client.capturedBodyJson.contains("includeHistoricalProtocol"),
+        s"expected request body not to mention includeHistoricalProtocol, got: " +
+          client.capturedBodyJson
+      )
+    } finally {
+      client.close()
+    }
+  }
+
+  // When the client is configured for both parquet *and* delta (e.g. responseFormat=parquet,delta
+  // for negotiation), the caller's `includeHistoricalProtocol=true` should still be forwarded
+  // because the server can pick the delta-format response and inline historical Protocol actions.
+  test("getCDFFiles - includeHistoricalProtocol is forwarded when responseFormat includes delta " +
+      "alongside parquet") {
+    val client = new UrlCapturingRestClient(
+      new TestProfileProvider(false),
+      responseFormat = s"$RESPONSE_FORMAT_PARQUET,$RESPONSE_FORMAT_DELTA")
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getCDFFiles(
+        table,
+        cdfOptions = Map("startingVersion" -> "0"),
+        includeHistoricalMetadata = false,
+        fileIdHash = None,
+        includeHistoricalProtocol = true
+      )
+      assert(
+        client.capturedTarget != null &&
+          client.capturedTarget.contains("includeHistoricalProtocol=true"),
+        s"expected URL to contain includeHistoricalProtocol=true when delta is in " +
+          s"responseFormat, got: ${client.capturedTarget}"
       )
     } finally {
       client.close()

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -163,7 +163,8 @@ class TestDeltaSharingClient(
       table: Table,
       startingVersion: Long,
       endingVersion: Option[Long],
-      fileIdHash: Option[String]): DeltaTableFiles = {
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles = {
     // This is not used anywhere.
     DeltaTableFiles(
       0, Protocol(0), metadata, Nil, Nil, Nil, Nil, respondedFormat = RESPONSE_FORMAT_PARQUET

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -174,7 +174,8 @@ class TestDeltaSharingClient(
       table: Table,
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
-      fileIdHash: Option[String]): DeltaTableFiles = {
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles = {
     val addFiles: Seq[AddFileForCDF] = Seq(
       AddFileForCDF("cdf_add1.parquet", "cdf_add1", Map.empty, 100, 1, 1000)
     )


### PR DESCRIPTION
## Summary

Client-side half of `includeHistoricalProtocol` support for both delta-sharing endpoints that can stream a range of versions:

- `getCDFFiles` (`GET .../changes`) — flag is appended to the **URL query string** via `getEncodedCDFParams`, next to `includeHistoricalMetadata`.
- streaming `getFiles(table, startingVersion, endingVersion, fileIdHash)` (`POST .../query`) — flag is set on the **`QueryTableRequest` POST body** (it logically belongs alongside `startingVersion` / `endingVersion`).

Both paths get a new `includeHistoricalProtocol: Boolean = false` parameter on the `DeltaSharingClient` trait. The `TestDeltaSharingClient` mock implementing the trait is updated to match.

The matching server change (parse the new param, emit historical `Protocol` actions in delta-format responses, version-stamp each Protocol) is in companion PR #970.

## Wire surface

### `getCDFFiles` (`GET .../changes`)

- `getEncodedCDFParams` appends `includeHistoricalProtocol=true` only when the caller opted in **and** the client's `responseFormat` includes `delta`.

### Streaming `getFiles` (`POST .../query`)

- `QueryTableRequest` case class gains `includeHistoricalProtocol: Option[Boolean] = None`. `getFiles(startingVersion, ...)` sets this to `Some(true)` only when the caller opted in **and** the client's `responseFormat` includes `delta`. The target URL is unchanged.

### Parquet-format gating (both endpoints)

For parquet-only clients the flag is a no-op on the server — the parquet response returns the same single Protocol regardless. The client suppresses the flag (URL on `/changes`, body field on `/query`) for parquet-only clients to keep parquet-format requests byte-identical to today's. Clients negotiated for `parquet,delta` still forward the flag, because the server can pick the delta-format response.

## Backwards compatibility

- Default is `false`, so existing call sites (`RemoteDeltaCDFRelation`, `DeltaSharingSource`, `RemoteDeltaLogSuite`, etc.) compile and behave unchanged.
- When the flag is `false`, both the URL and the POST body are byte-for-byte identical to today's request, so old servers see no difference.
- When the flag is `true` against an old server, the unknown URL query string parameter (on `/changes`) and the unknown body field (on `/query`) are simply ignored.
- `TestDeltaSharingClient` (spark-test mock) is updated to match the new signatures so the `spark` module still compiles.

## Tests

`testOnly io.delta.sharing.client.DeltaSharingRestClientSuite -- -z "includeHistoricalProtocol"` → **7 succeeded** locally:

- 2 for `getCDFFiles` (URL contains/doesn't contain `includeHistoricalProtocol=true`).
- 2 for streaming `getFiles` (body JSON contains/doesn't contain `"includeHistoricalProtocol":true`; URL never contains it).
- 1 for `getCDFFiles` parquet suppression (caller opts in, parquet-only client, URL does not contain the flag).
- 1 for streaming `getFiles` parquet suppression (caller opts in, parquet-only client, body does not contain the flag).
- 1 for `getCDFFiles` parquet+delta forwarding (caller opts in, `responseFormat=parquet,delta`, URL contains the flag).

## Companion PR

Server + protocol-doc half: #970.

(Supersedes #967, which was opened from a fork branch and therefore could not run secret-gated CI.)