### PR TITLE
[branch-1.4][Client] Add includeHistoricalProtocol param on getCDFFiles and streaming getFiles

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -83,13 +83,15 @@ trait DeltaSharingClient {
     table: Table,
     startingVersion: Long,
     endingVersion: Option[Long],
-    fileIdHash: Option[String]): DeltaTableFiles
+    fileIdHash: Option[String],
+    includeHistoricalProtocol: Boolean = false): DeltaTableFiles
 
   def getCDFFiles(
       table: Table,
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
-      fileIdHash: Option[String]): DeltaTableFiles
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles
 
   def generateTemporaryTableCredential(
     table: Table,
@@ -159,7 +161,8 @@ private[sharing] case class QueryTableRequest(
   pageToken: Option[String],
   includeRefreshToken: Option[Boolean],
   refreshToken: Option[String],
-  idempotency_key: Option[String]
+  idempotency_key: Option[String],
+  includeHistoricalProtocol: Option[Boolean] = None
 ) extends NextPageRequest {
   override def clone(
         maxFiles: Option[Int],
@@ -544,13 +547,20 @@ class DeltaSharingRestClient(
       table: Table,
       startingVersion: Long,
       endingVersion: Option[Long],
-      fileIdHash: Option[String]): DeltaTableFiles = {
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles = {
     val start = System.currentTimeMillis()
     val encodedShareName = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchemaName = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTableName = URLEncoder.encode(table.name, "UTF-8")
     val target = getTargetUrl(
       s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/query")
+    // `includeHistoricalProtocol` only affects delta-format responses; parquet responses
+    // return the same single Protocol regardless of the flag, so only set the request body
+    // field when the client is configured to accept delta responses. Otherwise leave it as
+    // `None` so the serialized POST body is byte-identical to today's parquet-only request.
+    val sendIncludeHistoricalProtocol =
+      includeHistoricalProtocol && responseFormatSet.contains(RESPONSE_FORMAT_DELTA)
     val request: QueryTableRequest = QueryTableRequest(
       predicateHints = Nil,
       limitHint = None,
@@ -563,7 +573,8 @@ class DeltaSharingRestClient(
       pageToken = None,
       includeRefreshToken = None,
       refreshToken = None,
-      idempotency_key = None
+      idempotency_key = None,
+      includeHistoricalProtocol = if (sendIncludeHistoricalProtocol) Some(true) else None
     )
 
     val (version, respondedFormat, lines, responseFileIdHash) = if (queryTablePaginationEnabled) {
@@ -737,12 +748,14 @@ class DeltaSharingRestClient(
       table: Table,
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
-      fileIdHash: Option[String]): DeltaTableFiles = {
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles = {
     val start = System.currentTimeMillis()
     val encodedShare = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchema = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTable = URLEncoder.encode(table.name, "UTF-8")
-    val encodedParams = getEncodedCDFParams(cdfOptions, includeHistoricalMetadata)
+    val encodedParams = getEncodedCDFParams(
+      cdfOptions, includeHistoricalMetadata, includeHistoricalProtocol)
 
     val target = getTargetUrl(
       s"/shares/$encodedShare/schemas/$encodedSchema/tables/$encodedTable/changes?$encodedParams")
@@ -964,12 +977,20 @@ class DeltaSharingRestClient(
 
   private def getEncodedCDFParams(
       cdfOptions: Map[String, String],
-      includeHistoricalMetadata: Boolean): String = {
-    val paramMap = cdfOptions ++ (if (includeHistoricalMetadata) {
-      Map("includeHistoricalMetadata" -> "true")
-    } else {
-      Map.empty
-    })
+      includeHistoricalMetadata: Boolean,
+      includeHistoricalProtocol: Boolean = false): String = {
+    // `includeHistoricalProtocol` only affects delta-format responses; parquet responses
+    // return the same single Protocol regardless of the flag, so only forward it when the
+    // client is configured to accept delta responses.
+    val sendIncludeHistoricalProtocol =
+      includeHistoricalProtocol && responseFormatSet.contains(RESPONSE_FORMAT_DELTA)
+    val paramMap = cdfOptions ++
+      (if (includeHistoricalMetadata) Map("includeHistoricalMetadata" -> "true") else Map.empty) ++
+      (if (sendIncludeHistoricalProtocol) {
+        Map("includeHistoricalProtocol" -> "true")
+      } else {
+        Map.empty
+      })
     paramMap.map {
       case (cdfKey, cdfValue) => s"$cdfKey=${URLEncoder.encode(cdfValue)}"
     }.mkString("&")

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -2279,4 +2279,270 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       client.close()
     }
   }
+
+  // Captures the URL passed to getNDJson so we can assert the URL query string the client built
+  // for getCDFFiles. Returns a minimal ndjson body in the format the client is configured for
+  // so the call succeeds end-to-end.
+  private class UrlCapturingRestClient(
+      profileProvider: TestProfileProvider,
+      responseFormat: String = RESPONSE_FORMAT_DELTA)
+    extends DeltaSharingRestClient(
+      profileProvider = profileProvider,
+      responseFormat = responseFormat
+    ) {
+    var capturedTarget: String = _
+
+    override def getNDJson(
+        target: String,
+        requireVersion: Boolean,
+        setIncludeEndStreamAction: Boolean,
+        requestFileIdHash: Option[String] = None): ParsedDeltaSharingResponse = {
+      capturedTarget = target
+      val (respondedFormat, lines) = if (responseFormat == RESPONSE_FORMAT_DELTA) {
+        (RESPONSE_FORMAT_DELTA, Seq(
+          """{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}""",
+          """{"metaData":{"deltaMetadata":{"id":"id","format":{"provider":"parquet"},""" +
+            """"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}}"""
+        ))
+      } else {
+        (RESPONSE_FORMAT_PARQUET, Seq(
+          """{"protocol":{"minReaderVersion":1}}""",
+          """{"metaData":{"id":"id","format":{"provider":"parquet"},""" +
+            """"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}"""
+        ))
+      }
+      ParsedDeltaSharingResponse(
+        version = 0L,
+        respondedFormat = respondedFormat,
+        lines = lines,
+        capabilitiesMap = Map.empty,
+        fileIdHash = None
+      )
+    }
+  }
+
+  test("getCDFFiles - includeHistoricalProtocol=true sends URL param to server") {
+    val client = new UrlCapturingRestClient(new TestProfileProvider(false))
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getCDFFiles(
+        table,
+        cdfOptions = Map("startingVersion" -> "0"),
+        includeHistoricalMetadata = false,
+        fileIdHash = None,
+        includeHistoricalProtocol = true
+      )
+      assert(
+        client.capturedTarget != null && client.capturedTarget.contains("includeHistoricalProtocol=true"),
+        s"expected URL to contain includeHistoricalProtocol=true, got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
+
+  test("getCDFFiles - includeHistoricalProtocol is absent by default") {
+    val client = new UrlCapturingRestClient(new TestProfileProvider(false))
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getCDFFiles(
+        table,
+        cdfOptions = Map("startingVersion" -> "0"),
+        includeHistoricalMetadata = true,
+        fileIdHash = None
+      )
+      assert(client.capturedTarget != null)
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to contain includeHistoricalProtocol, got: ${client.capturedTarget}"
+      )
+      assert(
+        client.capturedTarget.contains("includeHistoricalMetadata=true"),
+        s"expected URL to contain includeHistoricalMetadata=true, got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
+
+  // Captures both the target URL and the serialized POST body for the streaming `getFiles`
+  // overload so tests can assert on whichever transport (URL vs body) a given parameter rides
+  // on. Returns a minimal ndjson body in the format the client is configured for so the call
+  // succeeds end-to-end.
+  private class PostUrlCapturingRestClient(
+      profileProvider: TestProfileProvider,
+      responseFormat: String = RESPONSE_FORMAT_DELTA)
+    extends DeltaSharingRestClient(
+      profileProvider = profileProvider,
+      responseFormat = responseFormat
+    ) {
+    var capturedTarget: String = _
+    var capturedBodyJson: String = _
+
+    override def getNDJsonPost[T: Manifest](
+        target: String,
+        data: T,
+        setIncludeEndStreamAction: Boolean,
+        requestFileIdHash: Option[String]
+    ): ParsedDeltaSharingResponse = {
+      capturedTarget = target
+      capturedBodyJson = JsonUtils.toJson(data)
+      val (respondedFormat, lines) = if (responseFormat == RESPONSE_FORMAT_DELTA) {
+        (RESPONSE_FORMAT_DELTA, Seq(
+          """{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}""",
+          """{"metaData":{"deltaMetadata":{"id":"id","format":{"provider":"parquet"},""" +
+            """"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}}"""
+        ))
+      } else {
+        (RESPONSE_FORMAT_PARQUET, Seq(
+          """{"protocol":{"minReaderVersion":1}}""",
+          """{"metaData":{"id":"id","format":{"provider":"parquet"},""" +
+            """"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}"""
+        ))
+      }
+      ParsedDeltaSharingResponse(
+        version = 0L,
+        respondedFormat = respondedFormat,
+        lines = lines,
+        capabilitiesMap = Map.empty,
+        fileIdHash = None
+      )
+    }
+  }
+
+  test("getFiles(startingVersion, ...) - includeHistoricalProtocol=true is added to request body") {
+    val client = new PostUrlCapturingRestClient(new TestProfileProvider(false))
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getFiles(
+        table,
+        startingVersion = 0L,
+        endingVersion = Some(5L),
+        fileIdHash = None,
+        includeHistoricalProtocol = true
+      )
+      assert(client.capturedBodyJson != null)
+      assert(
+        client.capturedBodyJson.contains("\"includeHistoricalProtocol\":true"),
+        s"expected request body to contain includeHistoricalProtocol=true, got: " +
+          client.capturedBodyJson
+      )
+      // The flag rides on the body for the streaming /query endpoint, not the URL.
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to mention includeHistoricalProtocol, got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
+
+  test("getFiles(startingVersion, ...) - includeHistoricalProtocol is absent by default") {
+    val client = new PostUrlCapturingRestClient(new TestProfileProvider(false))
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getFiles(
+        table,
+        startingVersion = 0L,
+        endingVersion = Some(5L),
+        fileIdHash = None
+      )
+      assert(client.capturedBodyJson != null)
+      assert(
+        !client.capturedBodyJson.contains("includeHistoricalProtocol"),
+        s"expected request body not to mention includeHistoricalProtocol, got: " +
+          client.capturedBodyJson
+      )
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to mention includeHistoricalProtocol, got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
+
+  // For parquet-only clients the flag is a no-op on the server (the parquet response returns
+  // the same single Protocol regardless), so the client must suppress the flag (whether it's
+  // carried in the URL on `/changes` or in the request body on `/query`) even when the caller
+  // sets `includeHistoricalProtocol = true`, to keep parquet-format requests unchanged.
+  test("getCDFFiles - includeHistoricalProtocol is suppressed when responseFormat=parquet " +
+      "even if caller asks for it") {
+    val client = new UrlCapturingRestClient(
+      new TestProfileProvider(false), responseFormat = RESPONSE_FORMAT_PARQUET)
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getCDFFiles(
+        table,
+        cdfOptions = Map("startingVersion" -> "0"),
+        includeHistoricalMetadata = false,
+        fileIdHash = None,
+        includeHistoricalProtocol = true
+      )
+      assert(client.capturedTarget != null)
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to contain includeHistoricalProtocol for parquet-only client, " +
+          s"got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
+
+  test("getFiles(startingVersion, ...) - includeHistoricalProtocol is suppressed when " +
+      "responseFormat=parquet even if caller asks for it") {
+    val client = new PostUrlCapturingRestClient(
+      new TestProfileProvider(false), responseFormat = RESPONSE_FORMAT_PARQUET)
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getFiles(
+        table,
+        startingVersion = 0L,
+        endingVersion = Some(5L),
+        fileIdHash = None,
+        includeHistoricalProtocol = true
+      )
+      assert(client.capturedBodyJson != null)
+      assert(
+        !client.capturedBodyJson.contains("includeHistoricalProtocol"),
+        s"expected request body not to mention includeHistoricalProtocol for parquet-only " +
+          s"client, got: ${client.capturedBodyJson}"
+      )
+      assert(
+        !client.capturedTarget.contains("includeHistoricalProtocol"),
+        s"expected URL not to mention includeHistoricalProtocol, got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
+
+  // When the client is configured for both parquet *and* delta (e.g. responseFormat=parquet,delta
+  // for negotiation), the caller's `includeHistoricalProtocol=true` should still be forwarded
+  // because the server can pick the delta-format response and inline historical Protocol actions.
+  test("getCDFFiles - includeHistoricalProtocol is forwarded when responseFormat includes delta " +
+      "alongside parquet") {
+    val client = new UrlCapturingRestClient(
+      new TestProfileProvider(false),
+      responseFormat = s"$RESPONSE_FORMAT_PARQUET,$RESPONSE_FORMAT_DELTA")
+    try {
+      val table = Table(name = "t", schema = "s", share = "sh")
+      client.getCDFFiles(
+        table,
+        cdfOptions = Map("startingVersion" -> "0"),
+        includeHistoricalMetadata = false,
+        fileIdHash = None,
+        includeHistoricalProtocol = true
+      )
+      assert(
+        client.capturedTarget != null &&
+          client.capturedTarget.contains("includeHistoricalProtocol=true"),
+        s"expected URL to contain includeHistoricalProtocol=true when delta is in " +
+          s"responseFormat, got: ${client.capturedTarget}"
+      )
+    } finally {
+      client.close()
+    }
+  }
 }

--- a/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/TestDeltaSharingClient.scala
@@ -163,7 +163,8 @@ class TestDeltaSharingClient(
       table: Table,
       startingVersion: Long,
       endingVersion: Option[Long],
-      fileIdHash: Option[String]): DeltaTableFiles = {
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles = {
     // This is not used anywhere.
     DeltaTableFiles(
       0, Protocol(0), metadata, Nil, Nil, Nil, Nil, respondedFormat = RESPONSE_FORMAT_PARQUET
@@ -174,7 +175,8 @@ class TestDeltaSharingClient(
       table: Table,
       cdfOptions: Map[String, String],
       includeHistoricalMetadata: Boolean,
-      fileIdHash: Option[String]): DeltaTableFiles = {
+      fileIdHash: Option[String],
+      includeHistoricalProtocol: Boolean = false): DeltaTableFiles = {
     val addFiles: Seq[AddFileForCDF] = Seq(
       AddFileForCDF("cdf_add1.parquet", "cdf_add1", Map.empty, 100, 1, 1000)
     )


### PR DESCRIPTION
## Summary

Backport of #969 to `branch-1.4` (clean cherry-pick of squash merge `8d323fb`; one auto-merge hunk in `DeltaSharingRestClientSuite`, no manual conflict resolution required).

Client-side half of `includeHistoricalProtocol` support for both delta-sharing endpoints that can stream a range of versions:

- `getCDFFiles` (`GET .../changes`) — flag is appended to the **URL query string** via `getEncodedCDFParams`, next to `includeHistoricalMetadata`.
- streaming `getFiles(table, startingVersion, endingVersion, fileIdHash)` (`POST .../query`) — flag is set on the **`QueryTableRequest` POST body** (it logically belongs alongside `startingVersion` / `endingVersion`).

Both paths get a new `includeHistoricalProtocol: Boolean = false` parameter on the `DeltaSharingClient` trait. The `TestDeltaSharingClient` mock implementing the trait is updated to match. Server-side wiring lands in #970 (also targeted for backports).

## Parquet-format gating

For parquet-only clients the flag is a no-op on the server — the parquet response returns the same single Protocol regardless. The client suppresses the flag (URL on `/changes`, body field on `/query`) for parquet-only clients to keep parquet-format requests byte-identical to today's. Clients negotiated for `parquet,delta` still forward the flag.

## Backwards compatibility

- Default is `false`, so existing call sites (`RemoteDeltaCDFRelation`, `DeltaSharingSource`, `RemoteDeltaLogSuite`, etc.) compile and behave unchanged.
- When the flag is `false`, both the URL and the POST body are byte-for-byte identical to today's request, so old servers see no difference.
- When the flag is `true` against an old server, the unknown URL query string parameter (on `/changes`) and the unknown body field (on `/query`) are simply ignored.

## Test plan

- [x] `client/Test/compile` succeeds; scalastyle clean.
- [x] `testOnly io.delta.sharing.client.DeltaSharingRestClientSuite -- -z "includeHistoricalProtocol"` → **7 succeeded** locally on `branch-1.4`.
- [ ] Full CI on this PR.

## Original PR

#969 (merged into `main` as `8d323fb`).