### PR TITLE
[Python] Fix BearerTokenAuthProvider.is_expired() for ISO-8601 'Z' timestamps

### DIFF
--- a/python/delta_sharing/_internal_auth.py
+++ b/python/delta_sharing/_internal_auth.py
@@ -17,6 +17,7 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from typing import Optional
+import re
 import requests
 import base64
 import json
@@ -79,10 +80,29 @@ class BearerTokenAuthProvider(AuthCredentialProvider):
         if self.expiration_time is None:
             return False
         try:
-            expiration_time_as_timestamp = datetime.fromisoformat(self.expiration_time)
-            return expiration_time_as_timestamp < datetime.now()
+            expiration_time_as_timestamp = self._parse_expiration_time(self.expiration_time)
         except ValueError:
             return False
+        return expiration_time_as_timestamp < datetime.now(timezone.utc)
+
+    @staticmethod
+    def _parse_expiration_time(expiration_time: str) -> datetime:
+        # The profile "expirationTime" is an ISO-8601 timestamp, e.g.
+        # "2021-11-12T00:12:29.0Z". datetime.fromisoformat does not accept the
+        # "Z" UTC designator or sub-millisecond fractions before Python 3.11, so
+        # normalize both before parsing. A timestamp with no offset is treated as
+        # UTC so the result is always timezone-aware and safe to compare.
+        normalized = expiration_time
+        if normalized.endswith("Z"):
+            normalized = normalized[:-1] + "+00:00"
+        match = re.search(r"\.(\d+)", normalized)
+        if match:
+            fraction = (match.group(1) + "000000")[:6]
+            normalized = f"{normalized[:match.start()]}.{fraction}{normalized[match.end():]}"
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
 
     def get_expiration_time(self) -> Optional[str]:
         return self.expiration_time

--- a/python/delta_sharing/tests/test_auth.py
+++ b/python/delta_sharing/tests/test_auth.py
@@ -15,7 +15,7 @@
 #
 
 from unittest.mock import MagicMock
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from delta_sharing._internal_auth import (
     ClientSecretOAuthClient,
     BasicAuthProvider,
@@ -54,6 +54,35 @@ def test_bearer_token_auth_provider_is_expired():
     valid_token = "valid-token"
     expiration_time = (datetime.now() + timedelta(days=1)).isoformat()
     provider = BearerTokenAuthProvider(valid_token, expiration_time)
+    assert not provider.is_expired()
+
+
+def test_bearer_token_auth_provider_is_expired_iso8601_utc():
+    # The profile "expirationTime" is emitted as an ISO-8601 UTC timestamp with a
+    # trailing "Z", e.g. "2021-11-12T00:12:29.0Z" (see the profile test fixtures).
+    provider = BearerTokenAuthProvider("expired-token", "2021-11-12T00:12:29.0Z")
+    assert provider.is_expired()
+
+    future = datetime.now(timezone.utc) + timedelta(days=1)
+    expiration_time = future.strftime("%Y-%m-%dT%H:%M:%S.0Z")
+    provider = BearerTokenAuthProvider("valid-token", expiration_time)
+    assert not provider.is_expired()
+
+
+def test_bearer_token_auth_provider_is_expired_with_offset():
+    # ISO-8601 timestamps may carry a non-UTC offset, e.g. "...-02:00".
+    provider = BearerTokenAuthProvider("expired-token", "2022-01-01T00:00:00-02:00")
+    assert provider.is_expired()
+
+    provider = BearerTokenAuthProvider("valid-token", "2999-01-01T00:00:00-02:00")
+    assert not provider.is_expired()
+
+
+def test_bearer_token_auth_provider_is_expired_invalid_timestamp():
+    provider = BearerTokenAuthProvider("token", "not-a-timestamp")
+    assert not provider.is_expired()
+
+    provider = BearerTokenAuthProvider("token", None)
     assert not provider.is_expired()
 
 


### PR DESCRIPTION

### What

Fix `BearerTokenAuthProvider.is_expired()` in the Python client so it correctly
handles the ISO-8601 `expirationTime` value that Delta Sharing profiles actually
carry, for example `"2021-11-12T00:12:29.0Z"`.

### Why

The profile `expirationTime` is an ISO-8601 timestamp with a trailing `Z` (UTC).
This is the format used by the profile test fixtures
(`python/delta_sharing/tests/test_profile.json`,
`test_profile_bearer.json`) and by the Scala client, which parses it with
`ISO_OFFSET_DATE_TIME`. The Python `is_expired()` parsed it with
`datetime.fromisoformat` and compared the result against a naive
`datetime.now()`, which is wrong two ways for that documented format:

- On Python 3.10 (the declared minimum, `requires-python = ">=3.10"`),
  `datetime.fromisoformat` cannot parse the `Z` suffix and raises `ValueError`.
  The `except ValueError: return False` clause swallowed it, so `is_expired()`
  returned `False` even for a long-expired token.
- On Python 3.11+, `fromisoformat` accepts `Z` and returns a timezone-aware
  `datetime`. Comparing that against a naive `datetime.now()` raises
  `TypeError: can't compare offset-naive and offset-aware datetimes`, which is
  not a `ValueError` and so propagated out of the public method.

A non-UTC offset such as `"2022-01-01T00:00:00-02:00"` hit the same
aware-vs-naive `TypeError` on both versions.

### How

`is_expired()` now normalizes the timestamp before comparing:

- Convert a trailing `Z` to `+00:00` so `fromisoformat` accepts it on Python 3.10.
- Pad or trim the fractional seconds to the 6 digits `fromisoformat` supports on
  3.10 (so sub-millisecond fractions and over-long fractions both parse).
- Treat a value with no offset as UTC, so the parsed `datetime` is always
  timezone-aware.
- Compare against `datetime.now(timezone.utc)`.

Invalid strings still return `False` (the `ValueError` path is preserved), and a
`None` expiration still short-circuits to `False`, so existing behavior for those
cases is unchanged.

### Tests

Added regression tests in `python/delta_sharing/tests/test_auth.py` that feed the
real profile `Z` format and a non-UTC offset, for both expired and future tokens,
plus invalid/`None` inputs. These fail on the current code (silent wrong `False`
on 3.10, uncaught `TypeError` on 3.11) and pass with the fix. Verified
`test_auth.py` green on both Python 3.10 and 3.11; ran `dev/lint-python`
(black, pycodestyle, flake8, mypy) clean on the package.

### Scope

Only `BearerTokenAuthProvider.is_expired()` and its tests are touched. Diff is
2 files, +52/-3.
