### PR TITLE
Add UnsupportedOp for unsupported predicate sub-expressions

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -70,6 +70,10 @@ object ConfUtils {
   val JSON_PREDICATE_V2_CONF = "spark.delta.sharing.jsonPredicateV2Hints.enabled"
   val JSON_PREDICATE_V2_DEFAULT = "true"
 
+  val JSON_PREDICATE_PARTIAL_FILTER_CONF =
+    "spark.delta.sharing.jsonPredicateHints.partialFilter.enabled"
+  val JSON_PREDICATE_PARTIAL_FILTER_DEFAULT = "false"
+
   val QUERY_PAGINATION_ENABLED_CONF = "spark.delta.sharing.queryPagination.enabled"
   val QUERY_PAGINATION_ENABLED_DEFAULT = "false"
 
@@ -258,6 +262,11 @@ object ConfUtils {
 
   def jsonPredicatesV2Enabled(conf: SQLConf): Boolean = {
     conf.getConfString(JSON_PREDICATE_V2_CONF, JSON_PREDICATE_V2_DEFAULT).toBoolean
+  }
+
+  def jsonPredicatePartialFilterEnabled(conf: SQLConf): Boolean = {
+    conf.getConfString(
+      JSON_PREDICATE_PARTIAL_FILTER_CONF, JSON_PREDICATE_PARTIAL_FILTER_DEFAULT).toBoolean
   }
 
   def queryTablePaginationEnabled(conf: SQLConf): Boolean = {

--- a/client/src/main/scala/io/delta/sharing/filters/JsonPredicates.scala
+++ b/client/src/main/scala/io/delta/sharing/filters/JsonPredicates.scala
@@ -303,6 +303,20 @@ case class NotOp(val children: Seq[BaseOp]) extends NonLeafOp with UnaryOp {
   override def eval(ctx: EvalContext): Any = !children(0).evalExpectBoolean(ctx)
 }
 
+/**
+ * Represents an unsupported operation that cannot be evaluated.
+ *
+ * Emitted by OpConverter when a sub-expression cannot be converted
+ * (e.g. nested struct field access). Evaluates conservatively to true so that
+ * compound predicates containing it can still prune based on their other children.
+ */
+case class UnsupportedOp() extends BaseOp {
+  override def validate(forV2: Boolean = false): Unit = {}
+
+  override def eval(ctx: EvalContext): Any = true
+}
+
+
 // A helper for evaluating opertions.
 object EvalHelper {
 

--- a/client/src/main/scala/io/delta/sharing/filters/OpConverter.scala
+++ b/client/src/main/scala/io/delta/sharing/filters/OpConverter.scala
@@ -62,34 +62,45 @@ object OpConverter {
   // Converts a set of SQL expression trees into a json predicate op.
   // We perform an implicit And across the input set at the top level.
   //
-  // The method throws an exception if the conversion fails, and callers
-  // should skip filtering in that case.
+  // If partialFilterEnabled is true, unsupported sub-expressions are replaced with UnsupportedOp,
+  // allowing the rest of the predicate tree to still be used for pruning.
+  // If false (default), throws IllegalArgumentException on any unsupported expression.
   @throws[IllegalArgumentException]
-  def convert(expressions: Seq[SqlExpression]): Option[BaseOp] = {
-    expressions.map(convertOne(_)) match {
+  def convert(
+      expressions: Seq[SqlExpression],
+      partialFilterEnabled: Boolean = false): Option[BaseOp] = {
+    expressions.map(convertOne(_, partialFilterEnabled)) match {
       case Seq() => None
       case Seq(child) => Some(child)
       case children => Some(AndOp(children.toList))
     }
   }
 
-  // Converts one SQL expression type into its corresponding Json predicate op type.
-  //
-  // Descends down the SQL expression tree and constucts the Json predicate tree
-  // using a post-order DFS strategy.
-  //
-  // Throws an exception if conversion fails.
-  private def convertOne(expr: SqlExpression): BaseOp = {
-    // Try converting to a leaf op first, and it that fails try converting to
+  // Converts one SQL expression, returning UnsupportedOp for any unsupported sub-expression
+  // when partialFilterEnabled is true, or throwing IllegalArgumentException when false.
+  private def convertOne(expr: SqlExpression, partialFilterEnabled: Boolean): BaseOp = {
+    if (partialFilterEnabled) {
+      try { convertOneInternal(expr, partialFilterEnabled) }
+      catch { case _: IllegalArgumentException => UnsupportedOp() }
+    } else {
+      convertOneInternal(expr, partialFilterEnabled)
+    }
+  }
+
+  // Descends down the SQL expression tree and constructs the Json predicate tree
+  // using a post-order DFS strategy. Throws IllegalArgumentException for unsupported
+  // expressions.
+  private def convertOneInternal(expr: SqlExpression, partialFilterEnabled: Boolean): BaseOp = {
+    // Try converting to a leaf op first, and if that fails try converting to
     // a non-leaf op.
     maybeConvertAsLeaf(expr).getOrElse(expr match {
       // Convert boolean logic operators.
       case SqlAnd(left, right) =>
-        AndOp(Seq(convertOne(left), convertOne(right)))
+        AndOp(Seq(convertOne(left, partialFilterEnabled), convertOne(right, partialFilterEnabled)))
       case SqlOr(left, right) =>
-        OrOp(Seq(convertOne(left), convertOne(right)))
+        OrOp(Seq(convertOne(left, partialFilterEnabled), convertOne(right, partialFilterEnabled)))
       case SqlNot(child) =>
-        NotOp(Seq(convertOne(child)))
+        NotOp(Seq(convertOne(child, partialFilterEnabled)))
 
       // Convert comparison operators.
       case SqlEqualTo(left, right) =>
@@ -114,8 +125,7 @@ object OpConverter {
         // Limit the number of predicates in the op to avoid pathological cases.
         if (list.size > kMaxSqlInOpSizeLimit) {
           throw new IllegalArgumentException(
-            "The In predicate exceeds max limit of " + kMaxSqlInOpSizeLimit
-          )
+            "The In predicate exceeds max limit of " + kMaxSqlInOpSizeLimit)
         }
         val leafOp = convertAsLeaf(value)
         list.map(e => EqualOp(Seq(leafOp, convertAsLeaf(e)))) match {
@@ -142,7 +152,7 @@ object OpConverter {
 
       // Unsupported expressions.
       case _ =>
-        throw new IllegalArgumentException("Unsupported expression during conversion " + expr)
+        throw new IllegalArgumentException("Unsupported expression during conversion: " + expr)
     })
   }
 

--- a/client/src/main/scala/io/delta/sharing/filters/OpConverter.scala
+++ b/client/src/main/scala/io/delta/sharing/filters/OpConverter.scala
@@ -18,6 +18,7 @@ package io.delta.sharing.filters
 
 import scala.collection.mutable.ListBuffer
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{
   And => SqlAnd,
   Attribute => SqlAttribute,
@@ -54,7 +55,7 @@ import org.apache.spark.sql.types.{
 // We support this conversion for a subset of SQL expressions, and will
 // throw an exception if the SQL expression cannot be converted. The caller
 // should skip filtering in such cases.
-object OpConverter {
+object OpConverter extends Logging {
 
   // Limit the number of predicates we allow in the IN op to avoid pathological cases.
   val kMaxSqlInOpSizeLimit = 20
@@ -81,7 +82,10 @@ object OpConverter {
   private def convertOne(expr: SqlExpression, partialFilterEnabled: Boolean): BaseOp = {
     if (partialFilterEnabled) {
       try { convertOneInternal(expr, partialFilterEnabled) }
-      catch { case _: IllegalArgumentException => UnsupportedOp() }
+      catch { case e: IllegalArgumentException =>
+        logWarning("Unsupported sub-expression replaced with UnsupportedOp: " + e.getMessage)
+        UnsupportedOp()
+      }
     } else {
       convertOneInternal(expr, partialFilterEnabled)
     }

--- a/client/src/main/scala/io/delta/sharing/filters/UnsupportedOpPruner.scala
+++ b/client/src/main/scala/io/delta/sharing/filters/UnsupportedOpPruner.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.filters
+
+// Prunes UnsupportedOp nodes from a json predicate op tree in a safe manner.
+//
+// OpConverter emits UnsupportedOp as a placeholder for sub-expressions it cannot convert
+// (e.g. nested struct field access). Before the tree is serialized and sent to the server,
+// this pruner collapses those nodes so the server only receives well-known op types.
+//
+// The pruning is conservative -- the returned tree covers a superset of matching data files:
+//   AND: an unsupported child is simply dropped (And(A,B,C) is a subset of And(A,B) when C
+//        is dropped, so no files are incorrectly skipped).
+//   OR:  if any child is unsupported the entire OrOp is dropped (Or(A,B,C) is a superset of
+//        Or(A,B) when C is dropped, so we cannot safely prune the branch).
+//   NOT: if the child subtree contains any unsupported node the NotOp is dropped
+//        (Not(And(A,B,C)) is a superset of Not(And(A,B)) when C is dropped).
+object UnsupportedOpPruner {
+
+  // Prune UnsupportedOp nodes from the tree rooted at op.
+  // Returns (Some(pruned tree) or None if the entire tree was pruned away,
+  //          true if any UnsupportedOp nodes were encountered during pruning).
+  def prune(op: BaseOp): (Option[BaseOp], Boolean) = pruneRecurse(op)
+
+  // Returns (pruned op or None, whether any UnsupportedOp was encountered in this subtree).
+  private def pruneRecurse(op: BaseOp): (Option[BaseOp], Boolean) = op match {
+    case _: UnsupportedOp =>
+      (None, true)
+
+    case AndOp(children) =>
+      var hadUnsupported = false
+      val kept = children.flatMap { child =>
+        val (result, unsupported) = pruneRecurse(child)
+        if (unsupported) hadUnsupported = true
+        result
+      }
+      kept match {
+        case Seq() => (None, hadUnsupported)
+        case Seq(only) => (Some(only), hadUnsupported)
+        case many => (Some(AndOp(many)), hadUnsupported)
+      }
+
+    case OrOp(children) =>
+      var hadUnsupported = false
+      val kept = children.flatMap { child =>
+        val (result, unsupported) = pruneRecurse(child)
+        if (unsupported) hadUnsupported = true
+        if (result.isEmpty) return (None, true)
+        result
+      }
+      (Some(OrOp(kept)), hadUnsupported)
+
+    case NotOp(children) =>
+      var hadUnsupported = false
+      val kept = children.flatMap { child =>
+        val (result, unsupported) = pruneRecurse(child)
+        if (unsupported) hadUnsupported = true
+        result
+      }
+      if (hadUnsupported) (None, true)
+      else (Some(NotOp(kept)), false)
+
+    case other =>
+      (Some(other), false)
+  }
+}

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -34,7 +34,7 @@ import io.delta.sharing.client.model.{
   RemoveFile
 }
 import io.delta.sharing.client.util.{ConfUtils, JsonUtils}
-import io.delta.sharing.filters.{AndOp, BaseOp, OpConverter}
+import io.delta.sharing.filters.{AndOp, BaseOp, OpConverter, UnsupportedOpPruner}
 import io.delta.sharing.spark.util.QueryUtils
 
 /*
@@ -146,9 +146,12 @@ private[sharing] abstract class RemoteDeltaFileIndexBase(
       return None
     }
 
+    val partialFilterEnabled =
+      ConfUtils.jsonPredicatePartialFilterEnabled(params.spark.sessionState.conf)
+
     // Convert the partition filters.
     val partitionOp = try {
-      OpConverter.convert(partitionFilters)
+      OpConverter.convert(partitionFilters, partialFilterEnabled)
     } catch {
       case e: Exception =>
         log.error("Error while converting partition filters: " + e)
@@ -159,7 +162,7 @@ private[sharing] abstract class RemoteDeltaFileIndexBase(
     val dataOp = try {
       if (ConfUtils.jsonPredicatesV2Enabled(params.spark.sessionState.conf)) {
         log.info("Converting data filters")
-        OpConverter.convert(dataFilters)
+        OpConverter.convert(dataFilters, partialFilterEnabled)
       } else {
         None
       }
@@ -177,10 +180,25 @@ private[sharing] abstract class RemoteDeltaFileIndexBase(
     } else {
       dataOp
     }
-    log.info("Using combined predicate: " + combinedOp)
 
-    if (combinedOp.isDefined) {
-      Some(JsonUtils.toJson[BaseOp](combinedOp.get))
+    // If partial filtering is enabled, prune UnsupportedOp nodes before serializing so the
+    // server only receives well-known op types. AND children are dropped safely; OR/NOT branches
+    // containing unsupported nodes are dropped entirely.
+    val finalOp = if (partialFilterEnabled) {
+      combinedOp.flatMap { op =>
+        val (pruned, hadUnsupported) = UnsupportedOpPruner.prune(op)
+        if (hadUnsupported) {
+          log.info(s"Predicate tree contained unsupported expressions; pruned: $op -> $pruned")
+        }
+        pruned
+      }
+    } else {
+      combinedOp
+    }
+    log.info("Using combined predicate: " + finalOp)
+
+    if (finalOp.isDefined) {
+      Some(JsonUtils.toJson[BaseOp](finalOp.get))
     } else {
       None
     }

--- a/client/src/test/scala/io/delta/sharing/filters/OpConverterSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/filters/OpConverterSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.{
   EqualNullSafe => SqlEqualNullSafe,
   EqualTo => SqlEqualTo,
   Expression => SqlExpression,
+  GetStructField,
   GreaterThan => SqlGreaterThan,
   GreaterThanOrEqual => SqlGreaterThanOrEqual,
   In => SqlIn,
@@ -45,6 +46,8 @@ import org.apache.spark.sql.types.{
   IntegerType => SqlIntegerType,
   LongType => SqlLongType,
   StringType => SqlStringType,
+  StructField,
+  StructType,
   TimestampType => SqlTimestampType
 }
 
@@ -345,6 +348,7 @@ class OpConverterSuite extends SparkFunSuite {
       // Make sure we stay within bounds for out of bound checks.
       tooManyVals = tooManyVals :+ (i + 5)
     }
+    // With partialFilterEnabled=false (default), these throw.
     assert(intercept[IllegalArgumentException] {
       convert(tooManyVals)
     }.getMessage.contains("The In predicate exceeds max limit"))
@@ -352,5 +356,158 @@ class OpConverterSuite extends SparkFunSuite {
     assert(intercept[IllegalArgumentException] {
       convert(Seq.empty)
     }.getMessage.contains("The In predicate must have at least one entry"))
+
+    // With partialFilterEnabled=true, they produce UnsupportedOp instead.
+    assert(OpConverter.convert(
+      Seq(SqlIn(SqlAttributeReference("x", SqlIntegerType)(),
+        tooManyVals.map(v => SqlLiteral(v, SqlIntegerType)))),
+      partialFilterEnabled = true).get.isInstanceOf[UnsupportedOp])
+
+    assert(OpConverter.convert(
+      Seq(SqlIn(SqlAttributeReference("x", SqlIntegerType)(), Seq.empty)),
+      partialFilterEnabled = true).get.isInstanceOf[UnsupportedOp])
+  }
+
+  test("unsupported leaf in comparison produces UnsupportedOp when partialFilterEnabled") {
+    // convertAsLeaf throws; convertOneOrUnsupported catches and returns UnsupportedOp.
+    val c2Type = StructType(Seq(StructField("f1", SqlIntegerType)))
+    val sqlF1 = GetStructField(SqlAttributeReference("c2", c2Type)(), 0, Some("f1"))
+    val sqlEq = SqlEqualTo(sqlF1, SqlLiteral(5, SqlIntegerType))
+
+    val op = OpConverter.convert(Seq(sqlEq), partialFilterEnabled = true).get
+    assert(op.isInstanceOf[UnsupportedOp])
+  }
+
+  test("unsupported expression throws when partialFilterEnabled is false") {
+    val c2Type = StructType(Seq(StructField("f1", SqlIntegerType)))
+    val sqlC2 = SqlAttributeReference("c2", c2Type)()
+    val sqlF1 = GetStructField(sqlC2, 0, Some("f1"))
+    val sqlEq = SqlEqualTo(sqlF1, SqlLiteral(5, SqlIntegerType))
+
+    intercept[IllegalArgumentException] {
+      OpConverter.convert(Seq(sqlEq), partialFilterEnabled = false)
+    }
+  }
+
+  test("AND with unsupported child prunes based on supported child when partialFilterEnabled") {
+    val sqlC1 = SqlAttributeReference("c1", SqlIntegerType)()
+    val supportedEq = SqlEqualTo(sqlC1, SqlLiteral(1, SqlIntegerType))
+
+    val c2Type = StructType(Seq(StructField("f1", SqlIntegerType)))
+    val sqlC2 = SqlAttributeReference("c2", c2Type)()
+    val sqlF1 = GetStructField(sqlC2, 0, Some("f1"))
+    val unsupportedEq = SqlEqualTo(sqlF1, SqlLiteral(5, SqlIntegerType))
+
+    val sqlAnd = SqlAnd(supportedEq, unsupportedEq)
+    val op = OpConverter.convert(Seq(sqlAnd), partialFilterEnabled = true).get.asInstanceOf[AndOp]
+
+    // AND tree is preserved: one EqualOp child and one UnsupportedOp child.
+    assert(op.children(0).isInstanceOf[EqualOp])
+    assert(op.children(1).isInstanceOf[UnsupportedOp])
+
+    // AND prunes when the supported predicate is false (c1 != 1).
+    assert(op.evalExpectBoolean(EvalContext(Map("c1" -> "2"))) == false)
+    // AND is conservative when the supported predicate is true (c1 == 1).
+    assert(op.evalExpectBoolean(EvalContext(Map("c1" -> "1"))) == true)
+  }
+
+  test("OR with unsupported child produces OrOp(EqualOp, UnsupportedOp) when partialFilter") {
+    val sqlC1 = SqlAttributeReference("c1", SqlIntegerType)()
+    val supportedEq = SqlEqualTo(sqlC1, SqlLiteral(1, SqlIntegerType))
+
+    val c2Type = StructType(Seq(StructField("f1", SqlIntegerType)))
+    val sqlF1 = GetStructField(SqlAttributeReference("c2", c2Type)(), 0, Some("f1"))
+    val unsupportedEq = SqlEqualTo(sqlF1, SqlLiteral(5, SqlIntegerType))
+
+    val op = OpConverter.convert(
+      Seq(SqlOr(supportedEq, unsupportedEq)), partialFilterEnabled = true).get.asInstanceOf[OrOp]
+    assert(op.children(0).isInstanceOf[EqualOp])
+    assert(op.children(1).isInstanceOf[UnsupportedOp])
+  }
+
+  test("NOT with unsupported child produces NotOp(UnsupportedOp) when partialFilterEnabled") {
+    val c2Type = StructType(Seq(StructField("f1", SqlIntegerType)))
+    val sqlF1 = GetStructField(SqlAttributeReference("c2", c2Type)(), 0, Some("f1"))
+    val unsupportedEq = SqlEqualTo(sqlF1, SqlLiteral(5, SqlIntegerType))
+
+    val op = OpConverter.convert(
+      Seq(SqlNot(unsupportedEq)), partialFilterEnabled = true).get.asInstanceOf[NotOp]
+    assert(op.children(0).isInstanceOf[UnsupportedOp])
+  }
+
+  test("IsNull with unsupported leaf produces UnsupportedOp when partialFilterEnabled") {
+    val c2Type = StructType(Seq(StructField("f1", SqlIntegerType)))
+    val sqlF1 = GetStructField(SqlAttributeReference("c2", c2Type)(), 0, Some("f1"))
+
+    val op = OpConverter.convert(Seq(SqlIsNull(sqlF1)), partialFilterEnabled = true).get
+    assert(op.isInstanceOf[UnsupportedOp])
+  }
+
+  test("IsNotNull with unsupported leaf produces UnsupportedOp when partialFilterEnabled") {
+    val c2Type = StructType(Seq(StructField("f1", SqlIntegerType)))
+    val sqlF1 = GetStructField(SqlAttributeReference("c2", c2Type)(), 0, Some("f1"))
+
+    val op = OpConverter.convert(Seq(SqlIsNotNull(sqlF1)), partialFilterEnabled = true).get
+    assert(op.isInstanceOf[UnsupportedOp])
+  }
+
+  test("EqualNullSafe with unsupported leaf produces UnsupportedOp when partialFilterEnabled") {
+    val c2Type = StructType(Seq(StructField("f1", SqlIntegerType)))
+    val sqlF1 = GetStructField(SqlAttributeReference("c2", c2Type)(), 0, Some("f1"))
+
+    val op = OpConverter.convert(
+      Seq(SqlEqualNullSafe(sqlF1, SqlLiteral(5, SqlIntegerType))),
+      partialFilterEnabled = true).get
+    assert(op.isInstanceOf[UnsupportedOp])
+  }
+
+  test("convert then prune end-to-end: AND(supported, unsupported) -> supported only") {
+    // Simulates the full client-side flow: convert with partialFilterEnabled, then prune.
+    val sqlC1 = SqlAttributeReference("c1", SqlIntegerType)()
+    val supportedEq = SqlEqualTo(sqlC1, SqlLiteral(1, SqlIntegerType))
+
+    val c2Type = StructType(Seq(StructField("f1", SqlIntegerType)))
+    val sqlF1 = GetStructField(SqlAttributeReference("c2", c2Type)(), 0, Some("f1"))
+    val unsupportedEq = SqlEqualTo(sqlF1, SqlLiteral(5, SqlIntegerType))
+
+    val converted = OpConverter.convert(
+      Seq(SqlAnd(supportedEq, unsupportedEq)), partialFilterEnabled = true).get
+    val (pruned, hadUnsupported) = UnsupportedOpPruner.prune(converted)
+
+    assert(hadUnsupported == true)
+    // After pruning, only the supported EqualOp remains -- safe to send to server.
+    assert(pruned.get.isInstanceOf[EqualOp])
+  }
+
+  test("convert then prune end-to-end: OR(supported, unsupported) -> None") {
+    val sqlC1 = SqlAttributeReference("c1", SqlIntegerType)()
+    val supportedEq = SqlEqualTo(sqlC1, SqlLiteral(1, SqlIntegerType))
+
+    val c2Type = StructType(Seq(StructField("f1", SqlIntegerType)))
+    val sqlF1 = GetStructField(SqlAttributeReference("c2", c2Type)(), 0, Some("f1"))
+    val unsupportedEq = SqlEqualTo(sqlF1, SqlLiteral(5, SqlIntegerType))
+
+    val converted = OpConverter.convert(
+      Seq(SqlOr(supportedEq, unsupportedEq)), partialFilterEnabled = true).get
+    val (pruned, hadUnsupported) = UnsupportedOpPruner.prune(converted)
+
+    assert(hadUnsupported == true)
+    // OR with unsupported child must be dropped entirely -- cannot safely prune.
+    assert(pruned.isEmpty)
+  }
+
+  test("convertOneOrUnsupported catch path: unsupported expr nested in AND via exception") {
+    // An expression that is not a known leaf and not a known compound op hits the wildcard
+    // case _ => unsupportedOrThrow. With partialFilterEnabled=true this goes through
+    // convertOneOrUnsupported's try/catch path when called from boolean operators.
+    val c2Type = StructType(Seq(StructField("f1", SqlIntegerType)))
+    val sqlF1 = GetStructField(SqlAttributeReference("c2", c2Type)(), 0, Some("f1"))
+    // Wrap in AND so convertOneOrUnsupported is called on the unsupported child.
+    val sqlC1 = SqlAttributeReference("c1", SqlIntegerType)()
+    val supportedEq = SqlEqualTo(sqlC1, SqlLiteral(1, SqlIntegerType))
+    val sqlAnd = SqlAnd(supportedEq, sqlF1)  // sqlF1 alone is not a known compound op
+
+    val op = OpConverter.convert(Seq(sqlAnd), partialFilterEnabled = true).get.asInstanceOf[AndOp]
+    assert(op.children(1).isInstanceOf[UnsupportedOp])
   }
 }

--- a/client/src/test/scala/io/delta/sharing/filters/UnsupportedOpPrunerSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/filters/UnsupportedOpPrunerSuite.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.filters
+
+import org.apache.spark.SparkFunSuite
+
+class UnsupportedOpPrunerSuite extends SparkFunSuite {
+
+  private def col(name: String) = ColumnOp(name, OpDataTypes.IntType)
+  private def lit(v: String) = LiteralOp(v, OpDataTypes.IntType)
+  private def eq(c: String, v: String) = EqualOp(Seq(col(c), lit(v)))
+
+  private def pruneOp(op: BaseOp): Option[BaseOp] = UnsupportedOpPruner.prune(op)._1
+  private def pruneHadUnsupported(op: BaseOp): Boolean = UnsupportedOpPruner.prune(op)._2
+
+  test("leaf op with no UnsupportedOp is unchanged") {
+    val op = eq("c1", "1")
+    assert(pruneOp(op) == Some(op))
+    assert(pruneHadUnsupported(op) == false)
+  }
+
+  test("UnsupportedOp alone is pruned to None") {
+    assert(pruneOp(UnsupportedOp()) == None)
+    assert(pruneHadUnsupported(UnsupportedOp()) == true)
+  }
+
+  test("AND: unsupported child is dropped, supported sibling kept") {
+    val op = AndOp(Seq(eq("c1", "1"), UnsupportedOp()))
+    assert(pruneOp(op) == Some(eq("c1", "1")))
+    assert(pruneHadUnsupported(op) == true)
+  }
+
+  test("AND: all children unsupported prunes to None") {
+    val op = AndOp(Seq(UnsupportedOp(), UnsupportedOp()))
+    assert(pruneOp(op) == None)
+    assert(pruneHadUnsupported(op) == true)
+  }
+
+  test("AND: multiple supported children with one unsupported keeps the rest as AND") {
+    val op = AndOp(Seq(eq("c1", "1"), eq("c2", "2"), UnsupportedOp()))
+    assert(pruneOp(op) == Some(AndOp(Seq(eq("c1", "1"), eq("c2", "2")))))
+    assert(pruneHadUnsupported(op) == true)
+  }
+
+  test("OR: any unsupported child prunes the entire OR") {
+    val op = OrOp(Seq(eq("c1", "1"), UnsupportedOp()))
+    assert(pruneOp(op) == None)
+    assert(pruneHadUnsupported(op) == true)
+  }
+
+  test("OR: no unsupported children is unchanged") {
+    val op = OrOp(Seq(eq("c1", "1"), eq("c2", "2")))
+    assert(pruneOp(op) == Some(op))
+    assert(pruneHadUnsupported(op) == false)
+  }
+
+  test("NOT: unsupported child prunes the entire NOT") {
+    val op = NotOp(Seq(UnsupportedOp()))
+    assert(pruneOp(op) == None)
+    assert(pruneHadUnsupported(op) == true)
+  }
+
+  test("NOT: supported child is unchanged") {
+    val op = NotOp(Seq(eq("c1", "1")))
+    assert(pruneOp(op) == Some(op))
+    assert(pruneHadUnsupported(op) == false)
+  }
+
+  test("AND containing OR with unsupported: OR branch is dropped, AND sibling kept") {
+    // AND(c1=1, OR(c2=2, unsupported)) -> AND drops the OR branch -> c1=1
+    val op = AndOp(Seq(eq("c1", "1"), OrOp(Seq(eq("c2", "2"), UnsupportedOp()))))
+    assert(pruneOp(op) == Some(eq("c1", "1")))
+    assert(pruneHadUnsupported(op) == true)
+  }
+
+  test("AND containing NOT with unsupported: NOT branch is dropped, AND sibling kept") {
+    // AND(c1=1, NOT(unsupported)) -> AND drops the NOT branch -> c1=1
+    val op = AndOp(Seq(eq("c1", "1"), NotOp(Seq(UnsupportedOp()))))
+    assert(pruneOp(op) == Some(eq("c1", "1")))
+    assert(pruneHadUnsupported(op) == true)
+  }
+
+  test("fully supported AND is unchanged") {
+    val op = AndOp(Seq(eq("c1", "1"), eq("c2", "2")))
+    assert(pruneOp(op) == Some(op))
+    assert(pruneHadUnsupported(op) == false)
+  }
+}


### PR DESCRIPTION
Previously OpConverter threw IllegalArgumentException for unsupported SQL expressions (e.g. nested struct field access via GetStructField), causing the entire predicate to be dropped. This prevented pruning even when other parts of the predicate (e.g. AND siblings) were fully supported.

Instead, this change uses UnsupportedOp for unsupported sub-expressions, and then prunes away parts of expression tree based on them. This preserves the compound predicate structure so that supported siblings can still drive file pruning. UnsupportedOp evaluates conservatively to true (never prunes), which is propagated up via AND/OR/NOT. The UnsupportOp stays local to this client, and is never sent back to the server.

The change is guarded behind a flag.