### PR TITLE
Classify Delta Sharing connection failures and retry BindException

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.SparkSession
 import io.delta.sharing.client.auth.{AuthConfig, AuthCredentialProviderFactory}
 import io.delta.sharing.client.model._
 import io.delta.sharing.client.util.{ConfUtils, JsonUtils, RetryUtils, UnexpectedHttpStatus}
-import io.delta.sharing.spark.{DeltaSharingServerException, MissingEndStreamActionException}
+import io.delta.sharing.spark.{DeltaSharingConnectionException, DeltaSharingServerException, MissingEndStreamActionException}
 
 /** An interface to fetch Delta metadata from remote server. */
 trait DeltaSharingClient {
@@ -1340,12 +1340,56 @@ class DeltaSharingRestClient(
   ): (Option[Long], Map[String, String], Seq[String], Option[String]) = {
     // Reset dsQueryId before calling RetryUtils, and before prepareHeaders.
     dsQueryId = Some(UUID.randomUUID().toString().split('-').head)
+    try {
+      getResponseWithRetries(
+        httpRequest,
+        allowNoContent,
+        fetchAsOneString,
+        setIncludeEndStreamAction,
+        requestFileIdHash)
+    } catch {
+      // A failure to establish the outbound connection to the sharing server (e.g. local
+      // ephemeral-port exhaustion, connection refused, or unresolvable host) surfaces here as a
+      // raw low-level exception after retries are exhausted. Rethrow it with a legible, actionable
+      // message so callers see a clear network error rather than an opaque internal error.
+      case e: java.io.IOException if isConnectionEstablishmentError(e) =>
+        val endpoint = profileProvider.getProfile.endpoint
+        throw new DeltaSharingConnectionException(
+          s"Could not connect to the Delta Sharing server endpoint $endpoint" +
+            s"$getDsQueryIdForLogging Please check your network egress/connectivity and that the " +
+            s"endpoint is reachable. Underlying error: ${e.getMessage}",
+          e)
+    }
+  }
+
+  // Whether the throwable represents a failure to establish the outbound connection to the sharing
+  // server (as opposed to a failure that occurred after a connection/response was obtained).
+  private def isConnectionEstablishmentError(t: Throwable): Boolean = t match {
+    case _: java.net.BindException | _: java.net.ConnectException |
+        _: java.net.UnknownHostException | _: java.net.NoRouteToHostException => true
+    case _ => false
+  }
+
+  // Execute the http request against the sharing server. Extracted into its own method so tests
+  // can inject connection-establishment failures without a live server.
+  private[client] def executeHttpRequest(
+      host: HttpHost,
+      httpRequest: HttpRequestBase): org.apache.http.client.methods.CloseableHttpResponse = {
+    client.execute(host, httpRequest, HttpClientContext.create())
+  }
+
+  private def getResponseWithRetries(
+      httpRequest: HttpRequestBase,
+      allowNoContent: Boolean,
+      fetchAsOneString: Boolean,
+      setIncludeEndStreamAction: Boolean,
+      requestFileIdHash: Option[String]
+  ): (Option[Long], Map[String, String], Seq[String], Option[String]) = {
     RetryUtils.runWithExponentialBackoff(numRetries, maxRetryDuration, retrySleepInterval) {
       val profile = profileProvider.getProfile
-      val response = client.execute(
+      val response = executeHttpRequest(
         getHttpHost(profile.endpoint),
-        prepareHeaders(httpRequest, setIncludeEndStreamAction, requestFileIdHash),
-        HttpClientContext.create()
+        prepareHeaders(httpRequest, setIncludeEndStreamAction, requestFileIdHash)
       )
       try {
         val status = response.getStatusLine()

--- a/client/src/main/scala/io/delta/sharing/client/util/RetryUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/RetryUtils.scala
@@ -77,6 +77,10 @@ private[sharing] object RetryUtils extends Logging {
         }
       case _: MissingEndStreamActionException => true
       case _: java.net.SocketTimeoutException => true
+      // BindException (e.g. "Cannot assign requested address" / "Address already in use") is
+      // usually caused by transient local ephemeral-port exhaustion, which is worth retrying.
+      // It extends SocketException, so this case must precede the SocketException case below.
+      case _: java.net.BindException => true
       case e: java.net.SocketException =>
         // Retry on connection reset errors
         if (e.getMessage != null &&

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
@@ -33,6 +33,12 @@ class MissingEndStreamActionException(message: String) extends IllegalStateExcep
 class DeltaSharingServerException(message: String, statusCodeOpt: Option[Int])
   extends DeltaSharingExceptionWithErrorCode(message, statusCodeOpt)
 
+// Thrown when the client fails to establish a network connection to the Delta Sharing server
+// endpoint (e.g. java.net.BindException / java.net.ConnectException), before any HTTP response is
+// received. This surfaces a legible, actionable message instead of the raw low-level exception.
+class DeltaSharingConnectionException(message: String, cause: Throwable)
+  extends IllegalStateException(message, cause)
+
 object DeltaSharingErrors {
   def nonExistentDeltaSharingTable(tableId: String): Throwable = {
     new IllegalStateException(s"Delta sharing table ${tableId} doesn't exist. " +

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -43,7 +43,7 @@ import io.delta.sharing.client.model.{
 import io.delta.sharing.client.util.ConfUtils
 import io.delta.sharing.client.util.JsonUtils
 import io.delta.sharing.client.util.UnexpectedHttpStatus
-import io.delta.sharing.spark.{DeltaSharingOptions, DeltaSharingServerException, MissingEndStreamActionException, RemoteDeltaLog}
+import io.delta.sharing.spark.{DeltaSharingConnectionException, DeltaSharingOptions, DeltaSharingServerException, MissingEndStreamActionException, RemoteDeltaLog}
 
 // scalastyle:off maxLineLength
 class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
@@ -2541,6 +2541,73 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
         s"expected URL to contain includeHistoricalProtocol=true when delta is in " +
           s"responseFormat, got: ${client.capturedTarget}"
       )
+    } finally {
+      client.close()
+    }
+  }
+
+  test("getResponse wraps connection-establishment failures in " +
+      "DeltaSharingConnectionException") {
+    // Each of these is thrown while establishing the outbound connection to the sharing server,
+    // before any HTTP response is received. They should be rethrown as a legible connection error
+    // rather than propagating as an opaque low-level exception.
+    val connectionErrors = Seq(
+      new java.net.BindException("Cannot assign requested address"),
+      new java.net.ConnectException("Connection refused"),
+      new java.net.UnknownHostException("no-such-host"),
+      new java.net.NoRouteToHostException("no route")
+    )
+
+    connectionErrors.foreach { thrown =>
+      // numRetries = 0 so the failure is surfaced immediately without any retry sleeps.
+      val client = new DeltaSharingRestClient(
+        profileProvider = new TestProfileProvider,
+        numRetries = 0,
+        sslTrustAll = true
+      ) {
+        override private[client] def executeHttpRequest(
+            host: org.apache.http.HttpHost,
+            httpRequest: HttpRequestBase)
+          : org.apache.http.client.methods.CloseableHttpResponse = {
+          throw thrown
+        }
+      }
+
+      try {
+        val e = intercept[DeltaSharingConnectionException] {
+          client.getResponse(new HttpGet("http://localhost:12345/test"))
+        }
+        assert(e.getMessage.contains("Could not connect to the Delta Sharing server endpoint"))
+        assert(e.getMessage.contains("http://localhost:12345"))
+        // The original low-level exception is preserved as the cause.
+        assert(e.getCause eq thrown)
+      } finally {
+        client.close()
+      }
+    }
+  }
+
+  test("getResponse does not wrap non-connection failures") {
+    // A failure that is not a connection-establishment error should propagate unchanged.
+    val thrown = new RuntimeException("boom")
+    val client = new DeltaSharingRestClient(
+      profileProvider = new TestProfileProvider,
+      numRetries = 0,
+      sslTrustAll = true
+    ) {
+      override private[client] def executeHttpRequest(
+          host: org.apache.http.HttpHost,
+          httpRequest: HttpRequestBase)
+        : org.apache.http.client.methods.CloseableHttpResponse = {
+        throw thrown
+      }
+    }
+
+    try {
+      val e = intercept[RuntimeException] {
+        client.getResponse(new HttpGet("http://localhost:12345/test"))
+      }
+      assert(e eq thrown)
     } finally {
       client.close()
     }

--- a/client/src/test/scala/io/delta/sharing/client/util/RetryUtilsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/RetryUtilsSuite.scala
@@ -47,6 +47,11 @@ class RetryUtilsSuite extends SparkFunSuite {
     assert(shouldRetry(new java.net.SocketException("CONNECTION RESET")))
     assert(!shouldRetry(new java.net.SocketException("Some other socket error")))
     assert(!shouldRetry(new java.net.SocketException(null: String)))
+    // BindException (transient local ephemeral-port exhaustion) is always retried, even though it
+    // extends SocketException and its message does not contain "connection reset".
+    assert(shouldRetry(new java.net.BindException("Cannot assign requested address")))
+    assert(shouldRetry(new java.net.BindException("Address already in use")))
+    assert(shouldRetry(new java.net.BindException(null: String)))
   }
 
   test("runWithExponentialBackoff") {


### PR DESCRIPTION
## Description

When the client fails to establish an outbound connection to the sharing server, the raw
low-level exception propagated to the caller and surfaced as an opaque internal error rather
than a legible network error. In particular a `java.net.BindException` (transient local
ephemeral-port exhaustion) was never retried, because it extends `SocketException` and the
existing `SocketException` retry branch only matches messages containing `"connection reset"`.

This PR:

- **`RetryUtils.shouldRetry`**: retry `BindException`. The new `case` precedes the
  `SocketException` case, since `BindException` extends it and ordering matters.
- **`DeltaSharingRestClient.getResponse`**: wrap the retry loop so a connection-establishment
  failure that survives retries (`BindException`, `ConnectException`, `UnknownHostException`,
  `NoRouteToHostException`) is rethrown as a new `DeltaSharingConnectionException` that names the
  endpoint and preserves the original exception as its cause. The wrapper sits *outside*
  `runWithExponentialBackoff`, so retries still fire on the raw exception first. The retry loop was
  extracted into a `getResponseWithRetries` helper (and the `client.execute` call into an
  `executeHttpRequest` seam) to keep the diff small and make the behavior testable.
- Adds `DeltaSharingConnectionException`.

## How was this patch tested?

Added unit tests:
- `RetryUtilsSuite`: `BindException` (including null-message) is retried.
- `DeltaSharingRestClientSuite`: `getResponse` wraps each connection-establishment exception in
  `DeltaSharingConnectionException` (message names the endpoint, cause is preserved) and leaves
  unrelated exceptions unwrapped.

## Does this PR introduce _any_ user-facing changes?

Yes. A network failure connecting to the sharing server now produces a clear "Could not connect to
the Delta Sharing server endpoint <host> ..." message instead of an opaque internal error, and
transient bind failures are retried.

