### PR TITLE
Bump Rust wrapper version to 0.3.3

### DIFF
--- a/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
+++ b/python/delta-kernel-rust-sharing-wrapper/Cargo.toml
@@ -2,7 +2,7 @@
 name = "delta-kernel-rust-sharing-wrapper"
 edition = "2021"
 license = "Apache-2.0"
-version = "0.3.2"
+version = "0.3.3"
 
 [lib]
 name = "delta_kernel_rust_sharing_wrapper"


### PR DESCRIPTION
Dummy release but required as we cannot upload new files to the 0.3.2 release anymore