### PR TITLE
[Client] Support backtick-quoted share/schema/table names with dots in parsePath

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -1621,7 +1621,9 @@ object DeltaSharingRestClient extends Logging {
       }
     }
 
-    val tableSplits = tablePath.split("\\.", -1)
+    val tableSplits = splitTablePath(tablePath).getOrElse {
+      throw new IllegalArgumentException(s"path $path is not valid")
+    }
     if (tableSplits.length != 3) {
       throw new IllegalArgumentException(s"path $path is not valid")
     }
@@ -1635,6 +1637,67 @@ object DeltaSharingRestClient extends Logging {
       schema = tableSplits(1),
       table = tableSplits(2)
     )
+  }
+
+  /**
+   * Split a `share.schema.table` identifier on unquoted dots. Each part may be quoted with
+   * backticks so that its name can contain dots, matching how Delta/Spark quotes identifiers:
+   * the part is wrapped in backticks and any backtick inside it is escaped by doubling it.
+   * The returned parts have their surrounding backticks stripped and doubled backticks unescaped.
+   *
+   * Returns None if the identifier is malformed (an unterminated quote, or a quoted part with
+   * unexpected characters outside its backticks); the caller turns this into the same
+   * "path is not valid" error used for the unquoted case. Unquoted input is split exactly like
+   * `split("\\.", -1)`, so existing behavior is preserved.
+   */
+  private def splitTablePath(tablePath: String): Option[Seq[String]] = {
+    val parts = scala.collection.mutable.ArrayBuffer.empty[String]
+    val current = new StringBuilder
+    // Tracks the state of the part currently being read: whether we are inside a backtick-quoted
+    // region, and whether a closing backtick has been seen (after which only a dot may follow).
+    var inQuotes = false
+    var quotedClosed = false
+    var i = 0
+    val len = tablePath.length
+    while (i < len) {
+      val c = tablePath.charAt(i)
+      if (inQuotes) {
+        if (c == '`') {
+          if (i + 1 < len && tablePath.charAt(i + 1) == '`') {
+            // An escaped backtick inside the quoted name.
+            current.append('`')
+            i += 1
+          } else {
+            inQuotes = false
+            quotedClosed = true
+          }
+        } else {
+          current.append(c)
+        }
+      } else if (c == '.') {
+        parts += current.toString
+        current.setLength(0)
+        quotedClosed = false
+      } else if (c == '`') {
+        // A backtick may only open a quote at the start of a part.
+        if (current.nonEmpty || quotedClosed) {
+          return None
+        }
+        inQuotes = true
+      } else if (quotedClosed) {
+        // Non-dot characters are not allowed after a closing backtick, e.g. `a`b.
+        return None
+      } else {
+        current.append(c)
+      }
+      i += 1
+    }
+    if (inQuotes) {
+      // Unterminated quote, e.g. `a.b.c.
+      return None
+    }
+    parts += current.toString
+    Some(parts.toSeq)
   }
 
   private def tryParseEndStreamAction(line: String): EndStreamAction = {

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -105,6 +105,35 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     intercept[IllegalArgumentException] {
       DeltaSharingRestClient.parsePath("foo#a.b.c.", emptyShareCredentialsOptions)
     }
+
+    // Backtick-quoted share/schema/table names may contain dots (issue #646). The surrounding
+    // backticks are stripped and doubled backticks are unescaped.
+    assert(
+      DeltaSharingRestClient.parsePath("file:///foo/bar#`a.b`.`c.d`.`e.f`", emptyShareCredentialsOptions) ==
+      ParsedDeltaSharingTablePath("file:///foo/bar", "a.b", "c.d", "e.f"))
+    assert(
+      DeltaSharingRestClient.parsePath("`a.b`.`c.d`.`e.f`", testShareCredentialsOptions) ==
+      ParsedDeltaSharingTablePath("", "a.b", "c.d", "e.f"))
+    // Quoted and unquoted parts can be mixed.
+    assert(
+      DeltaSharingRestClient.parsePath("file:///foo/bar#`my.share`.schema.table", emptyShareCredentialsOptions) ==
+      ParsedDeltaSharingTablePath("file:///foo/bar", "my.share", "schema", "table"))
+    // A backtick inside a quoted name is escaped by doubling it.
+    assert(
+      DeltaSharingRestClient.parsePath("file:///foo/bar#`a``b`.c.d", emptyShareCredentialsOptions) ==
+      ParsedDeltaSharingTablePath("file:///foo/bar", "a`b", "c", "d"))
+    // An unterminated quote is not a valid path.
+    intercept[IllegalArgumentException] {
+      DeltaSharingRestClient.parsePath("file:///foo/bar#`a.b.c", emptyShareCredentialsOptions)
+    }
+    // Characters outside a closing backtick are not a valid path.
+    intercept[IllegalArgumentException] {
+      DeltaSharingRestClient.parsePath("file:///foo/bar#`a`x.b.c", emptyShareCredentialsOptions)
+    }
+    // A quoted empty name is still empty and therefore invalid.
+    intercept[IllegalArgumentException] {
+      DeltaSharingRestClient.parsePath("file:///foo/bar#``.b.c", emptyShareCredentialsOptions)
+    }
   }
 
   test("parsePath with optionsProfileProvider disabled") {


### PR DESCRIPTION

Fixes #646.


- `DeltaSharingRestClient.parsePath` splits the `share.schema.table` identifier on every `.` via `tablePath.split("\\.", -1)` and then requires exactly three parts. As a result, any share, schema, or table whose name legitimately contains a dot cannot be loaded: for example `spark.read.format("deltaSharing").load("<profile>#`my.share`.`my.schema`.`my.table`")` throws `IllegalArgumentException: path ... is not valid` (issue #646), and there is no way to escape the dot.
- Parse the three-part identifier honoring backtick quoting instead of a naive split. Each part may be wrapped in backticks so its name can contain dots; a literal backtick inside a quoted part is escaped by doubling it. This mirrors how identifiers are already quoted elsewhere in this client (`RemoteDeltaCDFRelation.quoteIdentifier` builds ``s"`${part.replace("`", "``")}`"``), so the new parser is the inverse of an escaping scheme the codebase already uses, and it also matches how Spark/Delta quote identifiers.
- Unquoted input is split exactly like `split("\\.", -1)`, so all existing behavior and every existing validation error (wrong number of parts, empty part, missing profile) is preserved. Malformed quoting (an unterminated quote, or stray characters after a closing backtick) produces the same `path ... is not valid` error already used for bad input.

## Behavior

Given a profile file `<profile>`:

| Path | Before | After |
| --- | --- | --- |
| `<profile>#share.schema.table` | share=`share`, schema=`schema`, table=`table` | unchanged |
| ``<profile>#`my.share`.`my.schema`.`my.table` `` | `IllegalArgumentException` | share=`my.share`, schema=`my.schema`, table=`my.table` |
| ``<profile>#`my.share`.schema.table `` | `IllegalArgumentException` | share=`my.share`, schema=`schema`, table=`table` |
| ``<profile>#`a``b`.c.d `` | `IllegalArgumentException` | share=`` a`b ``, schema=`c`, table=`d` |

The backticks are optional: existing unquoted three-part paths keep working exactly as before.

## Test plan

- [x] `build/sbt "client/testOnly io.delta.sharing.client.DeltaSharingRestClientSuite -- -z parsePath"` - the extended `parsePath` test passes. New assertions cover quoted names containing dots, mixed quoted and unquoted parts, an escaped (doubled) backtick, and the malformed-quote error cases (unterminated quote, characters after a closing backtick, quoted empty name). `parsePath` is a plain unit test, so it runs without cloud credentials or a live server.
- [x] Verified this is a genuine regression test: reverting the one-line `parsePath` change back to `split("\\.", -1)` makes the new assertions fail with the exact issue #646 error, then passes again with the fix in place.
- [x] `build/sbt "client/compile"` and the `++2.12.18` cross-build both compile cleanly (Scala 2.13 and 2.12).
- [x] `build/sbt "client / Test / scalastyle"` (main and test) reports no errors or warnings.

## Notes

- Scope is the Scala client only. The Python client has the same limitation in its own path parsing; I have left it out to keep this change surgical and would be happy to follow up in a separate PR.
- The chosen escape character is the backtick, matching this client's existing `quoteIdentifier` and the escaping the reporter suggested in #646. Flagging it here in case the maintainers would prefer a different convention.
