### PR TITLE
[Python] Support timestamp_ntz in the parquet-format converter

### DIFF
--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ -49,6 +49,8 @@ def _get_dummy_column(schema_type):
         return pd.Series([pd.Timestamp(0).date()])
     elif schema_type == "timestamp":
         return pd.Series([pd.Timestamp(0)], dtype=np.dtype("datetime64[ns]"))
+    elif schema_type == "timestamp_ntz":
+        return pd.Series([pd.Timestamp(0)], dtype=np.dtype("datetime64[ns]"))
     elif schema_type == "binary":
         return pd.Series([0], dtype=np.dtype("O"))
     elif isinstance(schema_type, dict) and schema_type["type"] in ("array", "struct", "map"):
@@ -108,6 +110,8 @@ def to_converter(schema_type) -> Callable[[str], Any]:
     elif schema_type == "date":
         return lambda x: None if (x is None or x == "") else pd.Timestamp(x).date()
     elif schema_type == "timestamp":
+        return lambda x: pd.NaT if (x is None or x == "") else pd.Timestamp(x)
+    elif schema_type == "timestamp_ntz":
         return lambda x: pd.NaT if (x is None or x == "") else pd.Timestamp(x)
     elif schema_type == "binary":
         return None  # partition on binary column not supported

--- a/python/delta_sharing/tests/test_converter.py
+++ b/python/delta_sharing/tests/test_converter.py
@@ -73,16 +73,25 @@ def test_to_converter_timestamp():
     assert converter("") is pd.NaT
 
 
+def test_to_converter_timestamp_ntz():
+    converter = to_converter("timestamp_ntz")
+    assert converter("2021-04-28 23:36:47.599") == pd.Timestamp("2021-04-28 23:36:47.599")
+    assert converter("") is pd.NaT
+
+
 def test_get_empty_table():
     schema_string = (
         '{"fields": ['
         '{"metadata": {},"name": "a","nullable": true,"type": "long"},'
-        '{"metadata": {},"name": "b","nullable": true,"type": "string"}'
+        '{"metadata": {},"name": "b","nullable": true,"type": "string"},'
+        '{"metadata": {},"name": "c","nullable": true,"type": "timestamp_ntz"}'
         '],"type":"struct"}'
     )
     schema_json = loads(schema_string)
     pdf = get_empty_table(schema_json)
     assert pdf.empty
-    assert pdf.columns.values.size == 2
+    assert pdf.columns.values.size == 3
     assert pdf.columns.values[0] == "a"
     assert pdf.columns.values[1] == "b"
+    assert pdf.columns.values[2] == "c"
+    assert pdf.dtypes["c"] == np.dtype("datetime64[ns]")


### PR DESCRIPTION

Summary:
The Python client's converter handles the `timestamp` type but not Spark's
`timestamp_ntz` (timestamp without time zone) type token. As a result,
`to_converter` and `_get_dummy_column` fall through to their terminal `raise`,
so `to_converters()` / `get_empty_table()` raise
`ValueError: Could not parse datatype: timestamp_ntz` when reading a shared
table that has a TIMESTAMP_NTZ column in the parquet response format (for
example `load_as_pandas(..., use_delta_format=False)`).

timestampNtz support was previously added only for the delta-format
(delta-kernel) path via reader-feature negotiation (#654) and never covered the
parquet-format converter, which is the gap reported in #745.

Fix:
Add a `timestamp_ntz` branch to both functions, mirroring the existing
`timestamp` branch: a tz-naive `pd.Timestamp` / `datetime64[ns]`. This matches
TIMESTAMP_NTZ semantics (no timezone information, `isAdjustedToUTC=false`). The
partition value serialization for timestamp without timezone uses the same
`{year}-{month}-{day} {hour}:{minute}:{second}[.{microsecond}]` format that
`pd.Timestamp` already parses, so the existing `timestamp` lambda can be reused
verbatim. The existing `timestamp` branch is left untouched.

Scope:
- `python/delta_sharing/converter.py`: add one `timestamp_ntz` elif to
  `_get_dummy_column` and one to `to_converter` (4 lines total).

Not included:
- No change to the delta-format (delta-kernel) path, which already supports
  timestampNtz.
- No change to the existing `timestamp` branch (conservative, avoids any
  behavior change for the tz path).

Testing:
- `python/delta_sharing/tests/test_converter.py`: added
  `test_to_converter_timestamp_ntz` (mirrors `test_to_converter_timestamp`) and
  extended `test_get_empty_table` with a `timestamp_ntz` column plus a
  `datetime64[ns]` dtype assertion.
- `uv run dev/pytest delta_sharing/tests/test_converter.py` -> 13 passed.
- `uv run dev/pytest delta_sharing/tests/test_converter.py delta_sharing/tests/test_reader.py`
  -> 22 passed, 1 skipped.
- Verified the tests fail on `main` without the converter change (both raise the
  reported `ValueError: Could not parse datatype: timestamp_ntz`).
- `uv run dev/lint-python` (black, flake8, mypy) clean on the changed files.

Fixes #745

---

## Diff (for reviewer reference; source-only, 4 lines)

```diff
--- a/python/delta_sharing/converter.py
+++ b/python/delta_sharing/converter.py
@@ _get_dummy_column
     elif schema_type == "timestamp":
         return pd.Series([pd.Timestamp(0)], dtype=np.dtype("datetime64[ns]"))
+    elif schema_type == "timestamp_ntz":
+        return pd.Series([pd.Timestamp(0)], dtype=np.dtype("datetime64[ns]"))
@@ to_converter
     elif schema_type == "timestamp":
         return lambda x: pd.NaT if (x is None or x == "") else pd.Timestamp(x)
+    elif schema_type == "timestamp_ntz":
+        return lambda x: pd.NaT if (x is None or x == "") else pd.Timestamp(x)
```
