### PR TITLE
[Python] Add Arrow materializers for table changes

### DIFF
--- a/python/delta_sharing/__init__.py
+++ b/python/delta_sharing/__init__.py
@@ -16,7 +16,11 @@
 
 from delta_sharing.delta_sharing import SharingClient, load_as_arrow, load_as_pandas, load_as_spark
 from delta_sharing.delta_sharing import get_table_metadata, get_table_protocol, get_table_version
-from delta_sharing.delta_sharing import load_table_changes_as_pandas, load_table_changes_as_spark
+from delta_sharing.delta_sharing import (
+    load_table_changes_as_arrow,
+    load_table_changes_as_pandas,
+    load_table_changes_as_spark,
+)
 from delta_sharing.protocol import Share, Schema, Table
 from delta_sharing.version import __version__
 
@@ -31,6 +35,7 @@ __all__ = [
     "load_as_arrow",
     "load_as_pandas",
     "load_as_spark",
+    "load_table_changes_as_arrow",
     "load_table_changes_as_pandas",
     "load_table_changes_as_spark",
     "__version__",

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -612,6 +612,47 @@ def load_table_changes_as_pandas(
     )
 
 
+def load_table_changes_as_arrow(
+    url: str,
+    starting_version: Optional[int] = None,
+    ending_version: Optional[int] = None,
+    starting_timestamp: Optional[str] = None,
+    ending_timestamp: Optional[str] = None,
+    use_delta_format: Optional[bool] = None,
+) -> pa.Table:
+    """
+    Load the table changes of a shared table as a PyArrow Table using the given url.
+    Either starting_version or starting_timestamp needs to be provided. Only one starting and
+    ending parameter is accepted by the server. If the end parameter is not provided, the API
+    uses the latest table version. The parameter range is inclusive.
+
+    :param url: a url under the format "<profile>#<share>.<schema>.<table>".
+    :param starting_version: The starting version of table changes.
+    :param ending_version: The ending version of table changes.
+    :param starting_timestamp: The starting timestamp of table changes.
+    :param ending_timestamp: The ending timestamp of table changes.
+    :param use_delta_format: Whether to use delta format or parquet format. Default is parquet.
+    :return: A PyArrow Table representing the shared table changes.
+    """
+    profile_json, share, schema, table = _parse_url(url)
+    profile = DeltaSharingProfile.read_from_file(profile_json)
+    return DeltaSharingReader(
+        table=Table(name=table, share=share, schema=schema),
+        rest_client=DataSharingRestClient(profile),
+        use_delta_format=use_delta_format,
+    ).table_changes_to_arrow(
+        CdfOptions(
+            starting_version=starting_version,
+            ending_version=ending_version,
+            starting_timestamp=starting_timestamp,
+            ending_timestamp=ending_timestamp,
+            # when using delta format, we need to get metadata changes and
+            # handle them properly when replaying the delta log
+            include_historical_metadata=use_delta_format,
+        )
+    )
+
+
 class SharingClient:
     """
     A Delta Sharing client to query shares/schemas/tables from a Delta Sharing Server.

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -311,6 +311,15 @@ class TableChanges:
             self._cdf_options()
         )
 
+    def to_arrow(self) -> pa.Table:
+        return self._reader().table_changes_to_arrow(self._cdf_options())
+
+    def to_record_batches(self) -> Iterator[pa.RecordBatch]:
+        return self._reader().table_changes_to_record_batches(self._cdf_options())
+
+    def to_record_batch_reader(self) -> pa.RecordBatchReader:
+        return self._reader().table_changes_to_record_batch_reader(self._cdf_options())
+
     def to_spark(self) -> "PySparkDataFrame":  # noqa: F821
         if self._use_delta_format is not None:
             # TODO: Support use_delta_format once load_table_changes_as_spark can pass it through.

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -385,13 +385,15 @@ class DeltaSharingReader:
                 last_checkpoint_file.write(last_checkpoint_content)
                 last_checkpoint_file.close()
 
-    def __table_changes_to_pandas_kernel(self, cdfOptions: CdfOptions) -> pd.DataFrame:
-        # Create a temporary directory using the tempfile module
+    def __table_changes_scan_kernel(self, cdfOptions: CdfOptions, log_stats: bool = False):
         temp_dir = tempfile.TemporaryDirectory()
-        self._rest_client.set_delta_format_header(for_cdf=True)
         try:
-            response = self._rest_client.list_table_changes(self._table, cdfOptions)
-            lines = response.lines
+            self._rest_client.set_delta_format_header(for_cdf=True)
+            try:
+                response = self._rest_client.list_table_changes(self._table, cdfOptions)
+            finally:
+                self._rest_client.remove_delta_format_header()
+            lines = list(response.lines)
 
             # first line is protocol
             protocol_json = loads(lines.pop(0))
@@ -428,13 +430,14 @@ class DeltaSharingReader:
                     raise Exception(f"Invalid JSON object:\n{line}\nIs neither metadata nor file.")
 
             num_versions_with_action = len(version_to_actions)
-            print(
-                f"table_changes stats: min_version={min_version}, "
-                f"max_version={max_version}, "
-                f"num_versions_with_action={num_versions_with_action}, "
-                f"num_versions_with_metadata={len(version_to_metadata)}, "
-                f"lines_in_response={line_count}, "
-            )
+            if log_stats:
+                print(
+                    f"table_changes stats: min_version={min_version}, "
+                    f"max_version={max_version}, "
+                    f"num_versions_with_action={num_versions_with_action}, "
+                    f"num_versions_with_metadata={len(version_to_metadata)}, "
+                    f"lines_in_response={line_count}, "
+                )
             delta_log_dir_name = temp_dir.name
             table_path = "file:///" + delta_log_dir_name
 
@@ -451,14 +454,22 @@ class DeltaSharingReader:
                 version_to_timestamp,
             )
 
-            # Invoke delta-kernel-rust to return the pandas dataframe
+            # Invoke delta-kernel-rust to execute the scan.
             interface = delta_kernel_rust_sharing_wrapper.PythonInterface(table_path)
             table = delta_kernel_rust_sharing_wrapper.Table(table_path)
             scan = delta_kernel_rust_sharing_wrapper.TableChangesScanBuilder(
                 table, interface, min_version, max_version
             ).build()
+            return temp_dir, scan.execute(interface), num_versions_with_action
+        except Exception:
+            temp_dir.cleanup()
+            raise
 
-            scan_result = scan.execute(interface)
+    def __table_changes_to_pandas_kernel(self, cdfOptions: CdfOptions) -> pd.DataFrame:
+        temp_dir, scan_result, num_versions_with_action = self.__table_changes_scan_kernel(
+            cdfOptions, log_stats=True
+        )
+        try:
             if num_versions_with_action == 0:
                 schema = scan_result.schema
                 result = pd.DataFrame(columns=schema.names)
@@ -468,11 +479,51 @@ class DeltaSharingReader:
             else:
                 result = pa.Table.from_batches(scan_result).to_pandas(self_destruct=True)
         finally:
-            # Delete the temp folder explicitly and remove the delta format from header
+            # Delete the temp folder explicitly.
             temp_dir.cleanup()
-            self._rest_client.remove_delta_format_header()
 
         return result
+
+    def __table_changes_record_batches_kernel(
+        self, cdfOptions: CdfOptions
+    ) -> Tuple[pa.Schema, Iterator[pa.RecordBatch]]:
+        temp_dir, scan_result, _ = self.__table_changes_scan_kernel(cdfOptions)
+
+        def iterator() -> Iterator[pa.RecordBatch]:
+            try:
+                for batch in scan_result:
+                    yield batch
+            finally:
+                temp_dir.cleanup()
+
+        return scan_result.schema, iterator()
+
+    def _table_changes_to_arrow_stream(
+        self, cdfOptions: CdfOptions
+    ) -> Tuple[pa.Schema, Iterator[pa.RecordBatch]]:
+        if self._use_delta_format:
+            return self.__table_changes_record_batches_kernel(cdfOptions)
+
+        response = self._rest_client.list_table_changes(self._table, cdfOptions)
+
+        schema_json = loads(response.metadata.schema_string)
+        schema_with_cdf = self._add_special_cdf_schema(schema_json)
+        schema = to_arrow_schema(schema_with_cdf)
+
+        if len(response.actions) == 0:
+            return schema, iter(())
+
+        def iterator() -> Iterator[pa.RecordBatch]:
+            for action in response.actions:
+                for batch in DeltaSharingReader._to_record_batches(
+                    action,
+                    schema_with_cdf,
+                    None,
+                    for_cdf=True,
+                ):
+                    yield batch
+
+        return schema, iterator()
 
     def table_changes_to_pandas(self, cdfOptions: CdfOptions) -> pd.DataFrame:
         # Only use delta format if explicitly specified
@@ -502,6 +553,26 @@ class DeltaSharingReader:
             col_map[col.lower()] = col
 
         return merged[[col_map[field["name"].lower()] for field in schema_with_cdf["fields"]]]
+
+    def table_changes_to_arrow(self, cdfOptions: CdfOptions) -> pa.Table:
+        schema, batches = self._table_changes_to_arrow_stream(cdfOptions)
+        return pa.Table.from_batches(list(batches), schema=schema)
+
+    def table_changes_to_record_batches(self, cdfOptions: CdfOptions) -> Iterator[pa.RecordBatch]:
+        """
+        Batches are produced lazily; consume the iterator fully (or close it) so
+        that temporary resources backing the stream are released promptly.
+        """
+        _, batches = self._table_changes_to_arrow_stream(cdfOptions)
+        return batches
+
+    def table_changes_to_record_batch_reader(self, cdfOptions: CdfOptions) -> pa.RecordBatchReader:
+        """
+        Batches are produced lazily; read the reader fully (or close it) so that
+        temporary resources backing the stream are released promptly.
+        """
+        schema, batches = self._table_changes_to_arrow_stream(cdfOptions)
+        return pa.RecordBatchReader.from_batches(schema, batches)
 
     def _copy(
         self,
@@ -595,6 +666,7 @@ class DeltaSharingReader:
         action: FileAction,
         schema_json: dict,
         limit: Optional[int],
+        for_cdf: bool = False,
     ) -> Iterator[pa.RecordBatch]:
         filesystem = DeltaSharingReader._parquet_filesystem(action.url)
         pa_dataset = dataset(source=action.url, format="parquet", filesystem=filesystem)
@@ -608,7 +680,7 @@ class DeltaSharingReader:
             if limit is not None and rows_read + batch.num_rows > limit:
                 batch = batch.slice(0, limit - rows_read)
 
-            yield DeltaSharingReader._normalize_record_batch(batch, action, schema_json)
+            yield DeltaSharingReader._normalize_record_batch(batch, action, schema_json, for_cdf)
             rows_read += batch.num_rows
 
     @staticmethod
@@ -631,6 +703,7 @@ class DeltaSharingReader:
         batch: pa.RecordBatch,
         action: FileAction,
         schema_json: dict,
+        for_cdf: bool = False,
     ) -> pa.RecordBatch:
         columns = []
         names = []
@@ -649,6 +722,29 @@ class DeltaSharingReader:
                     column = column.cast(field_type)
                 columns.append(column)
                 continue
+
+            if for_cdf:
+                if field_name == DeltaSharingReader._change_type_col_name():
+                    if isinstance(action, AddCdcFile):
+                        raise ValueError("Missing _change_type column in change data feed file")
+                    columns.append(
+                        pa.array([action.get_change_type_col_value()] * num_rows, type=field_type)
+                    )
+                    continue
+                if field_name == DeltaSharingReader._commit_version_col_name():
+                    columns.append(
+                        pa.array([action.version] * num_rows, type=field_type)
+                        if action.version is not None
+                        else pa.nulls(num_rows, type=field_type)
+                    )
+                    continue
+                if field_name == DeltaSharingReader._commit_timestamp_col_name():
+                    columns.append(
+                        pa.array([action.timestamp] * num_rows, type=field_type)
+                        if action.timestamp is not None
+                        else pa.nulls(num_rows, type=field_type)
+                    )
+                    continue
 
             if field_name in action.partition_values:
                 schema_type = field["type"]
@@ -684,8 +780,8 @@ class DeltaSharingReader:
 
     @staticmethod
     def _add_special_cdf_schema(schema_json: dict) -> dict:
-        fields = schema_json["fields"]
+        fields = list(schema_json["fields"])
         fields.append({"name": DeltaSharingReader._change_type_col_name(), "type": "string"})
         fields.append({"name": DeltaSharingReader._commit_version_col_name(), "type": "long"})
         fields.append({"name": DeltaSharingReader._commit_timestamp_col_name(), "type": "long"})
-        return schema_json
+        return {**schema_json, "fields": fields}

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -386,6 +386,11 @@ class DeltaSharingReader:
                 last_checkpoint_file.close()
 
     def __table_changes_scan_kernel(self, cdfOptions: CdfOptions, log_stats: bool = False):
+        """
+        Build a delta-kernel CDF scan. The caller owns the returned temp dir and
+        must keep it alive until the scan result is fully consumed. The final
+        item is the number of versions containing file actions.
+        """
         temp_dir = tempfile.TemporaryDirectory()
         try:
             self._rest_client.set_delta_format_header(for_cdf=True)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -1151,40 +1151,6 @@ def test_snapshot_legacy_and_table_handle_materializers_match(
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
-def test_table_changes_arrow_matches_pandas_on_real_table(
-    profile_path: str, profile: DeltaSharingProfile
-):
-    fragments = "share8.default.cdf_table_cdf_enabled"
-    starting_version = 0
-    ending_version = 3
-
-    expected_pdf = load_table_changes_as_pandas(
-        f"{profile_path}#{fragments}",
-        starting_version=starting_version,
-        ending_version=ending_version,
-    )
-    legacy_arrow = load_table_changes_as_arrow(
-        f"{profile_path}#{fragments}",
-        starting_version=starting_version,
-        ending_version=ending_version,
-    )
-    changes = (
-        SharingClient(profile)
-        .table(fragments)
-        .changes(
-            starting_version=starting_version,
-            ending_version=ending_version,
-        )
-    )
-    arrow_table = changes.to_arrow()
-
-    pd.testing.assert_frame_equal(arrow_table.to_pandas(), expected_pdf)
-    assert legacy_arrow.equals(arrow_table)
-    assert pa.Table.from_batches(list(changes.to_record_batches())).equals(arrow_table)
-    assert changes.to_record_batch_reader().read_all().equals(arrow_table)
-
-
-@pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_table_snapshot_materializers_on_real_table(profile: DeltaSharingProfile):
     expected = pd.DataFrame(
         {
@@ -1492,6 +1458,7 @@ def test_load_snapshot_exception_client_delta_kernel_disabled_with_delta_table(
 )
 def test_load_table_changes(
     profile_path: str,
+    profile: DeltaSharingProfile,
     fragments: str,
     starting_version: Optional[int],
     ending_version: Optional[int],
@@ -1509,6 +1476,26 @@ def test_load_table_changes(
             ending_timestamp,
         )
         pd.testing.assert_frame_equal(pdf, expected)
+        arrow_table = load_table_changes_as_arrow(
+            f"{profile_path}#{fragments}",
+            starting_version,
+            ending_version,
+            starting_timestamp,
+            ending_timestamp,
+        )
+        pd.testing.assert_frame_equal(arrow_table.to_pandas(), expected)
+        table_arrow = (
+            SharingClient(profile)
+            .table(fragments)
+            .changes(
+                starting_version=starting_version,
+                ending_version=ending_version,
+                starting_timestamp=starting_timestamp,
+                ending_timestamp=ending_timestamp,
+            )
+            .to_arrow()
+        )
+        assert table_arrow.equals(arrow_table)
     else:
         try:
             load_table_changes_as_pandas(
@@ -1638,6 +1625,15 @@ def test_load_table_changes_kernel(
             ending_timestamp,
             use_delta_format=True,
         )
+        arrow_pdf = load_table_changes_as_arrow(
+            f"{profile_path}#{fragments}",
+            starting_version,
+            ending_version,
+            starting_timestamp,
+            ending_timestamp,
+            use_delta_format=True,
+        ).to_pandas()
+        pd.testing.assert_frame_equal(arrow_pdf, pdf)
         if len(pdf) > 0:
             pdf["_commit_timestamp"] = pdf["_commit_timestamp"].astype("int") // 1000
         pd.testing.assert_frame_equal(pdf, expected)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -313,7 +313,7 @@ def test_delta_sharing_table_snapshot_materializers(tmp_path):
     }
 
 
-def test_delta_sharing_table_changes_to_pandas(tmp_path):
+def test_delta_sharing_table_changes_materializers(tmp_path):
     source = pd.DataFrame({"value": [1, 2], "label": ["a", "b"]})
     parquet_path = tmp_path / "table_changes.parquet"
     source.to_parquet(parquet_path)
@@ -1483,7 +1483,7 @@ def test_load_table_changes(
             starting_timestamp,
             ending_timestamp,
         )
-        pd.testing.assert_frame_equal(arrow_table.to_pandas(), expected)
+        _assert_arrow_matches_pandas(pdf, arrow_table)
         table_arrow = (
             SharingClient(profile)
             .table(fragments)
@@ -1497,7 +1497,7 @@ def test_load_table_changes(
         )
         assert table_arrow.equals(arrow_table)
     else:
-        try:
+        with pytest.raises(HTTPError, match=error):
             load_table_changes_as_pandas(
                 f"{profile_path}#{fragments}",
                 starting_version,
@@ -1505,10 +1505,14 @@ def test_load_table_changes(
                 starting_timestamp,
                 ending_timestamp,
             )
-            assert False
-        except Exception as e:
-            assert isinstance(e, HTTPError)
-            assert error in str(e)
+        with pytest.raises(HTTPError, match=error):
+            load_table_changes_as_arrow(
+                f"{profile_path}#{fragments}",
+                starting_version,
+                ending_version,
+                starting_timestamp,
+                ending_timestamp,
+            )
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
@@ -1625,31 +1629,37 @@ def test_load_table_changes_kernel(
             ending_timestamp,
             use_delta_format=True,
         )
-        arrow_pdf = load_table_changes_as_arrow(
+        arrow_table = load_table_changes_as_arrow(
             f"{profile_path}#{fragments}",
             starting_version,
             ending_version,
             starting_timestamp,
             ending_timestamp,
             use_delta_format=True,
-        ).to_pandas()
-        pd.testing.assert_frame_equal(arrow_pdf, pdf)
+        )
+        _assert_arrow_matches_pandas(pdf, arrow_table)
         if len(pdf) > 0:
             pdf["_commit_timestamp"] = pdf["_commit_timestamp"].astype("int") // 1000
         pd.testing.assert_frame_equal(pdf, expected)
     else:
-        try:
+        with pytest.raises(HTTPError, match=error):
             load_table_changes_as_pandas(
                 f"{profile_path}#{fragments}",
                 starting_version,
                 ending_version,
                 starting_timestamp,
                 ending_timestamp,
+                use_delta_format=True,
             )
-            assert False
-        except Exception as e:
-            assert isinstance(e, HTTPError)
-            assert error in str(e)
+        with pytest.raises(HTTPError, match=error):
+            load_table_changes_as_arrow(
+                f"{profile_path}#{fragments}",
+                starting_version,
+                ending_version,
+                starting_timestamp,
+                ending_timestamp,
+                use_delta_format=True,
+            )
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -354,19 +354,24 @@ def test_delta_sharing_table_changes_to_pandas(tmp_path):
         Table(name="table", share="share", schema="schema"),
         RestClientMock(),
     )
-    result = table.changes(
+    changes = table.changes(
         starting_version=1,
         ending_version=2,
         starting_timestamp="2024-01-01T00:00:00Z",
         ending_timestamp="2024-01-02T00:00:00Z",
         use_delta_format=False,
-    ).to_pandas(convert_in_batches=True)
+    )
+    result = changes.to_pandas(convert_in_batches=True)
 
     expected = source.copy()
     expected["_change_type"] = "insert"
     expected["_commit_version"] = 2
     expected["_commit_timestamp"] = 12345
     pd.testing.assert_frame_equal(result, expected)
+    arrow_table = changes.to_arrow()
+    pd.testing.assert_frame_equal(arrow_table.to_pandas(), expected)
+    assert pa.Table.from_batches(list(changes.to_record_batches())).equals(arrow_table)
+    assert changes.to_record_batch_reader().read_all().equals(arrow_table)
     assert captured == {
         "table": Table(name="table", share="share", schema="schema"),
         "cdfOptions": CdfOptions(
@@ -1142,6 +1147,34 @@ def test_snapshot_legacy_and_table_handle_materializers_match(
 
     assert legacy_table.equals(table_arrow)
     _assert_arrow_matches_pandas(legacy_pdf, legacy_table)
+
+
+@pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
+def test_table_changes_arrow_matches_pandas_on_real_table(
+    profile_path: str, profile: DeltaSharingProfile
+):
+    fragments = "share8.default.cdf_table_cdf_enabled"
+    starting_version = 0
+    ending_version = 3
+
+    expected_pdf = load_table_changes_as_pandas(
+        f"{profile_path}#{fragments}",
+        starting_version=starting_version,
+        ending_version=ending_version,
+    )
+    changes = (
+        SharingClient(profile)
+        .table(fragments)
+        .changes(
+            starting_version=starting_version,
+            ending_version=ending_version,
+        )
+    )
+    arrow_table = changes.to_arrow()
+
+    pd.testing.assert_frame_equal(arrow_table.to_pandas(), expected_pdf)
+    assert pa.Table.from_batches(list(changes.to_record_batches())).equals(arrow_table)
+    assert changes.to_record_batch_reader().read_all().equals(arrow_table)
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/python/delta_sharing/tests/test_delta_sharing.py
+++ b/python/delta_sharing/tests/test_delta_sharing.py
@@ -32,6 +32,7 @@ from delta_sharing.delta_sharing import (
     load_as_arrow,
     load_as_pandas,
     load_as_spark,
+    load_table_changes_as_arrow,
     load_table_changes_as_spark,
     load_table_changes_as_pandas,
     _parse_url,
@@ -1162,6 +1163,11 @@ def test_table_changes_arrow_matches_pandas_on_real_table(
         starting_version=starting_version,
         ending_version=ending_version,
     )
+    legacy_arrow = load_table_changes_as_arrow(
+        f"{profile_path}#{fragments}",
+        starting_version=starting_version,
+        ending_version=ending_version,
+    )
     changes = (
         SharingClient(profile)
         .table(fragments)
@@ -1173,6 +1179,7 @@ def test_table_changes_arrow_matches_pandas_on_real_table(
     arrow_table = changes.to_arrow()
 
     pd.testing.assert_frame_equal(arrow_table.to_pandas(), expected_pdf)
+    assert legacy_arrow.equals(arrow_table)
     assert pa.Table.from_batches(list(changes.to_record_batches())).equals(arrow_table)
     assert changes.to_record_batch_reader().read_all().equals(arrow_table)
 

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -716,7 +716,7 @@ def test_snapshot_empty(rest_client: DataSharingRestClient):
     assert arrow_table.schema.names == list(expected.columns)
 
 
-def test_table_changes_to_pandas_non_partitioned(tmp_path):
+def test_table_changes_non_partitioned(tmp_path):
     # Create basic data frame.
     pdf1 = pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
     pdf2 = pd.DataFrame({"a": [4, 5, 6], "b": ["d", "e", "f"]})
@@ -828,7 +828,7 @@ def test_table_changes_to_pandas_non_partitioned(tmp_path):
     pd.testing.assert_frame_equal(pdf, expected)
 
 
-def test_table_changes_to_pandas_partitioned(tmp_path):
+def test_table_changes_partitioned(tmp_path):
     pdf1 = pd.DataFrame({"a": [1, 2, 3]})
     pdf2 = pd.DataFrame({"a": [4, 5, 6]})
 

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -819,6 +819,7 @@ def test_table_changes_to_pandas_non_partitioned(tmp_path):
 
     expected = pd.concat([pdf1, pdf2, pdf3, pdf4]).reset_index(drop=True)
     pd.testing.assert_frame_equal(pdf, expected)
+    pd.testing.assert_frame_equal(reader.table_changes_to_arrow(CdfOptions()).to_pandas(), expected)
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True
@@ -899,6 +900,8 @@ def test_table_changes_to_pandas_partitioned(tmp_path):
         ]
     ]
     pd.testing.assert_frame_equal(pdf, expected)
+    arrow_table = reader.table_changes_to_record_batch_reader(CdfOptions()).read_all()
+    pd.testing.assert_frame_equal(arrow_table.to_pandas(), expected)
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True
@@ -939,12 +942,136 @@ def test_table_changes_empty(tmp_path):
 
     pdf = reader.table_changes_to_pandas(CdfOptions())
     validate_pdf(pdf)
+    validate_pdf(reader.table_changes_to_arrow(CdfOptions()).to_pandas())
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock(), convert_in_batches=True
     )
     pdf = reader.table_changes_to_pandas(CdfOptions())
     validate_pdf(pdf)
+
+
+def test_add_special_cdf_schema_does_not_mutate_input():
+    schema_json = {
+        "type": "struct",
+        "fields": [
+            {"metadata": {}, "name": "a", "nullable": True, "type": "long"},
+            {"metadata": {}, "name": "b", "nullable": True, "type": "string"},
+        ],
+    }
+    original_fields = list(schema_json["fields"])
+
+    schema_with_cdf = DeltaSharingReader._add_special_cdf_schema(schema_json)
+
+    assert schema_json["fields"] == original_fields
+    assert schema_with_cdf["fields"] == original_fields + [
+        {"name": DeltaSharingReader._change_type_col_name(), "type": "string"},
+        {"name": DeltaSharingReader._commit_version_col_name(), "type": "long"},
+        {"name": DeltaSharingReader._commit_timestamp_col_name(), "type": "long"},
+    ]
+
+
+def test_table_changes_to_record_batches_delta_format_removes_header_after_failure():
+    class RestClientMock:
+        delta_format_removed = False
+
+        def set_delta_format_header(self, for_cdf=False):
+            assert for_cdf
+
+        def list_table_changes(
+            self, table: Table, cdfOptions: CdfOptions
+        ) -> ListTableChangesResponse:
+            assert table == _TEST_TABLE
+            raise RuntimeError("list changes failed")
+
+        def remove_delta_format_header(self):
+            self.delta_format_removed = True
+
+    rest_client = RestClientMock()
+    reader = DeltaSharingReader(
+        _TEST_TABLE,
+        rest_client,
+        use_delta_format=True,
+    )
+
+    with pytest.raises(RuntimeError, match="list changes failed"):
+        reader.table_changes_to_record_batches(CdfOptions())
+
+    assert rest_client.delta_format_removed
+
+
+def test_table_changes_to_record_batches_delta_format_removes_header_before_consumption(tmp_path):
+    parquet_file = tmp_path / "change.parquet"
+    pd.DataFrame({"a": [1]}).to_parquet(parquet_file)
+
+    escaped_schema_string = _SCHEMA_A.replace('"', '\\"')
+    lines = [
+        # CDF scans require a protocol whose writer features include changeDataFeed.
+        (
+            '{"protocol":{"deltaProtocol":{'
+            '"minReaderVersion":3,'
+            '"minWriterVersion":7,'
+            '"readerFeatures":[],'
+            '"writerFeatures":["changeDataFeed"]'
+            "}}}"
+        ),
+        (
+            '{"metaData":{'
+            '"version":0,'
+            '"deltaMetadata":{'
+            '"id":"id",'
+            '"format":{"provider":"parquet","options":{}},'
+            f'"schemaString":"{escaped_schema_string}",'
+            '"partitionColumns":[],'
+            '"configuration":{"delta.enableChangeDataFeed":"true"}'
+            "}}}"
+        ),
+        (
+            '{"file":{'
+            '"id":"change",'
+            '"version":0,'
+            '"timestamp":1000,'
+            '"deltaSingleAction":{'
+            '"add":{'
+            f'"path":"{parquet_file}",'
+            '"partitionValues":{},'
+            '"modificationTime":1000,'
+            '"dataChange":true,'
+            '"size":0'
+            "}}}}"
+        ),
+    ]
+
+    class RestClientMock:
+        delta_format_removed = False
+
+        def set_delta_format_header(self, for_cdf=False):
+            assert for_cdf
+
+        def list_table_changes(
+            self, table: Table, cdfOptions: CdfOptions
+        ) -> ListTableChangesResponse:
+            assert table == _TEST_TABLE
+            return ListTableChangesResponse(
+                protocol=None, metadata=None, actions=None, lines=list(lines)
+            )
+
+        def remove_delta_format_header(self):
+            self.delta_format_removed = True
+
+    rest_client = RestClientMock()
+    reader = DeltaSharingReader(
+        _TEST_TABLE,
+        rest_client,
+        use_delta_format=True,
+    )
+
+    batches = reader.table_changes_to_record_batches(CdfOptions())
+
+    assert rest_client.delta_format_removed
+    result = pa.Table.from_batches(list(batches))
+    assert result.column("a").to_pylist() == [1]
+    assert result.column(DeltaSharingReader._change_type_col_name()).to_pylist() == ["insert"]
 
 
 def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):


### PR DESCRIPTION
**Summary**

Adds Arrow-native materialization for table changes through:

- `TableChanges.to_arrow()`
- `TableChanges.to_record_batches()`
- `TableChanges.to_record_batch_reader()`
- `load_table_changes_as_arrow(...)`

Both parquet and delta-kernel CDF paths are supported.

**Implementation**

- shares delta-kernel CDF scan setup with the existing pandas path
- materializes CDF metadata columns with their Arrow schema types
- preserves logical Delta schema names and column order across Arrow batches
- keeps `_add_special_cdf_schema` output behavior while avoiding input mutation
- removes the Delta capability header before returning lazy kernel batches
- reuses existing pandas and integration scenarios for Arrow parity

**Testing**

- Python test suite: `89 passed, 131 skipped`
- `dev/lint-python` passed compilation, Black, pycodestyle, flake8, and mypy
- pydoc checks skipped because `sphinx-build` is not installed
- `git diff --check`: passed

Part of #860; follows the snapshot Arrow materializers merged in #949.
