### PR TITLE
[1.4] Wrap truncated-response ConnectionClosedException in DeltaSharingConnectionException

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -1416,19 +1416,23 @@ class DeltaSharingRestClient(
             }
           } catch {
             case e: org.apache.http.ConnectionClosedException =>
-              logError(s"Request to delta sharing server failed$getDsQueryIdForLogging " +
-                s"due to ${e}.")
+              // The response body was truncated: the server closed the connection before the full
+              // response body was delivered. Log the tail we received for debugging.
               // takeRight(3) is safe even if the lineBuffer is empty or has fewer than 3 lines.
               val linesToLog = lineBuffer.takeRight(3).mkString("\n")
-              logError("Last 3 lines:" + linesToLog)
+              logError("Connection closed before the full response body was delivered. " +
+                "Last 3 lines:" + linesToLog)
 
-              val error = s"Request to delta sharing server failed$getDsQueryIdForLogging " +
-                s"due to ${e.getMessage}."
-              if (lineBuffer.nonEmpty) {
-                val lastIndex = lineBuffer.length - 1
-                lineBuffer(lastIndex) = (error + lineBuffer(lastIndex)).replace(' ', '_')
-              } else {
-                lineBuffer += error.replace(' ', '_')
+              // The status line are received before the body is read, so the status may already
+              // be non-OK when the body truncates. If so, fall through to the UnexpectedHttpStatus
+              // handling below: it carries the status code and preserves retry semantics.
+              // Only re-throw as a connection error when the status was OK.
+              val statusCode = status.getStatusCode
+              if (statusCode == HttpStatus.SC_OK ||
+                (allowNoContent && statusCode == HttpStatus.SC_NO_CONTENT)) {
+                val error = s"Request to delta sharing server failed$getDsQueryIdForLogging " +
+                  s"due to ${e.getMessage}. This is likely caused by request timeout."
+                throw new DeltaSharingConnectionException(error, e)
               }
               lineBuffer.toList
           } finally {

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
@@ -33,9 +33,14 @@ class MissingEndStreamActionException(message: String) extends IllegalStateExcep
 class DeltaSharingServerException(message: String, statusCodeOpt: Option[Int])
   extends DeltaSharingExceptionWithErrorCode(message, statusCodeOpt)
 
-// Thrown when the client fails to establish a network connection to the Delta Sharing server
-// endpoint (e.g. java.net.BindException / java.net.ConnectException), before any HTTP response is
-// received. This surfaces a legible, actionable message instead of the raw low-level exception.
+// Thrown when a network-level failure prevents the client from receiving a complete response from
+// the Delta Sharing server. This covers two cases:
+//   1. Failure to establish the outbound connection to the endpoint (e.g. java.net.BindException /
+//      java.net.ConnectException), before any HTTP response is received.
+//   2. The response body is truncated mid-stream (org.apache.http.ConnectionClosedException) before
+//      the full body arrives.
+// In both cases this surfaces a legible, actionable message (including the query id for logging)
+// instead of the raw low-level exception.
 class DeltaSharingConnectionException(message: String, cause: Throwable)
   extends IllegalStateException(message, cause)
 


### PR DESCRIPTION
When the sharing server closed the connection mid-stream (the response stream is not finished by the chunked `0\r\n\r\n` terminator), the client stitched its error message into the last buffered line and returned it as valid response data. That corrupted line later surfaced as a confusing `JsonParseException` in `maybeExtractEndStreamAction` instead of a legible connection error.

Re-throw the failure wrapped in DeltaSharingConnectionException (carrying the query id for logging) so callers see a clear network error, and update the exception's doc comment to cover this mid-stream truncation case.