### PR TITLE
docs: update R connector capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,10 +370,11 @@ val df = spark.readStream.format("deltaSharing")
 <td>R</td>
 <td>
 
-[zacdav-db/delta-sharing-r](https://github.com/zacdav-db/delta-sharing-r)
+[zacdav-db/delta-sharing-r](https://github.com/zacdav-db/delta-sharing-r)<br>
+[Documentation](https://zacdav-db.github.io/delta-sharing-r/)
 </td>
 <td>Released</td>
-<td>QueryTableVersion<br>QueryTableMetadata<br>QueryTableLatestSnapshot</td>
+<td>QueryTableVersion<br>QueryTableMetadata<br>QueryTableLatestSnapshot<br>QueryTableChanges(CDF)<br>Time Travel Queries<br>Query Changes between Versions<br>Delta Format Queries<br>Deletion Vectors<br>Column Mapping<br>Limit and Predicate Hints</td>
 </tr>
 <tr>
 <td>Google Spreadsheet</td>


### PR DESCRIPTION
## Summary

- Link the R connector documentation site from its community entry.
- Update the existing R connector entry to reflect its current snapshot, time
  travel, change data feed, Delta format, deletion vector, column mapping, and
  query-hint support.

## Context

The community table currently reflects the earlier snapshot-only capabilities
of `delta-sharing-r`. The connector now uses Delta Kernel for table reads and
supports the additional features listed here.

This remains a community connector. This PR does not change the Delta Sharing
protocol or any upstream implementation code.

## Validation

- Rendered the README with Pandoc.
- Verified the repository and documentation links return successfully.
- Checked the patch for whitespace errors.
