### PR TITLE
Support CDF on views in Spark

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -1688,6 +1688,9 @@ class DeltaSharingRestClient(
   // Example: "capability1=value1;capability2=value3,value4,value5"
   private def constructDeltaSharingCapabilities(setIncludeEndStreamAction: Boolean): String = {
     var capabilities = Seq[String](s"${RESPONSE_FORMAT}=$responseFormat")
+    if (!forStreaming) {
+      capabilities = capabilities :+ s"$VERSIONLESS_CDF=true"
+    }
     if (responseFormatSet.contains(RESPONSE_FORMAT_DELTA) && readerFeatures.nonEmpty) {
       capabilities = capabilities :+ s"$READER_FEATURES=$readerFeatures"
     }

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -120,13 +120,15 @@ case class ParsedDeltaSharingTablePath(
  *                        response header
  * @param fileIdHash The fileidhash response header value, if present
  *                   (e.g. parquet or delta).
+ * @param hasTableVersion whether the response included a table version header
  */
 case class ParsedDeltaSharingResponse(
     version: Long,
     respondedFormat: String,
     lines: Seq[String],
     capabilitiesMap: Map[String, String],
-    fileIdHash: Option[String] = None)
+    fileIdHash: Option[String] = None,
+    hasTableVersion: Boolean = true)
 
 private[sharing] trait PaginationResponse {
   def nextPageToken: Option[String]
@@ -732,10 +734,13 @@ class DeltaSharingRestClient(
       val res = fetchNextPageFiles(
         targetUrl = nextPageUrl,
         requestBody = Some(pagingRequest),
-        expectedVersion = version,
-        expectedRespondedFormat = respondedFormat,
-        expectedProtocol = protocol,
-        expectedMetadata = metadata,
+        expectedResponse = ExpectedPaginationResponse(
+          version = version,
+          hasTableVersion = true,
+          isVersionlessCDF = false,
+          respondedFormat = respondedFormat,
+          protocol = protocol,
+          metadata = metadata),
         pageNumber = numPages,
         // Do not set EndStreamAction for async queries yet, and set it for sync queries.
         setIncludeEndStreamAction = !enableAsyncQuery,
@@ -774,27 +779,40 @@ class DeltaSharingRestClient(
 
     val target = getTargetUrl(
       s"/shares/$encodedShare/schemas/$encodedSchema/tables/$encodedTable/changes?$encodedParams")
-    val (version, respondedFormat, lines, responseFileIdHash) = if (queryTablePaginationEnabled) {
-      logInfo(
-        s"Making paginated queryTableChanges requests for table " +
-          getFullTableName(table) + s" with maxFiles=$maxFilesPerReq," +
+    val (
+      version,
+      respondedFormat,
+      lines,
+      hasTableVersion,
+      isVersionlessCDF,
+      responseFileIdHash) =
+      if (queryTablePaginationEnabled) {
+        logInfo(
+          s"Making paginated queryTableChanges requests for table " +
+            getFullTableName(table) + s" with maxFiles=$maxFilesPerReq," +
+            getDsQueryIdForLogging
+        )
+        getCDFFilesByPage(target, fileIdHash)
+      } else {
+        val response = getNDJson(
+          target,
+          requireVersion = false,
+          setIncludeEndStreamAction = endStreamActionEnabled,
+          requestFileIdHash = fileIdHash
+        )
+        val (filteredLines, _) = maybeExtractEndStreamAction(response.lines)
+        logInfo(s"Took ${System.currentTimeMillis() - start} ms to query ${filteredLines.size} " +
+          "files for table " + getFullTableName(table) + s" with CDF($cdfOptions)," +
           getDsQueryIdForLogging
-      )
-      getCDFFilesByPage(target, fileIdHash)
-    } else {
-      val response = getNDJson(
-        target,
-        requireVersion = false,
-        setIncludeEndStreamAction = endStreamActionEnabled,
-        requestFileIdHash = fileIdHash
-      )
-      val (filteredLines, _) = maybeExtractEndStreamAction(response.lines)
-      logInfo(s"Took ${System.currentTimeMillis() - start} ms to query ${filteredLines.size} " +
-        "files for table " + getFullTableName(table) + s" with CDF($cdfOptions)," +
-        getDsQueryIdForLogging
-      )
-      (response.version, response.respondedFormat, filteredLines, response.fileIdHash)
-    }
+        )
+        (
+          response.version,
+          response.respondedFormat,
+          filteredLines,
+          response.hasTableVersion,
+          getRespondedVersionlessCDF(response.capabilitiesMap),
+          response.fileIdHash)
+      }
 
     verifyFileIdHashResponse(
       fileIdHash,
@@ -808,19 +826,56 @@ class DeltaSharingRestClient(
     )
 
     // To ensure that it works with delta sharing server that doesn't support the requested format.
-    if (respondedFormat == RESPONSE_FORMAT_DELTA) {
+    if (isVersionlessCDF && hasTableVersion) {
+      throw new IllegalStateException(
+        "View CDF response must not include Delta-Table-Version in the header" +
+          getDsQueryIdForLogging)
+    }
+    if (!isVersionlessCDF && !hasTableVersion) {
+      throw new IllegalStateException(
+        "Cannot find Delta-Table-Version or versionlesscdf=true in the response header" +
+          getDsQueryIdForLogging)
+    }
+    if (isVersionlessCDF &&
+      (cdfOptions.contains("startingVersion") || cdfOptions.contains("endingVersion"))) {
+      throw new IllegalArgumentException(
+        "View CDF queries only support startingTimestamp and endingTimestamp" +
+          getDsQueryIdForLogging)
+    }
+    if (respondedFormat == RESPONSE_FORMAT_DELTA && !isVersionlessCDF) {
       return DeltaTableFiles(version, lines = lines, respondedFormat = respondedFormat)
     }
-    val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
+
+    val (protocol, metadata, actionLines, isDeltaViewCDF) =
+      if (respondedFormat == RESPONSE_FORMAT_DELTA) {
+        val protocolNode = JsonUtils.readTree(lines(0)).get("protocol").get("deltaProtocol")
+        val metadataNode = JsonUtils.readTree(lines(1)).get("metaData").get("deltaMetadata")
+        (
+          JsonUtils.fromJson[Protocol](protocolNode.toString),
+          JsonUtils.fromJson[Metadata](metadataNode.toString),
+          lines.drop(2),
+          true
+        )
+      } else {
+        (
+          JsonUtils.fromJson[SingleAction](lines(0)).protocol,
+          JsonUtils.fromJson[SingleAction](lines(1)).metaData,
+          lines.drop(2),
+          false
+        )
+      }
     checkProtocol(protocol)
-    val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
 
     val addFiles = ArrayBuffer[AddFileForCDF]()
     val cdfFiles = ArrayBuffer[AddCDCFile]()
     val removeFiles = ArrayBuffer[RemoveFile]()
     val additionalMetadatas = ArrayBuffer[Metadata]()
-    lines.drop(2).foreach { line =>
-      val action = JsonUtils.fromJson[SingleAction](line).unwrap
+    actionLines.foreach { line =>
+      val action = if (isDeltaViewCDF) {
+        parseDeltaViewCDFAction(line)
+      } else {
+        JsonUtils.fromJson[SingleAction](line).unwrap
+      }
       action match {
         case c: AddCDCFile => cdfFiles.append(c)
         case a: AddFileForCDF => addFiles.append(a)
@@ -833,6 +888,20 @@ class DeltaSharingRestClient(
               s"targetUrl $target" + getDsQueryIdForLogging)
       }
     }
+    if (isVersionlessCDF &&
+      (addFiles.exists(_.version != null) ||
+        cdfFiles.exists(_.version != null) ||
+        removeFiles.exists(_.version != null))) {
+      throw new IllegalStateException(
+        "View CDF file actions must not include a version" + getDsQueryIdForLogging)
+    }
+    if (!isVersionlessCDF &&
+      (addFiles.exists(_.version == null) ||
+        cdfFiles.exists(_.version == null) ||
+        removeFiles.exists(_.version == null))) {
+      throw new IllegalStateException(
+        "Table CDF file actions must include a version" + getDsQueryIdForLogging)
+    }
     DeltaTableFiles(
       version,
       protocol,
@@ -841,15 +910,87 @@ class DeltaSharingRestClient(
       cdfFiles = cdfFiles.toSeq,
       removeFiles = removeFiles.toSeq,
       additionalMetadatas = additionalMetadatas.toSeq,
-      respondedFormat = respondedFormat
+      respondedFormat = respondedFormat,
+      isVersionlessCDF = isVersionlessCDF
     )
   }
 
+  private[client] def parseDeltaViewCDFAction(line: String): Action = {
+    val root = JsonUtils.readTree(line)
+    if (root.has("metaData")) {
+      return JsonUtils.fromJson[Metadata](root.get("metaData").get("deltaMetadata").toString)
+    }
+    if (!root.has("file")) {
+      throw new IllegalStateException(
+        s"Unexpected Delta view CDF line:$line," + getDsQueryIdForLogging)
+    }
+
+    val file = root.get("file")
+    val deltaAction = file.get("deltaSingleAction")
+    val id = file.get("id").asText()
+    if (Option(file.get("version")).exists(node => !node.isNull)) {
+      throw new IllegalStateException(
+        s"View CDF file must not include a version:$line," + getDsQueryIdForLogging)
+    }
+    val timestampNode = file.get("timestamp")
+    if (timestampNode == null || timestampNode.isNull) {
+      throw new IllegalStateException(
+        s"Missing timestamp in Delta view CDF line:$line," + getDsQueryIdForLogging)
+    }
+    val timestamp = timestampNode.asLong()
+    val expirationTimestamp = Option(file.get("expirationTimestamp"))
+      .filterNot(_.isNull).map(n => Long.box(n.asLong())).orNull
+
+    def partitionValues(action: com.fasterxml.jackson.databind.JsonNode): Map[String, String] = {
+      Option(action.get("partitionValues")).filterNot(_.isNull)
+        .map(node => JsonUtils.fromJson[Map[String, String]](node.toString))
+        .getOrElse(Map.empty)
+    }
+
+    if (deltaAction.has("add")) {
+      val add = deltaAction.get("add")
+      AddFileForCDF(
+        add.get("path").asText(),
+        id,
+        partitionValues(add),
+        add.get("size").asLong(),
+        version = null,
+        timestamp = timestamp,
+        stats = Option(add.get("stats")).filterNot(_.isNull).map(_.asText()).orNull,
+        expirationTimestamp = expirationTimestamp)
+    } else if (deltaAction.has("cdc")) {
+      val cdc = deltaAction.get("cdc")
+      AddCDCFile(
+        cdc.get("path").asText(),
+        id,
+        partitionValues(cdc),
+        cdc.get("size").asLong(),
+        version = null,
+        timestamp = timestamp,
+        expirationTimestamp = expirationTimestamp)
+    } else if (deltaAction.has("remove")) {
+      val remove = deltaAction.get("remove")
+      RemoveFile(
+        remove.get("path").asText(),
+        id,
+        partitionValues(remove),
+        Option(remove.get("size")).filterNot(_.isNull).map(_.asLong()).getOrElse(0L),
+        version = null,
+        timestamp = timestamp,
+        expirationTimestamp = expirationTimestamp)
+    } else {
+      throw new IllegalStateException(
+        s"Delta view CDF file contains no add, cdc, or remove action:$line," +
+          getDsQueryIdForLogging)
+    }
+  }
+
   // Send paginated queryTableChanges requests. Loop internally to fetch and concatenate all pages,
-  // then return (version, respondedFormat, actions, responseFileIdHash) tuple.
+  // then return the version, format, actions, header metadata, and response file ID hash.
   private def getCDFFilesByPage(
       targetUrl: String,
-      fileIdHash: Option[String] = None): (Long, String, Seq[String], Option[String]) = {
+      fileIdHash: Option[String] = None):
+      (Long, String, Seq[String], Boolean, Boolean, Option[String]) = {
     val allLines = ArrayBuffer[String]()
     val start = System.currentTimeMillis()
     var numPages = 1
@@ -885,10 +1026,13 @@ class DeltaSharingRestClient(
       val res = fetchNextPageFiles(
         targetUrl = updatedUrl,
         requestBody = None,
-        expectedVersion = response.version,
-        expectedRespondedFormat = response.respondedFormat,
-        expectedProtocol = protocol,
-        expectedMetadata = metadata,
+        expectedResponse = ExpectedPaginationResponse(
+          version = response.version,
+          hasTableVersion = response.hasTableVersion,
+          isVersionlessCDF = getRespondedVersionlessCDF(response.capabilitiesMap),
+          respondedFormat = response.respondedFormat,
+          protocol = protocol,
+          metadata = metadata),
         pageNumber = numPages,
         setIncludeEndStreamAction = endStreamActionEnabled,
         requestFileIdHash = fileIdHash
@@ -912,19 +1056,30 @@ class DeltaSharingRestClient(
       s"Took ${System.currentTimeMillis() - start} ms to query $numPages pages " +
       s"of ${allLines.size} files," + getDsQueryIdForLogging
     )
-    (response.version, response.respondedFormat, allLines.toSeq, response.fileIdHash)
+    (
+      response.version,
+      response.respondedFormat,
+      allLines.toSeq,
+      response.hasTableVersion,
+      getRespondedVersionlessCDF(response.capabilitiesMap),
+      response.fileIdHash)
   }
 
   // Send next page query request. Validate the response and return next page files
   // (as original json string) with EndStreamAction. EndStreamAction might be null
   // if it's not returned in the response.
+  private case class ExpectedPaginationResponse(
+      version: Long,
+      hasTableVersion: Boolean,
+      isVersionlessCDF: Boolean,
+      respondedFormat: String,
+      protocol: String,
+      metadata: String)
+
   private def fetchNextPageFiles(
       targetUrl: String,
       requestBody: Option[NextPageRequest],
-      expectedVersion: Long,
-      expectedRespondedFormat: String,
-      expectedProtocol: String,
-      expectedMetadata: String,
+      expectedResponse: ExpectedPaginationResponse,
       pageNumber: Int,
       setIncludeEndStreamAction: Boolean,
       requestFileIdHash: Option[String] = None): (Seq[String], Option[EndStreamAction]) = {
@@ -948,15 +1103,18 @@ class DeltaSharingRestClient(
       s"of ${response.lines.size} lines," + getDsQueryIdForLogging)
 
     // Validate that version/format/protocol/metadata in the response don't change across pages
-    if (response.version != expectedVersion ||
-      response.respondedFormat != expectedRespondedFormat ||
+    if (response.version != expectedResponse.version ||
+      response.hasTableVersion != expectedResponse.hasTableVersion ||
+      getRespondedVersionlessCDF(response.capabilitiesMap) != expectedResponse.isVersionlessCDF ||
+      response.respondedFormat != expectedResponse.respondedFormat ||
       response.lines.size < 2 ||
-      response.lines(0) != expectedProtocol ||
-      response.lines(1) != expectedMetadata) {
+      response.lines(0) != expectedResponse.protocol ||
+      response.lines(1) != expectedResponse.metadata) {
       val errorMsg = s"""
         |Received inconsistent version/format/protocol/metadata across pages.
-        |Expected: version $expectedVersion, $expectedRespondedFormat,
-        |$expectedProtocol, $expectedMetadata. Actual: version ${response.version},
+        |Expected: version ${expectedResponse.version}, ${expectedResponse.respondedFormat},
+        |${expectedResponse.protocol}, ${expectedResponse.metadata}.
+        |Actual: version ${response.version},
         |${response.respondedFormat}, ${response.lines},$getDsQueryIdForLogging""".stripMargin
       logError(s"Error while fetching next page files at url $targetUrl " +
         s"with body(${JsonUtils.toJson(requestBody.orNull)}: $errorMsg)")
@@ -1035,9 +1193,10 @@ class DeltaSharingRestClient(
         }
       },
       respondedFormat = getRespondedFormat(capabilitiesMap),
-      lines,
+      lines = lines,
       capabilitiesMap = capabilitiesMap,
-      fileIdHash = fileIdHash
+      fileIdHash = fileIdHash,
+      hasTableVersion = version.isDefined
     )
   }
 
@@ -1174,9 +1333,10 @@ class DeltaSharingRestClient(
         )
       },
       respondedFormat = getRespondedFormat(capabilitiesMap),
-      lines,
+      lines = lines,
       capabilitiesMap = capabilitiesMap,
-      fileIdHash = fileIdHash
+      fileIdHash = fileIdHash,
+      hasTableVersion = true
     )
   }
 
@@ -1237,6 +1397,10 @@ class DeltaSharingRestClient(
 
   private def getRespondedFormat(capabilitiesMap: Map[String, String]): String = {
     capabilitiesMap.get(RESPONSE_FORMAT).getOrElse(RESPONSE_FORMAT_PARQUET)
+  }
+
+  private def getRespondedVersionlessCDF(capabilitiesMap: Map[String, String]): Boolean = {
+    capabilitiesMap.get(VERSIONLESS_CDF).contains("true")
   }
 
   private def parseDeltaSharingCapabilities(capabilities: Option[String]): Map[String, String] = {
@@ -1563,6 +1727,7 @@ object DeltaSharingRestClient extends Logging {
   val READER_FEATURES = "readerfeatures"
   val DELTA_SHARING_CAPABILITIES_ASYNC_READ = "asyncquery"
   val DELTA_SHARING_INCLUDE_END_STREAM_ACTION = "includeendstreamaction"
+  val VERSIONLESS_CDF = "versionlesscdf"
   val RESPONSE_FORMAT_DELTA = "delta"
   val RESPONSE_FORMAT_PARQUET = "parquet"
   val DELTA_SHARING_CAPABILITIES_DELIMITER = ";"

--- a/client/src/main/scala/io/delta/sharing/client/model.scala
+++ b/client/src/main/scala/io/delta/sharing/client/model.scala
@@ -27,12 +27,19 @@ private[sharing] object CDFColumnInfo {
   val change_type_col_name = "_change_type"
 
   // Returns internal partition schema for internal columns for CDC actions.
-  def getInternalPartitonSchemaForCDC(): Map[String, DataType] =
-    Map(commit_version_col_name -> LongType, commit_timestamp_col_name -> LongType)
+  def getInternalPartitonSchemaForCDC(
+      includeCommitVersion: Boolean = true): Map[String, DataType] = {
+    if (includeCommitVersion) {
+      Map(commit_version_col_name -> LongType, commit_timestamp_col_name -> LongType)
+    } else {
+      Map(commit_timestamp_col_name -> LongType)
+    }
+  }
 
   // Returns internal partition schema for internal columns for CDF add/remove actions.
-  def getInternalPartitonSchemaForCDFAddRemoveFile(): Map[String, DataType] =
-    getInternalPartitonSchemaForCDC() + (change_type_col_name -> StringType)
+  def getInternalPartitonSchemaForCDFAddRemoveFile(
+      includeCommitVersion: Boolean = true): Map[String, DataType] =
+    getInternalPartitonSchemaForCDC(includeCommitVersion) + (change_type_col_name -> StringType)
 }
 
 private[sharing] case class DeltaTableMetadata(

--- a/client/src/main/scala/io/delta/sharing/client/model.scala
+++ b/client/src/main/scala/io/delta/sharing/client/model.scala
@@ -53,7 +53,8 @@ private[sharing] case class DeltaTableFiles(
     additionalMetadatas: Seq[Metadata] = Nil,
     lines: Seq[String] = Nil,
     refreshToken: Option[String] = None,
-    respondedFormat: String)
+    respondedFormat: String,
+    isVersionlessCDF: Boolean = false)
 
 private[sharing] case class Share(name: String)
 
@@ -197,7 +198,7 @@ private[sharing] case class AddFileForCDF(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     override val partitionValues: Map[String, String],
     override val size: Long,
-    version: Long,
+    version: java.lang.Long = null,
     timestamp: Long,
     @JsonRawValue
     stats: String = null,
@@ -208,10 +209,12 @@ private[sharing] case class AddFileForCDF(
   override def getPartitionValuesInDF(): Map[String, String] = {
     // The scala map operation "+" will override values of existing keys.
     // So the function is idempotent, and calling it multiple times does not change its output.
-    partitionValues +
-    (CDFColumnInfo.commit_version_col_name -> version.toString) +
-    (CDFColumnInfo.commit_timestamp_col_name -> timestamp.toString) +
-    (CDFColumnInfo.change_type_col_name -> "insert")
+    val cdfPartitions = partitionValues +
+      (CDFColumnInfo.commit_timestamp_col_name -> timestamp.toString) +
+      (CDFColumnInfo.change_type_col_name -> "insert")
+    Option(version).map { v =>
+      cdfPartitions + (CDFColumnInfo.commit_version_col_name -> v.toString)
+    }.getOrElse(cdfPartitions)
   }
 }
 
@@ -221,7 +224,7 @@ private[sharing] case class AddCDCFile(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     override val partitionValues: Map[String, String],
     override val size: Long,
-    version: Long,
+    version: java.lang.Long = null,
     timestamp: Long,
     expirationTimestamp: java.lang.Long = null) extends FileAction(url, id, partitionValues, size) {
 
@@ -230,9 +233,11 @@ private[sharing] case class AddCDCFile(
   override def getPartitionValuesInDF(): Map[String, String] = {
     // The scala map operation "+" will override values of existing keys.
     // So the function is idempotent, and calling it multiple times does not change its output.
-    partitionValues +
-    (CDFColumnInfo.commit_version_col_name -> version.toString) +
-    (CDFColumnInfo.commit_timestamp_col_name -> timestamp.toString)
+    val cdfPartitions = partitionValues +
+      (CDFColumnInfo.commit_timestamp_col_name -> timestamp.toString)
+    Option(version).map { v =>
+      cdfPartitions + (CDFColumnInfo.commit_version_col_name -> v.toString)
+    }.getOrElse(cdfPartitions)
   }
 }
 
@@ -242,7 +247,7 @@ private[sharing] case class RemoveFile(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     override val partitionValues: Map[String, String],
     override val size: Long,
-    version: Long,
+    version: java.lang.Long = null,
     timestamp: Long,
     expirationTimestamp: java.lang.Long = null) extends FileAction(url, id, partitionValues, size) {
 
@@ -251,9 +256,11 @@ private[sharing] case class RemoveFile(
   override def getPartitionValuesInDF(): Map[String, String] = {
     // The scala map operation "+" will override values of existing keys.
     // So the function is idempotent, and calling it multiple times does not change its output.
-    partitionValues +
-    (CDFColumnInfo.commit_version_col_name -> version.toString) +
-    (CDFColumnInfo.commit_timestamp_col_name -> timestamp.toString) +
-    (CDFColumnInfo.change_type_col_name -> "delete")
+    val cdfPartitions = partitionValues +
+      (CDFColumnInfo.commit_timestamp_col_name -> timestamp.toString) +
+      (CDFColumnInfo.change_type_col_name -> "delete")
+    Option(version).map { v =>
+      cdfPartitions + (CDFColumnInfo.commit_version_col_name -> v.toString)
+    }.getOrElse(cdfPartitions)
   }
 }

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingErrors.scala
@@ -111,6 +111,11 @@ object DeltaSharingErrors {
     new UnsupportedOperationException("Cannot time travel streams.")
   }
 
+  def viewCDFStreamingNotSupportedException: Throwable = {
+    new UnsupportedOperationException(
+      "Change data feed on shared views is supported only for batch reads.")
+  }
+
   def schemaNotSetException: Throwable = {
     new IllegalStateException("Shared table schema is not set. Please contact your data provider.")
   }

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingSource.scala
@@ -617,6 +617,9 @@ case class DeltaSharingSource(
       true,
       None
     )
+    if (tableFiles.isVersionlessCDF) {
+      throw DeltaSharingErrors.viewCDFStreamingNotSupportedException
+    }
     queryParamsHashId = QueryUtils.getQueryParamsHashId(cdfOptions)
     latestRefreshFunc = _ => {
       val queryTimestamp = System.currentTimeMillis()

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaCDFRelation.scala
@@ -41,27 +41,50 @@ case class RemoteDeltaCDFRelation(
     table: DeltaSharingTable,
     cdfOptions: Map[String, String]) extends BaseRelation with PrunedFilteredScan {
 
-  override def schema: StructType = DeltaTableUtils.addCdcSchema(snapshotToUse.schema)
+  private lazy val deltaTableFiles = client.getCDFFiles(table, cdfOptions, false, None)
+
+  private lazy val baseSchema = {
+    if (deltaTableFiles.isVersionlessCDF) {
+      DeltaTableUtils.toSchema(deltaTableFiles.metadata.schemaString)
+    } else {
+      snapshotToUse.schema
+    }
+  }
+
+  private[sharing] lazy val fileIndexParams = {
+    val partitionSchemaOverride = if (deltaTableFiles.isVersionlessCDF) {
+      Some(new StructType(
+        deltaTableFiles.metadata.partitionColumns.map(column => baseSchema(column)).toArray))
+    } else {
+      None
+    }
+    new RemoteDeltaFileIndexParams(
+      spark,
+      snapshotToUse,
+      client.getProfileProvider,
+      Some(QueryUtils.getQueryParamsHashId(cdfOptions)),
+      includeCommitVersion = !deltaTableFiles.isVersionlessCDF,
+      partitionSchemaOverride = partitionSchemaOverride,
+      useActionSizes = deltaTableFiles.isVersionlessCDF)
+  }
+
+  override lazy val schema: StructType = {
+    DeltaTableUtils.addCdcSchema(
+      baseSchema, includeCommitVersion = !deltaTableFiles.isVersionlessCDF)
+  }
 
   override def sqlContext: SQLContext = spark.sqlContext
 
   override def buildScan(
       requiredColumns: Array[String],
       filters: Array[Filter]): RDD[Row] = {
-    val deltaTabelFiles = client.getCDFFiles(table, cdfOptions, false, None)
-
     DeltaSharingCDFReader.changesToDF(
-      new RemoteDeltaFileIndexParams(
-        spark,
-        snapshotToUse,
-        client.getProfileProvider,
-        Some(QueryUtils.getQueryParamsHashId(cdfOptions))
-      ),
+      fileIndexParams,
       requiredColumns,
-      deltaTabelFiles.addFiles,
-      deltaTabelFiles.cdfFiles,
-      deltaTabelFiles.removeFiles,
-      DeltaTableUtils.addCdcSchema(deltaTabelFiles.metadata.schemaString),
+      deltaTableFiles.addFiles,
+      deltaTableFiles.cdfFiles,
+      deltaTableFiles.removeFiles,
+      schema,
       false,
       _ => {
         val d = client.getCDFFiles(table, cdfOptions, false, None)
@@ -73,9 +96,9 @@ case class RemoteDeltaCDFRelation(
       },
       System.currentTimeMillis(),
       DeltaSharingCDFReader.getMinUrlExpiration(
-        deltaTabelFiles.addFiles,
-        deltaTabelFiles.cdfFiles,
-        deltaTabelFiles.removeFiles
+        deltaTableFiles.addFiles,
+        deltaTableFiles.cdfFiles,
+        deltaTableFiles.removeFiles
       )
     ).rdd
   }

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaFileIndex.scala
@@ -51,8 +51,13 @@ private[sharing] case class RemoteDeltaFileIndexParams(
     spark: SparkSession,
     snapshotAtAnalysis: RemoteSnapshot,
     profileProvider: DeltaSharingProfileProvider,
-    queryParamsHashId: Option[String] = None) {
+    queryParamsHashId: Option[String] = None,
+    includeCommitVersion: Boolean = true,
+    partitionSchemaOverride: Option[StructType] = None,
+    useActionSizes: Boolean = false) {
   def path: Path = snapshotAtAnalysis.getTablePath
+  def partitionSchema: StructType =
+    partitionSchemaOverride.getOrElse(snapshotAtAnalysis.partitionSchema)
 }
 
 // A base class for all file indices for remote delta log.
@@ -62,7 +67,7 @@ private[sharing] abstract class RemoteDeltaFileIndexBase(
 
   override def sizeInBytes: Long = params.snapshotAtAnalysis.sizeInBytes
 
-  override def partitionSchema: StructType = params.snapshotAtAnalysis.partitionSchema
+  override def partitionSchema: StructType = params.partitionSchema
 
   override def rootPaths: Seq[Path] = params.path :: Nil
 
@@ -123,7 +128,7 @@ private[sharing] abstract class RemoteDeltaFileIndexBase(
 
   protected def getColumnFilter(partitionFilters: Seq[Expression]): Column = {
     val rewrittenFilters = DeltaTableUtils.rewritePartitionFilters(
-      params.snapshotAtAnalysis.partitionSchema,
+      params.partitionSchema,
       params.spark.sessionState.conf.resolver,
       partitionFilters,
       params.spark.sessionState.conf.sessionLocalTimeZone)
@@ -242,8 +247,12 @@ private[sharing] abstract class RemoteDeltaCDFFileIndexBase(
     auxPartitionSchema: Map[String, DataType] = Map.empty)
     extends RemoteDeltaFileIndexBase(params) {
 
+  override def sizeInBytes: Long = {
+    if (params.useActionSizes) actions.map(_.size).sum else super.sizeInBytes
+  }
+
   override def partitionSchema: StructType = {
-    DeltaTableUtils.updateSchema(params.snapshotAtAnalysis.partitionSchema, auxPartitionSchema)
+    DeltaTableUtils.updateSchema(params.partitionSchema, auxPartitionSchema)
   }
 
   override def inputFiles: Array[String] = {
@@ -259,7 +268,7 @@ private[sharing] case class RemoteDeltaCDFAddFileIndex(
     extends RemoteDeltaCDFFileIndexBase(
       params,
       addFiles,
-      CDFColumnInfo.getInternalPartitonSchemaForCDFAddRemoveFile) {
+      CDFColumnInfo.getInternalPartitonSchemaForCDFAddRemoveFile(params.includeCommitVersion)) {
   override def listFiles(
     partitionFilters: Seq[Expression],
     dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
@@ -286,7 +295,7 @@ private[sharing] case class RemoteDeltaCDCFileIndex(
     extends RemoteDeltaCDFFileIndexBase(
       params,
       cdfFiles,
-      CDFColumnInfo.getInternalPartitonSchemaForCDC) {
+      CDFColumnInfo.getInternalPartitonSchemaForCDC(params.includeCommitVersion)) {
 
   override def listFiles(
     partitionFilters: Seq[Expression],
@@ -314,7 +323,7 @@ private[sharing] case class RemoteDeltaCDFRemoveFileIndex(
     extends RemoteDeltaCDFFileIndexBase(
       params,
       removeFiles,
-      CDFColumnInfo.getInternalPartitonSchemaForCDFAddRemoveFile) {
+      CDFColumnInfo.getInternalPartitonSchemaForCDFAddRemoveFile(params.includeCommitVersion)) {
   override def listFiles(
     partitionFilters: Seq[Expression],
     dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -435,14 +435,24 @@ private[sharing] object DeltaTableUtils {
 
   // Adds cdc schema to the table schema.
   def addCdcSchema(tableSchema: StructType): StructType = {
-    updateSchema(tableSchema, CDFColumnInfo.getInternalPartitonSchemaForCDFAddRemoveFile())
+    addCdcSchema(tableSchema, includeCommitVersion = true)
+  }
+
+  def addCdcSchema(tableSchema: StructType, includeCommitVersion: Boolean): StructType = {
+    updateSchema(
+      tableSchema,
+      CDFColumnInfo.getInternalPartitonSchemaForCDFAddRemoveFile(includeCommitVersion))
   }
 
   // Adds cdc schema to the table schema string.
   def addCdcSchema(tableSchemaStr: String): StructType = {
+    addCdcSchema(tableSchemaStr, includeCommitVersion = true)
+  }
+
+  def addCdcSchema(tableSchemaStr: String, includeCommitVersion: Boolean): StructType = {
     updateSchema(
       toSchema(tableSchemaStr),
-      CDFColumnInfo.getInternalPartitonSchemaForCDFAddRemoveFile()
+      CDFColumnInfo.getInternalPartitonSchemaForCDFAddRemoveFile(includeCommitVersion)
     )
   }
 

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -50,6 +50,13 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
 
   import DeltaSharingRestClient._
 
+  private val unitTestProfileProvider = new DeltaSharingProfileProvider {
+    override def getProfile: DeltaSharingProfile = BearerTokenDeltaSharingProfile(
+      shareCredentialsVersion = Some(1),
+      endpoint = "http://localhost",
+      bearerToken = "token")
+  }
+
   private var spark: org.apache.spark.sql.SparkSession = _
 
   override def beforeAll(): Unit = {
@@ -104,6 +111,168 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
     intercept[IllegalArgumentException] {
       DeltaSharingRestClient.parsePath("foo#a.b.c.", emptyShareCredentialsOptions)
+    }
+  }
+
+  test("parse versionless view CDF responses") {
+    Seq(RESPONSE_FORMAT_PARQUET, RESPONSE_FORMAT_DELTA).foreach { responseFormat =>
+      val metadata =
+        """{"id":"view-id","format":{"provider":"parquet"},"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}"""
+      val lines = if (responseFormat == RESPONSE_FORMAT_DELTA) {
+        Seq(
+          """{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}""",
+          s"""{"metaData":{"deltaMetadata":$metadata}}""",
+          """{"file":{"id":"change","timestamp":1234,"deltaSingleAction":{"cdc":{"path":"https://example.com/change.parquet","partitionValues":{},"size":10}}}}"""
+        )
+      } else {
+        Seq(
+          """{"protocol":{"minReaderVersion":1}}""",
+          s"""{"metaData":$metadata}""",
+          """{"cdf":{"url":"https://example.com/change.parquet","id":"change","partitionValues":{},"size":10,"timestamp":1234}}"""
+        )
+      }
+
+      val client = new DeltaSharingRestClient(
+        profileProvider = unitTestProfileProvider,
+        responseFormat = responseFormat) {
+        override def getNDJson(
+            target: String,
+            requireVersion: Boolean,
+            setIncludeEndStreamAction: Boolean,
+            requestFileIdHash: Option[String] = None): ParsedDeltaSharingResponse = {
+          ParsedDeltaSharingResponse(
+            version = 0L,
+            respondedFormat = responseFormat,
+            lines = lines,
+            capabilitiesMap = Map(
+              RESPONSE_FORMAT -> responseFormat,
+              VERSIONLESS_CDF -> "true"),
+            hasTableVersion = false)
+        }
+      }
+
+      try {
+        val result = client.getCDFFiles(
+          Table("view", "schema", "share"),
+          Map("startingTimestamp" -> "2026-01-01T00:00:00Z"),
+          includeHistoricalMetadata = false,
+          fileIdHash = None)
+        assert(result.isVersionlessCDF)
+        assert(result.cdfFiles == Seq(AddCDCFile(
+          "https://example.com/change.parquet",
+          "change",
+          Map.empty,
+          10L,
+          version = null,
+          timestamp = 1234L)))
+      } finally {
+        client.close()
+      }
+    }
+  }
+
+  test("reject versionless CDF response without versionless CDF capability") {
+    val lines = Seq(
+      """{"protocol":{"minReaderVersion":1}}""",
+      """{"metaData":{"id":"view-id","format":{"provider":"parquet"},"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}"""
+    )
+    val client = new DeltaSharingRestClient(unitTestProfileProvider) {
+      override def getNDJson(
+          target: String,
+          requireVersion: Boolean,
+          setIncludeEndStreamAction: Boolean,
+          requestFileIdHash: Option[String] = None): ParsedDeltaSharingResponse = {
+        ParsedDeltaSharingResponse(
+          version = 0L,
+          respondedFormat = RESPONSE_FORMAT_PARQUET,
+          lines = lines,
+          capabilitiesMap = Map.empty,
+          hasTableVersion = false)
+      }
+    }
+
+    try {
+      val error = intercept[IllegalStateException] {
+        client.getCDFFiles(
+          Table("view", "schema", "share"),
+          Map("startingTimestamp" -> "2026-01-01T00:00:00Z"),
+          includeHistoricalMetadata = false,
+          fileIdHash = None)
+      }
+      assert(error.getMessage.contains(
+        "Cannot find Delta-Table-Version or versionlesscdf=true in the response header"))
+    } finally {
+      client.close()
+    }
+  }
+
+  test("reject version bounds for view CDF responses") {
+    val lines = Seq(
+      """{"protocol":{"minReaderVersion":1}}""",
+      """{"metaData":{"id":"view-id","format":{"provider":"parquet"},"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}"""
+    )
+    val client = new DeltaSharingRestClient(unitTestProfileProvider) {
+      override def getNDJson(
+          target: String,
+          requireVersion: Boolean,
+          setIncludeEndStreamAction: Boolean,
+          requestFileIdHash: Option[String] = None): ParsedDeltaSharingResponse = {
+        ParsedDeltaSharingResponse(
+          version = 0L,
+          respondedFormat = RESPONSE_FORMAT_PARQUET,
+          lines = lines,
+          capabilitiesMap = Map(VERSIONLESS_CDF -> "true"),
+          hasTableVersion = false)
+      }
+    }
+
+    try {
+      val error = intercept[IllegalArgumentException] {
+        client.getCDFFiles(
+          Table("view", "schema", "share"),
+          Map("startingVersion" -> "1"),
+          includeHistoricalMetadata = false,
+          fileIdHash = None)
+      }
+      assert(error.getMessage.contains(
+        "View CDF queries only support startingTimestamp and endingTimestamp"))
+    } finally {
+      client.close()
+    }
+  }
+
+  test("reject table CDF actions without versions") {
+    val lines = Seq(
+      """{"protocol":{"minReaderVersion":1}}""",
+      """{"metaData":{"id":"table-id","format":{"provider":"parquet"},"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[]}}""",
+      """{"cdf":{"url":"https://example.com/change.parquet","id":"change","partitionValues":{},"size":10,"timestamp":1234}}"""
+    )
+    val client = new DeltaSharingRestClient(unitTestProfileProvider) {
+      override def getNDJson(
+          target: String,
+          requireVersion: Boolean,
+          setIncludeEndStreamAction: Boolean,
+          requestFileIdHash: Option[String] = None): ParsedDeltaSharingResponse = {
+        ParsedDeltaSharingResponse(
+          version = 1L,
+          respondedFormat = RESPONSE_FORMAT_PARQUET,
+          lines = lines,
+          capabilitiesMap = Map.empty,
+          hasTableVersion = true)
+      }
+    }
+
+    try {
+      val error = intercept[IllegalStateException] {
+        client.getCDFFiles(
+          Table("table", "schema", "share"),
+          Map("startingVersion" -> "1"),
+          includeHistoricalMetadata = false,
+          fileIdHash = None)
+      }
+      assert(error.getMessage.contains("Table CDF file actions must include a version"))
+    } finally {
+      client.close()
     }
   }
 

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -114,6 +114,21 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
     }
   }
 
+  test("advertise versionless CDF capability") {
+    Seq(false, true).foreach { forStreaming =>
+      val client = new DeltaSharingRestClient(
+        unitTestProfileProvider, forStreaming = forStreaming)
+      try {
+        val request = client.prepareHeaders(
+          new HttpGet("http://localhost/test"), setIncludeEndStreamAction = false)
+        val capabilities = request.getFirstHeader(DELTA_SHARING_CAPABILITIES_HEADER).getValue
+        assert(capabilities.toLowerCase.contains(s"$VERSIONLESS_CDF=true") == !forStreaming)
+      } finally {
+        client.close()
+      }
+    }
+  }
+
   test("parse versionless view CDF responses") {
     Seq(RESPONSE_FORMAT_PARQUET, RESPONSE_FORMAT_DELTA).foreach { responseFormat =>
       val metadata =
@@ -356,7 +371,9 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       responseFormat: String,
       readerFeatures: String,
       endStreamActionEnabled: Boolean): Unit = {
-      val expected = s"${RESPONSE_FORMAT}=$responseFormat$readerFeatures" +
+      val versionlessCDF = if (request.getFirstHeader(HttpHeaders.USER_AGENT).getValue
+          .contains(SPARK_STRUCTURED_STREAMING)) "" else s";$VERSIONLESS_CDF=true"
+      val expected = s"${RESPONSE_FORMAT}=$responseFormat$versionlessCDF$readerFeatures" +
         getEndStreamActionHeader(endStreamActionEnabled)
       val h = request.getFirstHeader(DELTA_SHARING_CAPABILITIES_HEADER)
       assert(h.getValue == expected)

--- a/python/delta_sharing/protocol.py
+++ b/python/delta_sharing/protocol.py
@@ -309,6 +309,42 @@ class FileAction:
         else:
             return None
 
+    @staticmethod
+    def from_delta_json(file_json) -> "FileAction":
+        """Convert a Delta-format file wrapper into the connector's file action model."""
+        action_json = file_json["deltaSingleAction"]
+        common = {
+            "id": file_json["id"],
+            "timestamp": file_json.get("timestamp", None),
+            "version": file_json.get("version", None),
+        }
+        if "add" in action_json:
+            action = action_json["add"]
+            return AddFile(
+                url=action["path"],
+                partition_values=action.get("partitionValues") or {},
+                size=int(action["size"]),
+                stats=action.get("stats", None),
+                **common,
+            )
+        elif "cdf" in action_json or "cdc" in action_json:
+            action = action_json.get("cdf", action_json.get("cdc"))
+            return AddCdcFile(
+                url=action["path"],
+                partition_values=action.get("partitionValues") or {},
+                size=int(action["size"]),
+                **common,
+            )
+        elif "remove" in action_json:
+            action = action_json["remove"]
+            return RemoveFile(
+                url=action["path"],
+                partition_values=action.get("partitionValues") or {},
+                size=int(action.get("size") or 0),
+                **common,
+            )
+        raise ValueError("Delta file wrapper contains no add, cdc, or remove action")
+
 
 @dataclass(frozen=True)
 class AddFile(FileAction):
@@ -343,8 +379,8 @@ class AddCdcFile(FileAction):
             id=json["id"],
             partition_values=json["partitionValues"],
             size=int(json["size"]),
-            timestamp=json["timestamp"],
-            version=json["version"],
+            timestamp=json.get("timestamp", None),
+            version=json.get("version", None),
         )
 
 

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -391,6 +391,8 @@ class DeltaSharingReader:
         self._rest_client.set_delta_format_header(for_cdf=True)
         try:
             response = self._rest_client.list_table_changes(self._table, cdfOptions)
+            if response.is_versionless_cdf:
+                return self.__table_changes_response_to_pandas(response)
             lines = response.lines
 
             # first line is protocol
@@ -481,9 +483,14 @@ class DeltaSharingReader:
 
         response = self._rest_client.list_table_changes(self._table, cdfOptions)
 
+        return self.__table_changes_response_to_pandas(response)
+
+    def __table_changes_response_to_pandas(self, response) -> pd.DataFrame:
         schema_json = loads(response.metadata.schema_string)
         converters = to_converters(schema_json)
-        schema_with_cdf = self._add_special_cdf_schema(schema_json)
+        schema_with_cdf = self._add_special_cdf_schema(
+            schema_json, include_commit_version=not response.is_versionless_cdf
+        )
 
         if len(response.actions) == 0:
             return get_empty_table(schema_with_cdf)
@@ -683,9 +690,12 @@ class DeltaSharingReader:
         return "_commit_version"
 
     @staticmethod
-    def _add_special_cdf_schema(schema_json: dict) -> dict:
+    def _add_special_cdf_schema(
+        schema_json: dict, include_commit_version: bool = True
+    ) -> dict:
         fields = schema_json["fields"]
         fields.append({"name": DeltaSharingReader._change_type_col_name(), "type": "string"})
-        fields.append({"name": DeltaSharingReader._commit_version_col_name(), "type": "long"})
+        if include_commit_version:
+            fields.append({"name": DeltaSharingReader._commit_version_col_name(), "type": "long"})
         fields.append({"name": DeltaSharingReader._commit_timestamp_col_name(), "type": "long"})
         return schema_json

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -92,6 +92,7 @@ class ListTableChangesResponse:
     metadata: Metadata
     actions: Sequence[FileAction]
     lines: Sequence[str]
+    is_versionless_cdf: bool = False
 
 
 def retry_with_exponential_backoff(func):
@@ -146,6 +147,7 @@ class DataSharingRestClient:
     DELTA_SNAPSHOT_READER_FEATURES = "readerfeatures=deletionvectors,columnmapping,timestampntz"
     DELTA_CDF_READER_FEATURES = "readerfeatures=deletionvectors,columnmapping"
     CAPABILITIES_HEADER = "delta-sharing-capabilities"
+    VERSIONLESS_CDF = "versionlesscdf=true"
     DELTA_TABLE_VERSION_HEADER = "delta-table-version"
     DELTA_FORMAT = "delta"
     PARQUET_FORMAT = "parquet"
@@ -203,6 +205,40 @@ class DataSharingRestClient:
 
     def remove_delta_format_header(self):
         del self._session.headers[DataSharingRestClient.CAPABILITIES_HEADER]
+
+    def _versionless_cdf_headers(self) -> Dict[str, str]:
+        capabilities = self._session.headers.get(DataSharingRestClient.CAPABILITIES_HEADER, "")
+        capabilities = ";".join(
+            capability
+            for capability in capabilities.split(";")
+            if capability and capability.partition("=")[0].strip().lower() != "versionlesscdf"
+        )
+        capabilities = ";".join(
+            capability
+            for capability in (capabilities, DataSharingRestClient.VERSIONLESS_CDF)
+            if capability
+        )
+        return {DataSharingRestClient.CAPABILITIES_HEADER: capabilities}
+
+    @staticmethod
+    def _response_has_versionless_cdf(headers) -> bool:
+        capabilities = headers.get(DataSharingRestClient.CAPABILITIES_HEADER, "")
+        return any(
+            capability.partition("=")[0].strip().lower() == "versionlesscdf"
+            and capability.partition("=")[2].strip().lower() == "true"
+            for capability in capabilities.split(";")
+        )
+
+    @staticmethod
+    def _validate_cdf_actions(actions, is_versionless_cdf: bool):
+        if any(action is None for action in actions):
+            raise ValueError("CDF response contains an unknown file action")
+        if any(action.timestamp is None for action in actions):
+            raise ValueError("CDF file actions must include a timestamp")
+        if is_versionless_cdf and any(action.version is not None for action in actions):
+            raise ValueError("View CDF file actions must not include a version")
+        if not is_versionless_cdf and any(action.version is None for action in actions):
+            raise ValueError("Table CDF file actions must include a version")
 
     @retry_with_exponential_backoff
     def list_shares(
@@ -428,19 +464,52 @@ class DataSharingRestClient:
             params.append(f"includeHistoricalMetadata={cdfOptions.include_historical_metadata}")
         query_str += "&".join(params)
 
-        with self._get_internal(query_str, return_headers=True) as (headers, lines):
-            if DataSharingRestClient.DELTA_TABLE_VERSION_HEADER not in headers:
-                raise LookupError("Missing delta-table-version header")
+        with self._get_internal(
+            query_str, return_headers=True, headers=self._versionless_cdf_headers()
+        ) as (headers, lines):
+            has_table_version = DataSharingRestClient.DELTA_TABLE_VERSION_HEADER in headers
+            is_versionless_cdf = self._response_has_versionless_cdf(headers)
+            if is_versionless_cdf and has_table_version:
+                raise LookupError("View CDF response must not include delta-table-version header")
+            if not is_versionless_cdf and not has_table_version:
+                raise LookupError(
+                    "Missing delta-table-version header and versionlesscdf=true response capability"
+                )
+            if is_versionless_cdf and (
+                cdfOptions.starting_version is not None or cdfOptions.ending_version is not None
+            ):
+                raise ValueError(
+                    "View CDF queries only support starting_timestamp and ending_timestamp"
+                )
 
             if (
                 DataSharingRestClient.CAPABILITIES_HEADER in headers
                 and "responseformat=delta" in headers[DataSharingRestClient.CAPABILITIES_HEADER]
             ):
+                delta_lines = list(lines)
+                if is_versionless_cdf:
+                    protocol_json = json.loads(delta_lines[0])
+                    metadata_json = json.loads(delta_lines[1])
+                    actions = []
+                    for line in delta_lines[2:]:
+                        action_json = json.loads(line)
+                        if "file" in action_json:
+                            actions.append(FileAction.from_delta_json(action_json["file"]))
+                        elif "metaData" not in action_json:
+                            raise ValueError("Delta CDF response contains an unknown action")
+                    self._validate_cdf_actions(actions, is_versionless_cdf=True)
+                    return ListTableChangesResponse(
+                        protocol=Protocol.from_json(protocol_json["protocol"]),
+                        metadata=Metadata.from_json(metadata_json["metaData"]),
+                        actions=actions,
+                        lines=delta_lines,
+                        is_versionless_cdf=True,
+                    )
                 return ListTableChangesResponse(
                     protocol=None,
                     metadata=None,
                     actions=None,
-                    lines=list(lines),
+                    lines=delta_lines,
                 )
             else:
                 protocol_json = json.loads(next(lines))
@@ -448,12 +517,14 @@ class DataSharingRestClient:
                 actions: List[FileAction] = []
                 for line in lines:
                     actions.append(FileAction.from_json(json.loads(line)))
+                self._validate_cdf_actions(actions, is_versionless_cdf)
 
                 return ListTableChangesResponse(
                     protocol=Protocol.from_json(protocol_json["protocol"]),
                     metadata=Metadata.from_json(metadata_json["metaData"]),
                     actions=actions,
                     lines=None,
+                    is_versionless_cdf=is_versionless_cdf,
                 )
 
     def close(self):
@@ -464,9 +535,14 @@ class DataSharingRestClient:
         target: str,
         data: Optional[Dict[str, Any]] = None,
         return_headers: bool = False,
+        headers: Optional[Dict[str, str]] = None,
     ):
         return self._request_internal(
-            request=self._session.get, return_headers=return_headers, target=target, params=data
+            request=self._session.get,
+            return_headers=return_headers,
+            target=target,
+            params=data,
+            headers=headers,
         )
 
     def _post_internal(

--- a/python/delta_sharing/tests/test_protocol.py
+++ b/python/delta_sharing/tests/test_protocol.py
@@ -22,6 +22,7 @@ from delta_sharing.protocol import (
     AddFile,
     DeltaSharingProfile,
     Format,
+    FileAction,
     Metadata,
     Protocol,
     RemoveFile,
@@ -29,6 +30,31 @@ from delta_sharing.protocol import (
     Share,
     Table,
 )
+
+
+def test_delta_cdf_file_without_version():
+    action = FileAction.from_delta_json(
+        {
+            "id": "file-id",
+            "timestamp": 1234,
+            "deltaSingleAction": {
+                "cdc": {
+                    "path": "https://example.com/cdf.parquet",
+                    "partitionValues": {},
+                    "size": 10,
+                }
+            },
+        }
+    )
+
+    assert action == AddCdcFile(
+        url="https://example.com/cdf.parquet",
+        id="file-id",
+        partition_values={},
+        size=10,
+        timestamp=1234,
+        version=None,
+    )
 
 
 def test_share_profile(tmp_path):

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -947,6 +947,60 @@ def test_table_changes_empty(tmp_path):
     validate_pdf(pdf)
 
 
+@pytest.mark.parametrize("use_delta_format", [False, True])
+def test_view_changes_to_pandas_omit_commit_version(tmp_path, use_delta_format):
+    change_timestamp = 1652140000000
+    change_data = pd.DataFrame(
+        {"a": [1, 2], DeltaSharingReader._change_type_col_name(): ["insert", "delete"]}
+    )
+    change_data.to_parquet(tmp_path / "view-changes.parquet")
+
+    class RestClientMock:
+        def list_table_changes(self, table, cdfOptions):
+            assert cdfOptions.starting_timestamp == "2022-05-09T00:00:00Z"
+            return ListTableChangesResponse(
+                protocol=None,
+                metadata=Metadata(
+                    schema_string=(
+                        '{"fields":['
+                        '{"metadata":{},"name":"a","nullable":true,"type":"long"}'
+                        '],"type":"struct"}'
+                    )
+                ),
+                actions=[
+                    AddCdcFile(
+                        url=str(tmp_path / "view-changes.parquet"),
+                        id="view-changes",
+                        partition_values={},
+                        size=0,
+                        timestamp=change_timestamp,
+                        version=None,
+                    )
+                ],
+                lines=[],
+                is_versionless_cdf=True,
+            )
+
+        def set_delta_format_header(self, for_cdf=False):
+            return
+
+        def remove_delta_format_header(self):
+            return
+
+    reader = DeltaSharingReader(
+        Table("view", "share", "schema"),
+        RestClientMock(),
+        use_delta_format=use_delta_format,
+    )
+    result = reader.table_changes_to_pandas(
+        CdfOptions(starting_timestamp="2022-05-09T00:00:00Z")
+    )
+
+    assert result.columns.tolist() == ["a", "_change_type", "_commit_timestamp"]
+    assert "_commit_version" not in result
+    assert result["_commit_timestamp"].tolist() == [change_timestamp, change_timestamp]
+
+
 def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
     # Create basic data frame.
     pdf1 = pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})

--- a/python/delta_sharing/tests/test_rest_client.py
+++ b/python/delta_sharing/tests/test_rest_client.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from contextlib import contextmanager
+
 import pytest
 
 from requests.models import Response
@@ -93,6 +95,148 @@ def test_retry(rest_client: DataSharingRestClient):
     assert wrapper.fail_before_success()
     assert wrapper.sleeps == [100, 200, 400, 800]
     wrapper.sleeps.clear()
+
+
+@pytest.mark.parametrize("response_format", ["parquet", "delta"])
+def test_list_view_changes_without_versions(rest_client, response_format):
+    metadata = (
+        '{"id":"view-id","format":{"provider":"parquet"},'
+        '"schemaString":"{\\"type\\":\\"struct\\",\\"fields\\":[]}",'
+        '"partitionColumns":[]}'
+    )
+    if response_format == "delta":
+        response_headers = {
+            DataSharingRestClient.CAPABILITIES_HEADER: "responseformat=delta;versionlesscdf=true"
+        }
+        lines = [
+            '{"protocol":{"deltaProtocol":{"minReaderVersion":1,"minWriterVersion":2}}}',
+            f'{{"metaData":{{"deltaMetadata":{metadata}}}}}',
+            '{"file":{"id":"change","timestamp":1234,"deltaSingleAction":'
+            '{"cdc":{"path":"https://example.com/change.parquet",'
+            '"partitionValues":{},"size":10}}}}',
+        ]
+        rest_client.set_delta_format_header(for_cdf=True)
+    else:
+        response_headers = {DataSharingRestClient.CAPABILITIES_HEADER: "versionlesscdf=true"}
+        lines = [
+            '{"protocol":{"minReaderVersion":1}}',
+            f'{{"metaData":{metadata}}}',
+            '{"cdf":{"url":"https://example.com/change.parquet","id":"change",'
+            '"partitionValues":{},"size":10,"timestamp":1234}}',
+        ]
+
+    captured_headers = None
+
+    @contextmanager
+    def get_internal(_target, **kwargs):
+        nonlocal captured_headers
+        captured_headers = kwargs["headers"]
+        yield response_headers, iter(lines)
+
+    rest_client._get_internal = get_internal
+    response = rest_client.list_table_changes(
+        Table(name="view", share="share", schema="schema"),
+        CdfOptions(starting_timestamp="2026-01-01T00:00:00Z"),
+    )
+
+    assert "versionlesscdf=true" in captured_headers[DataSharingRestClient.CAPABILITIES_HEADER]
+    assert response.is_versionless_cdf
+    assert response.actions == [
+        AddCdcFile(
+            url="https://example.com/change.parquet",
+            id="change",
+            partition_values={},
+            size=10,
+            timestamp=1234,
+            version=None,
+        )
+    ]
+
+
+def test_reject_versionless_cdf_response_without_versionless_cdf_capability(rest_client):
+    lines = [
+        '{"protocol":{"minReaderVersion":1}}',
+        '{"metaData":{"id":"view-id","format":{"provider":"parquet"},'
+        '"schemaString":"{\\"type\\":\\"struct\\",\\"fields\\":[]}",'
+        '"partitionColumns":[]}}',
+    ]
+
+    @contextmanager
+    def get_internal(_target, **_kwargs):
+        yield {}, iter(lines)
+
+    rest_client._get_internal = get_internal
+    with pytest.raises(
+        LookupError,
+        match="Missing delta-table-version header and versionlesscdf=true response capability",
+    ):
+        rest_client.list_table_changes(
+            Table(name="view", share="share", schema="schema"),
+            CdfOptions(starting_timestamp="2026-01-01T00:00:00Z"),
+        )
+
+
+def test_reject_version_bounds_for_view_cdf_response(rest_client):
+    lines = [
+        '{"protocol":{"minReaderVersion":1}}',
+        '{"metaData":{"id":"view-id","format":{"provider":"parquet"},'
+        '"schemaString":"{\\"type\\":\\"struct\\",\\"fields\\":[]}",'
+        '"partitionColumns":[]}}',
+    ]
+
+    @contextmanager
+    def get_internal(_target, **_kwargs):
+        yield {DataSharingRestClient.CAPABILITIES_HEADER: "versionlesscdf=true"}, iter(lines)
+
+    rest_client._get_internal = get_internal
+    with pytest.raises(
+        ValueError,
+        match="View CDF queries only support starting_timestamp and ending_timestamp",
+    ):
+        rest_client.list_table_changes(
+            Table(name="view", share="share", schema="schema"),
+            CdfOptions(starting_version=1),
+        )
+
+
+@pytest.mark.parametrize(
+    "response_headers,action,error",
+    [
+        (
+            {DataSharingRestClient.DELTA_TABLE_VERSION_HEADER: "1"},
+            '{"cdf":{"url":"https://example.com/change.parquet","id":"change",'
+            '"partitionValues":{},"size":10,"timestamp":1234}}',
+            "Table CDF file actions must include a version",
+        ),
+        (
+            {DataSharingRestClient.CAPABILITIES_HEADER: "versionlesscdf=true"},
+            '{"cdf":{"url":"https://example.com/change.parquet","id":"change",'
+            '"partitionValues":{},"size":10}}',
+            "CDF file actions must include a timestamp",
+        ),
+    ],
+)
+def test_reject_cdf_actions_with_missing_required_fields(
+    rest_client, response_headers, action, error
+):
+    lines = [
+        '{"protocol":{"minReaderVersion":1}}',
+        '{"metaData":{"id":"object-id","format":{"provider":"parquet"},'
+        '"schemaString":"{\\"type\\":\\"struct\\",\\"fields\\":[]}",'
+        '"partitionColumns":[]}}',
+        action,
+    ]
+
+    @contextmanager
+    def get_internal(_target, **_kwargs):
+        yield response_headers, iter(lines)
+
+    rest_client._get_internal = get_internal
+    with pytest.raises(ValueError, match=error):
+        rest_client.list_table_changes(
+            Table(name="object", share="share", schema="schema"),
+            CdfOptions(starting_timestamp="2026-01-01T00:00:00Z"),
+        )
 
 
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)

--- a/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/RemoteDeltaLogSuite.scala
@@ -30,7 +30,16 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
 import io.delta.sharing.client.{DeltaSharingFileSystem, DeltaSharingRestClient}
-import io.delta.sharing.client.model.Table
+import io.delta.sharing.client.model.{
+  AddCDCFile,
+  AddFileForCDF,
+  DeltaTableFiles,
+  Format,
+  Metadata,
+  Protocol,
+  RemoveFile,
+  Table
+}
 import io.delta.sharing.client.util.ConfUtils
 import io.delta.sharing.spark.util.QueryUtils
 
@@ -829,6 +838,81 @@ class RemoteDeltaLogSuite extends SparkFunSuite with SharedSparkSession {
     assert(removeInputFileList.size == 2)
     assert(removeInputFileList(0) == "delta-sharing:/prefix.test/cdf_rem1/400")
     assert(removeInputFileList(1) == "delta-sharing:/prefix.test/cdf_rem2/420")
+  }
+
+  test("view CDF uses response metadata and omits commit version") {
+    val viewMetadata = Metadata(
+      id = "view-id",
+      format = Format(),
+      schemaString =
+        """{"type":"struct","fields":[{"name":"value","type":"string","nullable":true,""" +
+          """"metadata":{}},{"name":"part","type":"string","nullable":true,"metadata":{}}]}""",
+      partitionColumns = Seq("part"))
+    val viewFiles = DeltaTableFiles(
+      version = 0L,
+      protocol = Protocol(1),
+      metadata = viewMetadata,
+      addFiles = Seq(
+        AddFileForCDF(
+          "add-a.parquet", "add-a", Map("part" -> "a"), 10L,
+          version = null, timestamp = 1000L),
+        AddFileForCDF(
+          "add-z.parquet", "add-z", Map("part" -> "z"), 11L,
+          version = null, timestamp = 1000L)),
+      cdfFiles = Seq(AddCDCFile(
+        "cdc.parquet", "cdc", Map("part" -> "b"), 10L, version = null, timestamp = 1000L)),
+      removeFiles = Seq(RemoveFile(
+        "remove.parquet", "remove", Map("part" -> "c"), 10L,
+        version = null, timestamp = 1000L)),
+      respondedFormat = DeltaSharingRestClient.RESPONSE_FORMAT_PARQUET,
+      isVersionlessCDF = true)
+    val client = new TestDeltaSharingClient() {
+      override def getCDFFiles(
+          table: Table,
+          cdfOptions: Map[String, String],
+          includeHistoricalMetadata: Boolean,
+          fileIdHash: Option[String],
+          includeHistoricalProtocol: Boolean = false): DeltaTableFiles = viewFiles
+    }
+    client.clear()
+    val snapshot = new RemoteSnapshot(new Path("view"), client, Table("view", "schema", "share"))
+    val relation = RemoteDeltaCDFRelation(
+      SparkSession.active,
+      snapshot,
+      client,
+      Table("view", "schema", "share"),
+      Map(DeltaSharingOptions.CDF_START_TIMESTAMP -> "2026-01-01T00:00:00Z"))
+
+    assert(relation.schema == StructType(Array(
+      StructField("value", StringType),
+      StructField("part", StringType),
+      StructField("_commit_timestamp", LongType),
+      StructField("_change_type", StringType))))
+
+    val params = relation.fileIndexParams
+    val addIndex = RemoteDeltaCDFAddFileIndex(params, viewFiles.addFiles)
+    val cdcIndex = RemoteDeltaCDCFileIndex(params, viewFiles.cdfFiles)
+    val removeIndex = RemoteDeltaCDFRemoveFileIndex(params, viewFiles.removeFiles)
+    assert(!viewFiles.addFiles.head.getPartitionValuesInDF().contains("_commit_version"))
+    assert(addIndex.partitionSchema.fieldNames.sameElements(
+      Array("part", "_commit_timestamp", "_change_type")))
+    assert(cdcIndex.partitionSchema.fieldNames.sameElements(
+      Array("part", "_commit_timestamp")))
+    assert(removeIndex.partitionSchema.fieldNames.sameElements(
+      Array("part", "_commit_timestamp", "_change_type")))
+    assert(addIndex.sizeInBytes == 21L)
+    assert(cdcIndex.sizeInBytes == 10L)
+    assert(removeIndex.sizeInBytes == 10L)
+    val partFilter = SqlEqualTo(
+      SqlAttributeReference("part", StringType)(),
+      SqlLiteral.create("a", StringType))
+    val filteredAddFiles = addIndex.listFiles(Seq(partFilter), Nil)
+    assert(filteredAddFiles.size == 1)
+    assert(filteredAddFiles.head.files.size == 1)
+    assert(filteredAddFiles.head.files.head.getPath.toString.endsWith("/add-a/10"))
+    assert(cdcIndex.listFiles(Nil, Nil).nonEmpty)
+    assert(removeIndex.listFiles(Nil, Nil).nonEmpty)
+    assert(TestDeltaSharingClient.numMetadataCalled == 0)
   }
 
   test("Limit pushdown test") {


### PR DESCRIPTION
## Stack
[`Support CDF on views responses`](https://github.com/delta-io/delta-sharing/pull/1005) 
[`Add Python support for CDF on shared views` ](https://github.com/delta-io/delta-sharing/pull/1006)
[`Enable CDF on shared views in Spark`](https://github.com/delta-io/delta-sharing/pull/1007) ← This PR
[`Add end-to-end coverage for CDF on shared views`](https://github.com/delta-io/delta-sharing/pull/1008)

[View incremental diff](https://github.com/delta-io/delta-sharing/commit/415a5c075e7ee7bf7df2a3c410f2f1ad980ec927)

## Description
Adds Spark batch-read support for Change Data Feed (CDF) on shared views.

For non-streaming requests, the Spark client now advertises the `cdfonviews=true` capability. When the server identifies the response as view CDF:
  - Uses the schema and partition columns returned in the CDF response instead of the table snapshot metadata.
  - Handles add, remove, and CDC file actions without commit versions.
  - Includes `_change_type` and `_commit_timestamp` while omitting `_commit_version`.
  - Builds partition-aware file indexes from the view metadata.
  - Uses individual action sizes when estimating the size of the CDF relation.
  - Preserves partition filtering across view CDF files.

CDF on shared views is currently batch only. Streaming requests are not advertised as supporting this capability and produce an explicit "unsupported operation" error for CDF on views.

## Testing
Added coverage for capability, view CDF schema construction, partition filtering, file sizing, versionless actions, and streaming behavior.